### PR TITLE
fix: only check API token when not in hosted mode

### DIFF
--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -159,7 +159,9 @@ def main():
         logger.warning("--host argument is deprecated, use --hosted instead")
         hosted_mode = True
     
-    check_api_token()
+    # Only check API token if not in hosted mode
+    if not hosted_mode:
+        check_api_token()
     
     try:
         # Parse allowed paths from command line argument


### PR DESCRIPTION
This fixes the critical authentication bug where check_api_token() was always called regardless of --hosted flag, causing ECS deployments to fail.

Root cause: August 12th switch from routemap_server to server.py introduced hosted mode support but __main__.py was never updated to handle it properly.