### PR TITLE
fix: reduce alert API response payload by ~79% and add User-Agent tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/rootly-mcp-server.svg)](https://pypi.org/project/rootly-mcp-server/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/rootly-mcp-server)](https://pypi.org/project/rootly-mcp-server/)
 [![Python Version](https://img.shields.io/pypi/pyversions/rootly-mcp-server.svg)](https://pypi.org/project/rootly-mcp-server/)
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=rootly&config=eyJjb21tYW5kIjoibnB4IC15IG1jcC1yZW1vdGUgaHR0cHM6Ly9tY3Aucm9vdGx5LmNvbS9zc2UgLS1oZWFkZXIgQXV0aG9yaXphdGlvbjoke1JPT1RMWV9BVVRIX0hFQURFUn0iLCJlbnYiOnsiUk9PVExZX0FVVEhfSEVBREVSIjoiQmVhcmVyIDxZT1VSX1JPT1RMWV9BUElfVE9LRU4%2BIn19)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=rootly&config=eyJ1cmwiOiJodHRwczovL21jcC5yb290bHkuY29tL3NzZSIsImhlYWRlcnMiOnsiQXV0aG9yaXphdGlvbiI6IkJlYXJlciA8WU9VUl9ST09UTFlfQVBJX1RPS0VOPiJ9fQ==)
 
 An MCP server for the [Rootly API](https://docs.rootly.com/api-reference/overview) that integrates seamlessly with MCP-compatible editors like Cursor, Windsurf, and Claude. Resolve production incidents in under a minute without leaving your IDE.
 
@@ -29,9 +29,33 @@ The MCP server requires a Rootly API token. Choose the appropriate token type ba
 
 For full functionality of tools like `get_oncall_handoff_summary`, `get_oncall_shift_metrics`, and organization-wide incident search, a **Global API Key** is recommended.
 
-## Installation
+## Quick Start
 
-Configure your MCP-compatible editor (tested with Cursor) with one of the configurations below. The package will be automatically downloaded and installed when you first open your editor.
+The fastest way to get started is to connect to our hosted MCP server — no installation required, just add the configuration to your editor:
+
+```json
+{
+  "mcpServers": {
+    "rootly": {
+      "url": "https://mcp.rootly.com/sse",
+      "headers": {
+        "Authorization": "Bearer <YOUR_ROOTLY_API_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+For **Claude Code**, run:
+
+```bash
+claude mcp add rootly --transport sse https://mcp.rootly.com/sse \
+  --header "Authorization: Bearer YOUR_ROOTLY_API_TOKEN"
+```
+
+## Alternative Installation (Local)
+
+If you prefer to run the MCP server locally, configure your editor with one of the options below. The package will be automatically downloaded and installed when you first open your editor.
 
 ### With uv
 
@@ -46,7 +70,7 @@ Configure your MCP-compatible editor (tested with Cursor) with one of the config
         "--from",
         "rootly-mcp-server",
         "rootly-mcp-server"
-      ],      
+      ],
       "env": {
         "ROOTLY_API_TOKEN": "<YOUR_ROOTLY_API_TOKEN>"
       }
@@ -66,33 +90,9 @@ Configure your MCP-compatible editor (tested with Cursor) with one of the config
         "--from",
         "rootly-mcp-server",
         "rootly-mcp-server"
-      ],      
-      "env": {
-        "ROOTLY_API_TOKEN": "<YOUR_ROOTLY_API_TOKEN>"
-      }
-    }
-  }
-}
-```
-
-### Connect to Hosted MCP Server
-
-Alternatively, connect directly to our hosted MCP server:
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.rootly.com/sse",
-        "--header",
-        "Authorization:${ROOTLY_AUTH_HEADER}"
       ],
       "env": {
-        "ROOTLY_AUTH_HEADER": "Bearer <YOUR_ROOTLY_API_TOKEN>"
+        "ROOTLY_API_TOKEN": "<YOUR_ROOTLY_API_TOKEN>"
       }
     }
   }

--- a/tests/unit/test_alert_stripping.py
+++ b/tests/unit/test_alert_stripping.py
@@ -1,0 +1,278 @@
+"""
+Unit tests for alert response stripping.
+
+Tests cover:
+- strip_heavy_alert_data() with list responses, single-resource responses,
+  empty/malformed data
+- AuthenticatedHTTPXClient._is_alert_endpoint() URL matching
+- AuthenticatedHTTPXClient._maybe_strip_alert_response() integration
+"""
+
+import json
+
+import httpx
+
+from rootly_mcp_server.server import (
+    ALERT_ESSENTIAL_ATTRIBUTES,
+    AuthenticatedHTTPXClient,
+    strip_heavy_alert_data,
+)
+
+
+def _make_alert(alert_id="abc-123", extra_attrs=None):
+    """Helper to create a realistic alert dict with heavy fields."""
+    attrs = {
+        # Essential fields
+        "short_id": "XYZ",
+        "source": "pagerduty",
+        "status": "triggered",
+        "summary": "CPU usage above 90%",
+        "description": "Host db-01 CPU spiked",
+        "noise": "not_noise",
+        "alert_urgency_id": "urg-1",
+        "url": "https://rootly.com/alerts/abc",
+        "external_url": "https://pagerduty.com/incidents/123",
+        "created_at": "2026-02-18T10:00:00Z",
+        "updated_at": "2026-02-18T10:05:00Z",
+        "started_at": "2026-02-18T10:00:00Z",
+        "ended_at": None,
+        # Heavy fields that should be stripped
+        "labels": [{"key": "env", "value": "prod"}],
+        "services": [{"id": "svc-1", "name": "API", "nested": {"deep": "data"}}],
+        "service_ids": ["svc-1"],
+        "groups": [{"id": "grp-1", "name": "Backend"}],
+        "group_ids": ["grp-1"],
+        "environments": [{"id": "env-1", "name": "Production"}],
+        "environment_ids": ["env-1"],
+        "responders": [{"user_id": "u1", "name": "Alice"}],
+        "incidents": [{"id": "inc-1"}],
+        "data": {"raw_payload": "very large blob" * 100},
+        "deduplication_key": "dedup-abc",
+        "external_id": "ext-123",
+        "group_leader_alert_id": None,
+        "is_group_leader_alert": False,
+        "notification_target_type": "schedule",
+        "notification_target_id": "sched-1",
+        "alert_urgency": {"id": "urg-1", "name": "high"},
+        "notified_users": [{"id": "u1"}, {"id": "u2"}],
+        "alerting_targets": [{"type": "schedule", "id": "s1"}],
+        "alert_field_values": [{"field": "region", "value": "us-east-1"}],
+    }
+    if extra_attrs:
+        attrs.update(extra_attrs)
+    return {
+        "id": alert_id,
+        "type": "alerts",
+        "attributes": attrs,
+        "relationships": {
+            "events": {
+                "data": [
+                    {"id": "ev-1", "type": "events"},
+                    {"id": "ev-2", "type": "events"},
+                ]
+            }
+        },
+    }
+
+
+class TestStripHeavyAlertData:
+    """Tests for the strip_heavy_alert_data function."""
+
+    def test_strips_heavy_fields_from_list_response(self):
+        data = {"data": [_make_alert("a1"), _make_alert("a2")]}
+        result = strip_heavy_alert_data(data)
+
+        for alert in result["data"]:
+            attr_keys = set(alert["attributes"].keys())
+            assert attr_keys <= ALERT_ESSENTIAL_ATTRIBUTES
+            # Verify essential fields are kept
+            assert alert["attributes"]["summary"] == "CPU usage above 90%"
+            assert alert["attributes"]["status"] == "triggered"
+            assert alert["attributes"]["source"] == "pagerduty"
+            # Verify heavy fields are gone
+            assert "services" not in alert["attributes"]
+            assert "data" not in alert["attributes"]
+            assert "labels" not in alert["attributes"]
+            assert "notified_users" not in alert["attributes"]
+
+    def test_strips_heavy_fields_from_single_resource_response(self):
+        data = {"data": _make_alert("a1")}
+        result = strip_heavy_alert_data(data)
+
+        attr_keys = set(result["data"]["attributes"].keys())
+        assert attr_keys <= ALERT_ESSENTIAL_ATTRIBUTES
+        assert result["data"]["attributes"]["summary"] == "CPU usage above 90%"
+        assert "services" not in result["data"]["attributes"]
+
+    def test_collapses_relationships_to_counts(self):
+        data = {"data": [_make_alert()]}
+        result = strip_heavy_alert_data(data)
+
+        events = result["data"][0]["relationships"]["events"]
+        assert events == {"count": 2}
+
+    def test_removes_included_sideloads(self):
+        data = {
+            "data": [_make_alert()],
+            "included": [
+                {"id": "svc-1", "type": "services", "attributes": {"name": "API"}},
+                {"id": "u1", "type": "users", "attributes": {"name": "Alice", "email": "a@b.com"}},
+            ],
+        }
+        result = strip_heavy_alert_data(data)
+        assert "included" not in result
+
+    def test_preserves_id_and_type(self):
+        data = {"data": [_make_alert("my-id")]}
+        result = strip_heavy_alert_data(data)
+
+        assert result["data"][0]["id"] == "my-id"
+        assert result["data"][0]["type"] == "alerts"
+
+    def test_preserves_meta_and_links(self):
+        data = {
+            "data": [_make_alert()],
+            "meta": {"total_count": 42, "current_page": 1},
+            "links": {"self": "/v1/alerts?page[number]=1"},
+        }
+        result = strip_heavy_alert_data(data)
+        assert result["meta"] == {"total_count": 42, "current_page": 1}
+        assert result["links"] == {"self": "/v1/alerts?page[number]=1"}
+
+    def test_handles_empty_data_list(self):
+        data = {"data": []}
+        result = strip_heavy_alert_data(data)
+        assert result == {"data": []}
+
+    def test_handles_no_data_key(self):
+        data = {"error": "something went wrong"}
+        result = strip_heavy_alert_data(data)
+        assert result == {"error": "something went wrong"}
+
+    def test_handles_alert_with_no_attributes(self):
+        data = {"data": [{"id": "a1", "type": "alerts"}]}
+        result = strip_heavy_alert_data(data)
+        assert result["data"][0]["id"] == "a1"
+
+    def test_handles_alert_with_no_relationships(self):
+        alert = _make_alert()
+        del alert["relationships"]
+        data = {"data": [alert]}
+        result = strip_heavy_alert_data(data)
+        assert "relationships" not in result["data"][0]
+
+    def test_relationship_without_data_list_left_alone(self):
+        """Relationships with non-list data (e.g. single resource) are not collapsed."""
+        alert = _make_alert()
+        alert["relationships"]["urgency"] = {"data": {"id": "urg-1", "type": "alert_urgencies"}}
+        data = {"data": [alert]}
+        result = strip_heavy_alert_data(data)
+        # Single-resource relationship should be left alone
+        assert result["data"][0]["relationships"]["urgency"] == {
+            "data": {"id": "urg-1", "type": "alert_urgencies"}
+        }
+
+
+class TestIsAlertEndpoint:
+    """Tests for AuthenticatedHTTPXClient._is_alert_endpoint."""
+
+    def test_matches_alerts_list(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/alerts") is True
+
+    def test_matches_single_alert(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/alerts/abc-123") is True
+
+    def test_matches_incident_alerts(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/incidents/inc-1/alerts") is True
+
+    def test_excludes_alert_urgencies(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/alert_urgencies") is False
+
+    def test_excludes_alert_events(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/alerts/abc/alert_events") is False
+
+    def test_excludes_alert_sources(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/alert_sources") is False
+
+    def test_excludes_alert_routing(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/alert_routing") is False
+
+    def test_excludes_unrelated_endpoints(self):
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/incidents") is False
+        assert AuthenticatedHTTPXClient._is_alert_endpoint("/v1/users") is False
+
+
+class TestMaybeStripAlertResponse:
+    """Tests for AuthenticatedHTTPXClient._maybe_strip_alert_response."""
+
+    def _make_response(self, data, status_code=200):
+        """Create an httpx.Response with given JSON data."""
+        return httpx.Response(
+            status_code=status_code,
+            json=data,
+        )
+
+    def test_strips_get_alert_response(self):
+        alert_data = {"data": [_make_alert()]}
+        response = self._make_response(alert_data)
+        result = AuthenticatedHTTPXClient._maybe_strip_alert_response("GET", "/v1/alerts", response)
+        parsed = result.json()
+        assert "services" not in parsed["data"][0]["attributes"]
+
+    def test_skips_non_get_methods(self):
+        alert_data = {"data": _make_alert()}
+        response = self._make_response(alert_data)
+        result = AuthenticatedHTTPXClient._maybe_strip_alert_response(
+            "POST", "/v1/alerts", response
+        )
+        parsed = result.json()
+        # POST response should not be stripped
+        assert "services" in parsed["data"]["attributes"]
+
+    def test_skips_error_responses(self):
+        error_data = {"errors": [{"detail": "Not found"}]}
+        response = self._make_response(error_data, status_code=404)
+        result = AuthenticatedHTTPXClient._maybe_strip_alert_response(
+            "GET", "/v1/alerts/bad-id", response
+        )
+        parsed = result.json()
+        assert parsed == error_data
+
+    def test_skips_non_alert_endpoints(self):
+        data = {"data": [{"id": "1", "attributes": {"title": "incident"}}]}
+        response = self._make_response(data)
+        result = AuthenticatedHTTPXClient._maybe_strip_alert_response(
+            "GET", "/v1/incidents", response
+        )
+        parsed = result.json()
+        assert "title" in parsed["data"][0]["attributes"]
+
+    def test_handles_malformed_json_gracefully(self):
+        response = httpx.Response(status_code=200, content=b"not json")
+        result = AuthenticatedHTTPXClient._maybe_strip_alert_response("GET", "/v1/alerts", response)
+        # Should return the original response without raising
+        assert result.content == b"not json"
+
+
+class TestPayloadSizeReduction:
+    """Verify that stripping actually reduces payload size significantly."""
+
+    def test_significant_size_reduction(self):
+        """A realistic alert response should be much smaller after stripping."""
+        alerts = [_make_alert(f"alert-{i}") for i in range(10)]
+        data = {
+            "data": alerts,
+            "included": [
+                {"id": f"svc-{i}", "type": "services", "attributes": {"name": f"Service {i}"}}
+                for i in range(20)
+            ],
+        }
+        original_size = len(json.dumps(data))
+        stripped = strip_heavy_alert_data(data)
+        stripped_size = len(json.dumps(stripped))
+
+        # Should be at least 50% smaller
+        assert stripped_size < original_size * 0.5, (
+            f"Expected >50% reduction, got {original_size} -> {stripped_size} "
+            f"({stripped_size / original_size * 100:.0f}%)"
+        )


### PR DESCRIPTION
## Summary

- **Alert response stripping**: Auto-generated OpenAPI tools (like `listAlerts`) were returning 1.5MB+ responses. Added `strip_heavy_alert_data()` that uses a whitelist approach to keep only 13 essential attributes, removes `included` sideloads, and collapses relationships to counts. Reduces payload by ~79%.
- **Response post-processing in HTTP client**: Added `_maybe_strip_alert_response()` in `AuthenticatedHTTPXClient` that intercepts GET responses from alert endpoints. Applied in both `request()` and `send()` paths for forward compatibility with newer FastMCP versions.
- **Fixed path mismatch**: `DEFAULT_ALLOWED_PATHS` had `/alerts/{alert_id}` but the OpenAPI spec uses `/alerts/{id}`. The single-alert GET endpoint was never exposed.
- **User-Agent header**: Added `rootly-mcp-server/{version}` User-Agent for API traffic attribution (filterable in Datadog via `@http.useragent`).
- **README**: Moved hosted MCP server config to Quick Start for better onboarding.

## Test plan

- [x] 26 new unit tests covering `strip_heavy_alert_data()`, `_is_alert_endpoint()`, `_maybe_strip_alert_response()`, and payload size reduction
- [x] All 243 existing unit tests pass
- [x] Integration tested against live Rootly API: 5,167 chars → 1,097 chars (78.8% reduction per alert)