### PR TITLE
Always use token regardeless of hosted mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,7 @@ swagger.json
 # Test outputs and temporary files
 test_output/
 *.tmp
+
+# Markdown files (exclude all except README)
+*.md
+!README.md

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -36,8 +36,8 @@ class AuthenticatedHTTPXClient:
         self._api_token = None
         self.parameter_mapping = parameter_mapping or {}
 
-        if not self.hosted:
-            self._api_token = self._get_api_token()
+        # Always get API token regardless of hosted mode
+        self._api_token = self._get_api_token()
 
         # Create the HTTPX client
         headers = {"Content-Type": "application/json", "Accept": "application/json"}


### PR DESCRIPTION
Needs auth for both local and remote