### PR TITLE
fix: pass AuthenticatedHTTPXClient wrapper to FastMCP for parameter transformation

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -417,9 +417,11 @@ def create_rootly_mcp_server(
 
     # Create the MCP server using OpenAPI integration
     # By default, all routes become tools which is what we want
+    # NOTE: We pass http_client (the wrapper) instead of http_client.client (the inner httpx client)
+    # so that parameter transformation (e.g., filter_status -> filter[status]) is applied
     mcp = FastMCP.from_openapi(
         openapi_spec=filtered_spec,
-        client=http_client.client,
+        client=http_client,
         name=name,
         timeout=30.0,
         tags={"rootly", "incident-management"},


### PR DESCRIPTION
## Summary

🥇 Assisted by Claude Code for working on this bugfix.

- Fixed a bug where filter parameters (e.g., `filter_status`, `filter_services`) were not being transformed back to their API format (`filter[status]`, `filter[services]`) when making requests to the Rootly API
- The root cause was passing `http_client.client` (the inner `httpx.AsyncClient`) to `FastMCP.from_openapi()` instead of `http_client` (the `AuthenticatedHTTPXClient` wrapper)
- Added unit tests for the `_transform_params` method

## Problem

When the MCP server sanitizes OpenAPI parameter names for MCP compatibility (e.g., `filter[status]` → `filter_status`), it creates a mapping to transform them back when making API requests. However, because the inner httpx client was being used instead of the wrapper, the `_transform_params` method was never called.

This caused filter parameters to be sent as-is (e.g., `filter_status=acknowledged`) instead of their proper API format (`filter[status]=acknowledged`), resulting in the Rootly API ignoring these filters.

## Test plan

- [ ] Existing unit tests pass
- [ ] New `TestParameterTransformation` tests verify the transform logic
- [ ] Manual testing: `listAlerts` with `filter_status=acknowledged` should now properly filter results

🤖 Generated with [Claude Code](https://claude.com/claude-code)