### PR TITLE
ci: scope workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, staging]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit least-privilege `permissions` blocks to the CI workflow
- add explicit least-privilege `permissions` blocks to the PyPI release workflow

## Why
GitHub code scanning is flagging both workflows for missing explicit `GITHUB_TOKEN` permissions. These workflows only need repository read access for checkout and related actions, so this scopes the token down to the minimum required permission.

## Validation
- YAML parsed successfully for both workflow files
- pre-commit hook suite passed during commit
