### PR TITLE
chore: normalize log severity levels on main baseline

### DIFF
--- a/src/rootly_mcp_server/client.py
+++ b/src/rootly_mcp_server/client.py
@@ -148,7 +148,10 @@ class RootlyClient:
             # Sanitize error message to remove stack traces
             error_msg = sanitize_error_message(str(e))
 
-            logger.error("HTTP error", status_code=status_code, error=error_msg)
+            if status_code is not None and status_code >= 500:
+                logger.error("HTTP error", status_code=status_code, error=error_msg)
+            else:
+                logger.warning("HTTP error", status_code=status_code, error=error_msg)
 
             # Categorize HTTP errors
             if status_code == 401:


### PR DESCRIPTION
## Summary
- Normalize noisy logging levels on the current main setup (no streamable-http dependency)
- Downgrade hot-path auth/header chatter from info/error to debug/warning where appropriate
- Classify HTTP status logs by severity (4xx => warning, 5xx => error)

## Why
- Reduce alert noise and improve Datadog signal quality
- Keep true failures visible while preserving useful diagnostics

## Changes
- `src/rootly_mcp_server/server.py`
  - `make_authenticated_request` request/header logs: info -> debug
  - missing header / header extraction issues: error -> warning
  - outbound request auth-missing: error -> warning
  - HTTP response logging split by status class (4xx warning, 5xx error)
  - schema cleanup warning -> debug
- `src/rootly_mcp_server/client.py`
  - HTTP error logging split by status class (4xx warning, 5xx error)

## Validation
- `uv run ruff check src/rootly_mcp_server tests`
- `uv run pyright`
- `uv run pytest tests/unit -q` (243 passed)

## Notes
- `mypy` currently reports pre-existing baseline issues on main; unchanged by this PR.