### PR TITLE
feat: split SSE vs streamable-http tool telemetry for Datadog

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -52,6 +52,7 @@ AuthCaptureMiddleware = transport.AuthCaptureMiddleware
 _session_auth_token = transport._session_auth_token
 _session_client_ip = transport._session_client_ip
 _session_request_id = transport._session_request_id
+_session_transport = transport._session_transport
 _extract_client_ip = transport._extract_client_ip
 _extract_request_id = transport._extract_request_id
 
@@ -110,15 +111,20 @@ def _current_tool_identity() -> dict[str, str]:
     try:
         from fastmcp.server.context import _current_transport
 
-        current_transport = str(_current_transport.get() or "")
+        transport_runtime = str(_current_transport.get() or "")
     except Exception:
-        current_transport = ""
+        transport_runtime = ""
+
+    transport_effective = _session_transport.get("") or transport_runtime
 
     return {
         "token_fingerprint": _fingerprint_auth_header(auth_header),
         "client_ip": client_ip,
         "request_id": request_id,
-        "transport": current_transport,
+        # Keep `transport` backward-compatible while introducing explicit fields.
+        "transport": transport_effective,
+        "transport_effective": transport_effective,
+        "transport_runtime": transport_runtime,
     }
 
 
@@ -146,6 +152,8 @@ def _log_tool_usage_event(
         "client_ip": identity.get("client_ip", ""),
         "request_id": identity.get("request_id", ""),
         "transport": identity.get("transport", ""),
+        "transport_effective": identity.get("transport_effective", ""),
+        "transport_runtime": identity.get("transport_runtime", ""),
     }
     if error_type:
         event["error_type"] = error_type

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -25,6 +25,9 @@ _session_client_ip: contextvars.ContextVar[str] = contextvars.ContextVar(
 _session_request_id: contextvars.ContextVar[str] = contextvars.ContextVar(
     "_session_request_id", default=""
 )
+_session_transport: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "_session_transport", default=""
+)
 
 
 def _normalize_path(path: str) -> str:
@@ -68,11 +71,27 @@ def _extract_request_id(headers: dict[str, str]) -> str:
     return ""
 
 
+def _infer_transport_from_path(
+    path: str,
+    sse_path: str,
+    message_path: str,
+    streamable_path: str,
+) -> str:
+    """Infer effective transport name from the incoming MCP path."""
+    normalized = _normalize_path(path)
+    if normalized in {sse_path, message_path}:
+        return "sse"
+    if normalized == streamable_path:
+        return "streamable-http"
+    return ""
+
+
 def _get_auth_capture_paths() -> set[str]:
     """Get MCP HTTP paths that should capture auth headers."""
     sse_path = _normalize_path(os.getenv("FASTMCP_SSE_PATH", "/sse"))
+    message_path = _normalize_path(os.getenv("FASTMCP_MESSAGE_PATH", "/messages"))
     streamable_path = _normalize_path(os.getenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp"))
-    return {sse_path, streamable_path}
+    return {sse_path, message_path, streamable_path}
 
 
 class AuthCaptureMiddleware:
@@ -86,7 +105,16 @@ class AuthCaptureMiddleware:
 
     def __init__(self, app):
         self.app = app
-        self._capture_paths = _get_auth_capture_paths()
+        self._sse_path = _normalize_path(os.getenv("FASTMCP_SSE_PATH", "/sse"))
+        self._message_path = _normalize_path(os.getenv("FASTMCP_MESSAGE_PATH", "/messages"))
+        self._streamable_path = _normalize_path(
+            os.getenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp")
+        )
+        self._capture_paths = {
+            self._sse_path,
+            self._message_path,
+            self._streamable_path,
+        }
 
     async def __call__(self, scope, receive, send):
         path = _normalize_path(str(scope.get("path", "")))
@@ -95,6 +123,11 @@ class AuthCaptureMiddleware:
 
             request = Request(scope)
             headers = _normalize_headers(dict(request.headers))
+            effective_transport = _infer_transport_from_path(
+                path, self._sse_path, self._message_path, self._streamable_path
+            )
+            if effective_transport:
+                _session_transport.set(effective_transport)
             auth = request.headers.get("authorization", "")
             if auth:
                 _session_auth_token.set(auth)
@@ -104,8 +137,10 @@ class AuthCaptureMiddleware:
             request_id = _extract_request_id(headers)
             if request_id:
                 _session_request_id.set(request_id)
-            if auth or client_ip or request_id:
-                logger.debug(f"Captured hosted auth/identity context from path: {path}")
+            if auth or client_ip or request_id or effective_transport:
+                logger.debug(
+                    f"Captured hosted auth/identity context from path: {path} (transport={effective_transport or 'unknown'})"
+                )
         await self.app(scope, receive, send)
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -236,6 +236,7 @@ class TestToolUsageIdentityHelpers:
         token_ctx = server_module._session_auth_token.set("Bearer rootly_session_token")
         ip_ctx = server_module._session_client_ip.set("192.0.2.8")
         req_ctx = server_module._session_request_id.set("req-session-1")
+        transport_ctx = server_module._session_transport.set("sse")
         try:
             with patch("fastmcp.server.dependencies.get_http_headers", return_value={}):
                 identity = _current_tool_identity()
@@ -243,12 +244,31 @@ class TestToolUsageIdentityHelpers:
             server_module._session_auth_token.reset(token_ctx)
             server_module._session_client_ip.reset(ip_ctx)
             server_module._session_request_id.reset(req_ctx)
+            server_module._session_transport.reset(transport_ctx)
 
         assert identity["token_fingerprint"] == _fingerprint_auth_header(
             "Bearer rootly_session_token"
         )
         assert identity["client_ip"] == "192.0.2.8"
         assert identity["request_id"] == "req-session-1"
+        assert identity["transport"] == "sse"
+        assert identity["transport_effective"] == "sse"
+
+    def test_current_tool_identity_prefers_session_transport_over_runtime(self):
+        token_ctx = server_module._session_auth_token.set("Bearer rootly_session_token")
+        transport_ctx = server_module._session_transport.set("streamable-http")
+        try:
+            with patch("fastmcp.server.dependencies.get_http_headers", return_value={}):
+                with patch("fastmcp.server.context._current_transport") as mock_transport:
+                    mock_transport.get.return_value = "both"
+                    identity = _current_tool_identity()
+        finally:
+            server_module._session_auth_token.reset(token_ctx)
+            server_module._session_transport.reset(transport_ctx)
+
+        assert identity["transport_runtime"] == "both"
+        assert identity["transport_effective"] == "streamable-http"
+        assert identity["transport"] == "streamable-http"
 
     def test_log_tool_usage_event_emits_json_line(self):
         with patch.object(server_module, "_configure_tool_usage_json_logger") as mock_configure:
@@ -263,6 +283,8 @@ class TestToolUsageIdentityHelpers:
                         "client_ip": "203.0.113.10",
                         "request_id": "req-1",
                         "transport": "sse",
+                        "transport_effective": "sse",
+                        "transport_runtime": "both",
                     },
                 )
 
@@ -274,6 +296,8 @@ class TestToolUsageIdentityHelpers:
         assert payload["status"] == "success"
         assert payload["duration_ms"] == 123.46
         assert payload["transport"] == "sse"
+        assert payload["transport_effective"] == "sse"
+        assert payload["transport_runtime"] == "both"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -24,6 +24,7 @@ class TestTransportModule:
 
         # Ensure a known baseline in this context.
         transport._session_auth_token.set("")
+        transport._session_transport.set("")
 
         async def receive():
             return {"type": "http.request"}
@@ -33,6 +34,7 @@ class TestTransportModule:
 
         await middleware(scope, receive, send)
         assert transport._session_auth_token.get() == "Bearer test-token"
+        assert transport._session_transport.get() == "sse"
 
     @pytest.mark.asyncio
     async def test_auth_capture_middleware_sets_token_for_streamable_http(self):
@@ -47,6 +49,7 @@ class TestTransportModule:
         }
 
         transport._session_auth_token.set("")
+        transport._session_transport.set("")
 
         async def receive():
             return {"type": "http.request"}
@@ -56,6 +59,32 @@ class TestTransportModule:
 
         await middleware(scope, receive, send)
         assert transport._session_auth_token.get() == "Bearer streamable-token"
+        assert transport._session_transport.get() == "streamable-http"
+
+    @pytest.mark.asyncio
+    async def test_auth_capture_middleware_sets_transport_for_messages_path(self):
+        async def app(scope, receive, send):
+            return None
+
+        middleware = transport.AuthCaptureMiddleware(app)
+        scope = {
+            "type": "http",
+            "path": "/messages",
+            "headers": [(b"authorization", b"Bearer sse-message-token")],
+        }
+
+        transport._session_auth_token.set("")
+        transport._session_transport.set("")
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(_message):
+            return None
+
+        await middleware(scope, receive, send)
+        assert transport._session_auth_token.get() == "Bearer sse-message-token"
+        assert transport._session_transport.get() == "sse"
 
     @pytest.mark.asyncio
     async def test_auth_capture_middleware_ignores_non_mcp_paths(self):
@@ -70,6 +99,7 @@ class TestTransportModule:
         }
 
         transport._session_auth_token.set("")
+        transport._session_transport.set("")
 
         async def receive():
             return {"type": "http.request"}
@@ -79,6 +109,7 @@ class TestTransportModule:
 
         await middleware(scope, receive, send)
         assert transport._session_auth_token.get() == ""
+        assert transport._session_transport.get() == ""
 
     @pytest.mark.asyncio
     async def test_auth_capture_middleware_respects_custom_paths(self):
@@ -89,12 +120,14 @@ class TestTransportModule:
             "os.environ",
             {
                 "FASTMCP_SSE_PATH": "/custom-sse",
+                "FASTMCP_MESSAGE_PATH": "/custom-messages",
                 "FASTMCP_STREAMABLE_HTTP_PATH": "/custom-mcp",
             },
         ):
             middleware = transport.AuthCaptureMiddleware(app)
 
         transport._session_auth_token.set("")
+        transport._session_transport.set("")
 
         async def receive():
             return {"type": "http.request"}
@@ -109,6 +142,28 @@ class TestTransportModule:
         }
         await middleware(custom_scope, receive, send)
         assert transport._session_auth_token.get() == "Bearer custom-token"
+        assert transport._session_transport.get() == "streamable-http"
+
+        custom_message_scope = {
+            "type": "http",
+            "path": "/custom-messages",
+            "headers": [(b"authorization", b"Bearer custom-message-token")],
+        }
+        await middleware(custom_message_scope, receive, send)
+        assert transport._session_auth_token.get() == "Bearer custom-message-token"
+        assert transport._session_transport.get() == "sse"
+
+    def test_infer_transport_from_path(self):
+        assert transport._infer_transport_from_path("/sse", "/sse", "/messages", "/mcp") == "sse"
+        assert (
+            transport._infer_transport_from_path("/messages", "/sse", "/messages", "/mcp")
+            == "sse"
+        )
+        assert (
+            transport._infer_transport_from_path("/mcp", "/sse", "/messages", "/mcp")
+            == "streamable-http"
+        )
+        assert transport._infer_transport_from_path("/healthz", "/sse", "/messages", "/mcp") == ""
 
     def test_authenticated_client_user_agent_contains_mode(self):
         with patch.object(transport.AuthenticatedHTTPXClient, "_get_api_token", return_value="token"):


### PR DESCRIPTION
## Summary
- infer effective per-request transport in hosted mode from incoming MCP paths
- include `/messages` in auth capture paths to correctly classify SSE message posts
- emit `transport_runtime` and `transport_effective` in `mcp_tool_call` logs
- keep legacy `transport` field for backward compatibility, now normalized to effective transport

## Why
In dual transport mode, some tool logs were tagged as `transport=both`, which made Datadog split widgets ambiguous. This change keeps backwards compatibility while adding explicit fields for clean SSE vs streamable-http dashboards.

## Changes
- `src/rootly_mcp_server/transport.py`
  - added `_session_transport` context var
  - added `_infer_transport_from_path(...)`
  - expanded capture paths to include `FASTMCP_MESSAGE_PATH` (default `/messages`)
  - set transport context in `AuthCaptureMiddleware`
- `src/rootly_mcp_server/server.py`
  - `_current_tool_identity()` now computes:
    - `transport_runtime` from FastMCP runtime context
    - `transport_effective` from session path inference fallback/runtime
  - `mcp_tool_call` event now emits `transport_runtime` and `transport_effective`
- tests
  - added middleware tests for `/messages`, custom message path, and path inference
  - added identity/logging tests for effective-vs-runtime transport behavior

## Validation
- `uv run ruff check src/rootly_mcp_server/transport.py src/rootly_mcp_server/server.py tests/unit/test_transport_module.py tests/unit/test_server.py`
- `uv run isort --check-only src tests`
- `uv run pyright`
- `uv run pytest tests/unit/test_transport_module.py tests/unit/test_server.py -q`
- `uv run pytest -q`