### PR TITLE
Fix looping/max payload/auth issues

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -297,6 +297,7 @@ def create_rootly_mcp_server(
     ) -> dict:
         """
         Get all incidents matching a query by automatically fetching multiple pages.
+        """
         all_incidents = []
         page_number = 1
         page_size = min(max_results, 10)  # Reasonable page size for efficient API calls
@@ -321,7 +322,7 @@ def create_rootly_mcp_server(
                         if not incidents:
                             break
                         
-                                    simplified_incidents = []
+                        simplified_incidents = []
                         for incident in incidents:
                             simplified = {
                                 "id": incident["id"],


### PR DESCRIPTION
MCP server was looping, custom endpoints were not authorizing

  - Return Python objects directly instead of JSON strings
  - Optimize payload sizes and increase reasonable limits
  - Remove double encoding that caused crashes

Aimed for minimal changes. 

I mimicked the remote server with a Docker instance and queried it with Cursor. 

Tested the following:

**Custom** 

-   get_all_incidents_matching
-   search_incidents_paginated
-   list_endpoints

**Swagger-Generated List Endpoints**
-   listAlerts
-   listUsers
-   getCurrentUser
-   listTeams
-   listServices
-   listSeverities
-   listIncidentTypes
-   listFunctionalities
-   listWorkflows
-   listEnvironments
- 
-   Complex Relational Endpoints
-   listIncidentAlerts