### PR TITLE
fix: enforce JSON-API headers via httpx event hook

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1658,7 +1658,7 @@ wheels = [
 
 [[package]]
 name = "rootly-mcp-server"
-version = "2.2.0"
+version = "2.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
## Summary
- Fixes HTTP 415 (Unsupported Media Type) errors on all API calls when running with newer fastmcp versions (>=2.10)
- Root cause: newer fastmcp calls `client.send()` instead of `client.request()`, bypassing our header override. The `__getattr__` delegation silently forwarded `send()` to the inner httpx client without applying `Content-Type: application/vnd.api+json`
- Adds an httpx event hook (`_enforce_jsonapi_headers`) that enforces correct headers at the transport level before every outgoing request, regardless of how it was initiated
- Adds explicit `send()` proxy and fixes `base_url` property for newer fastmcp compatibility

## Test plan
- [x] All 244 existing tests pass
- [ ] Deploy and verify `listTeams`, `getCurrentUser`, and other tools no longer return 415
- [ ] Verify hosted mode with MCP client (Claude Desktop / Claude Code)