### PR TITLE
fix: pass AuthenticatedHTTPXClient wrapper for parameter transformation

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -487,9 +487,12 @@ def create_rootly_mcp_server(
 
     # Create the MCP server using OpenAPI integration
     # By default, all routes become tools which is what we want
+    # NOTE: We pass http_client (the wrapper) instead of http_client.client (the inner httpx client)
+    # so that parameter transformation (e.g., filter_status -> filter[status]) is applied.
+    # The wrapper implements the same interface as httpx.AsyncClient (duck typing).
     mcp = FastMCP.from_openapi(
         openapi_spec=filtered_spec,
-        client=http_client.client,
+        client=http_client,  # type: ignore[arg-type]
         name=name,
         timeout=30.0,
         tags={"rootly", "incident-management"},

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -238,3 +238,52 @@ class TestAuthenticationModeComparison:
 
         assert local_client.hosted is False
         assert hosted_client.hosted is True
+
+
+class TestParameterTransformation:
+    """Test suite for parameter transformation functionality."""
+
+    def test_transform_params_with_mapping(self):
+        """Test that parameters are transformed according to mapping."""
+        mapping = {
+            "filter_status": "filter[status]",
+            "filter_services": "filter[services]",
+        }
+        client = AuthenticatedHTTPXClient(parameter_mapping=mapping)
+
+        params = {"filter_status": "active", "filter_services": "api,web", "page": 1}
+        result = client._transform_params(params)
+
+        assert result is not None
+        assert result["filter[status]"] == "active"
+        assert result["filter[services]"] == "api,web"
+        assert result["page"] == 1
+        assert "filter_status" not in result
+        assert "filter_services" not in result
+
+    def test_transform_params_without_mapping(self):
+        """Test that params pass through unchanged when no mapping exists."""
+        client = AuthenticatedHTTPXClient(parameter_mapping={})
+
+        params = {"filter_status": "active", "page": 1}
+        result = client._transform_params(params)
+
+        assert result is not None
+        assert result["filter_status"] == "active"
+        assert result["page"] == 1
+
+    def test_transform_params_with_none(self):
+        """Test that None params return None."""
+        client = AuthenticatedHTTPXClient(parameter_mapping={"foo": "bar"})
+
+        result = client._transform_params(None)
+
+        assert result is None
+
+    def test_transform_params_with_empty_dict(self):
+        """Test that empty dict returns empty dict."""
+        client = AuthenticatedHTTPXClient(parameter_mapping={"foo": "bar"})
+
+        result = client._transform_params({})
+
+        assert result == {}


### PR DESCRIPTION
## Summary

Fixes the parameter transformation bug reported in #29 by @smoya.

- Pass `http_client` (the wrapper) instead of `http_client.client` (the inner httpx client) to `FastMCP.from_openapi()`
- Added `# type: ignore[arg-type]` with explanation comment (wrapper implements same interface via duck typing)
- Added unit tests for `_transform_params` method

## Problem

When the MCP server sanitizes OpenAPI parameter names for MCP compatibility (e.g., `filter[status]` → `filter_status`), it creates a mapping to transform them back when making API requests. However, because the inner httpx client was being used instead of the wrapper, the `_transform_params` method was never called.

This caused filter parameters to be sent as-is (e.g., `filter_status=acknowledged`) instead of their proper API format (`filter[status]=acknowledged`), resulting in the Rootly API ignoring these filters.

## Solution

Pass the `AuthenticatedHTTPXClient` wrapper to FastMCP instead of the inner client. The wrapper implements the same interface (get, post, put, patch, delete, request) and intercepts requests to transform parameters before forwarding to the underlying httpx client.

## Test plan

- [x] All existing unit tests pass (182 passed)
- [x] New `TestParameterTransformation` tests verify the transform logic
- [x] pyright type check passes (0 errors)
- [x] ruff/black/isort checks pass
- [ ] Manual testing: `listAlerts` with `filter_status=acknowledged` should now properly filter results

Closes #29