### PR TITLE
feat: add incident readback for PIR verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ docker run -p 8000:8000 \
 
 ## Supported Tools
 
-The default server configuration currently exposes **100 tools** (including custom agentic tools and OpenAPI-generated tools).
+The default server configuration currently exposes **101 tools** (including custom agentic tools and OpenAPI-generated tools).
 
 ### Custom Agentic Tools
 
@@ -264,6 +264,7 @@ The default server configuration currently exposes **100 tools** (including cust
 - `check_responder_availability`
 - `create_override_recommendation`
 - `find_related_incidents`
+- `getIncident` - retrieve a single incident for direct verification, including PIR-related fields
 - `get_alert_by_short_id`
 - `get_oncall_handoff_summary`
 - `get_oncall_schedule_summary`

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -15,6 +15,9 @@ StripHeavyNestedData = Callable[[JsonDict], JsonDict]
 GenerateRecommendation = Callable[[JsonDict], str]
 
 RETROSPECTIVE_PROGRESS_STATUSES = ("not_started", "active", "completed", "skipped")
+INCIDENT_SEARCH_FIELDS = (
+    "id,title,summary,status,created_at,updated_at,url,started_at,retrospective_progress_status"
+)
 
 
 def register_incident_tools(
@@ -62,7 +65,7 @@ def register_incident_tools(
                 "page[size]": page_size,  # Use requested page size (already limited to max 20)
                 "page[number]": page_number,
                 "include": "",
-                "fields[incidents]": "id,title,summary,status,created_at,updated_at,url,started_at",
+                "fields[incidents]": INCIDENT_SEARCH_FIELDS,
             }
             if query:
                 params["filter[search]"] = query
@@ -87,7 +90,7 @@ def register_incident_tools(
                     "page[size]": effective_page_size,
                     "page[number]": current_page,
                     "include": "",
-                    "fields[incidents]": "id,title,summary,status,created_at,updated_at,url,started_at",
+                    "fields[incidents]": INCIDENT_SEARCH_FIELDS,
                 }
                 if query:
                     params["filter[search]"] = query
@@ -156,6 +159,30 @@ def register_incident_tools(
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(JsonDict, mcp_error.tool_error(error_message, error_type))
+
+    @mcp.tool(name="getIncident")
+    async def get_incident(
+        incident_id: Annotated[str, Field(description="Incident ID to retrieve")],
+    ) -> JsonDict:
+        """Retrieve a single incident with PIR-related fields for direct verification."""
+        try:
+            response = await make_authenticated_request("GET", f"/v1/incidents/{incident_id}")
+            response.raise_for_status()
+
+            response_data = response.json()
+            if isinstance(response_data.get("data"), dict):
+                stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
+                response_data["data"] = stripped["data"][0]
+            return cast(JsonDict, response_data)
+        except Exception as e:
+            error_type, error_message = mcp_error.categorize_error(e)
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to retrieve incident: {error_message}",
+                    error_type,
+                ),
+            )
 
     @mcp.tool(name="updateIncident")
     async def update_incident(

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -144,6 +144,30 @@ class TestScopedIncidentUpdateTool:
         tools, _ = self._register_tools()
 
         assert "updateIncident" in tools
+        assert "getIncident" in tools
+
+    @pytest.mark.asyncio
+    async def test_get_incident_fetches_single_incident(self):
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {
+                "id": "inc-123",
+                "type": "incidents",
+                "attributes": {
+                    "summary": "Updated PIR summary",
+                    "retrospective_progress_status": "active",
+                },
+            }
+        }
+        request.return_value = response
+
+        result = await tools["getIncident"](incident_id="inc-123")
+
+        request.assert_awaited_once_with("GET", "/v1/incidents/inc-123")
+        assert result["data"]["id"] == "inc-123"
+        assert result["data"]["attributes"]["retrospective_progress_status"] == "active"
 
     @pytest.mark.asyncio
     async def test_update_incident_sends_only_allowed_fields(self):
@@ -244,3 +268,19 @@ class TestScopedIncidentUpdateTool:
         assert result["error"] is True
         assert result["error_type"] == "validation_error"
         assert "retrospective_progress_status must be one of" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_search_incidents_requests_retrospective_progress_status_field(self):
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"data": []}
+        request.return_value = response
+
+        await tools["search_incidents"](query="pir", page_size=5, page_number=1)
+
+        request.assert_awaited_once()
+        await_args = request.await_args
+        assert await_args is not None
+        kwargs = await_args.kwargs
+        assert "retrospective_progress_status" in kwargs["params"]["fields[incidents]"]


### PR DESCRIPTION
## Summary
- add a direct `getIncident` custom tool for incident read-back and verification
- include `retrospective_progress_status` in `search_incidents` field selection
- update docs and tests for the new incident read path

## Why
`updateIncident` is already merged, but verifying PIR status changes through the existing MCP read path is awkward:
- there was no direct incident read tool
- `search_incidents` did not request `retrospective_progress_status`

This follow-up makes the PIR lifecycle flow easier to validate and troubleshoot in both classic MCP and Code Mode.

## Validation
- `uv run ruff check src/rootly_mcp_server/tools/incidents.py tests/unit/test_tools.py`
- `uv run pytest tests/unit/test_tools.py -q`
- `uv run pyright src/rootly_mcp_server/tools/incidents.py tests/unit/test_tools.py`
- pre-commit hook suite on commit
