### PR TITLE
fix: restore code mode execute compatibility

### DIFF
--- a/src/rootly_mcp_server/code_mode.py
+++ b/src/rootly_mcp_server/code_mode.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import importlib
 import os
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from fastmcp.experimental.transforms.code_mode import (
     CodeMode,
     GetSchemas,
     GetTags,
     ListTools,
+    MontySandboxProvider,
     Search,
+    _ensure_async,
 )
 
 from .server import create_rootly_mcp_server
@@ -53,9 +57,74 @@ def code_mode_path_from_env() -> str:
     return normalize_code_mode_path(os.getenv("ROOTLY_CODE_MODE_PATH", DEFAULT_CODE_MODE_PATH))
 
 
+class CompatibleMontySandboxProvider(MontySandboxProvider):
+    """Monty sandbox provider that tolerates older constructor signatures.
+
+    Some deployed environments can end up with a Monty runtime that supports
+    ``run_monty_async(..., external_functions=...)`` but still rejects the
+    newer ``Monty(..., external_functions=[...])`` constructor argument. This
+    provider falls back to the older constructor form so Code Mode execution
+    continues to work during mixed-version rollouts.
+    """
+
+    @staticmethod
+    def _build_monty_runner(
+        pydantic_monty: Any,
+        code: str,
+        *,
+        input_names: list[str],
+        external_function_names: list[str],
+    ) -> Any:
+        try:
+            return pydantic_monty.Monty(
+                code,
+                inputs=input_names,
+                external_functions=external_function_names,
+            )
+        except TypeError as exc:
+            if "external_functions" not in str(exc):
+                raise
+            return pydantic_monty.Monty(code, inputs=input_names)
+
+    async def run(
+        self,
+        code: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        external_functions: dict[str, Callable[..., Any]] | None = None,
+    ) -> Any:
+        try:
+            pydantic_monty = importlib.import_module("pydantic_monty")
+        except ModuleNotFoundError as exc:
+            raise ImportError(
+                "CodeMode requires pydantic-monty for the Monty sandbox provider. "
+                "Install it with `fastmcp[code-mode]` or pass a custom SandboxProvider."
+            ) from exc
+
+        inputs = inputs or {}
+        async_functions = {
+            key: _ensure_async(value)
+            for key, value in (external_functions or {}).items()
+        }
+
+        monty = self._build_monty_runner(
+            pydantic_monty,
+            code,
+            input_names=list(inputs.keys()),
+            external_function_names=list(async_functions.keys()),
+        )
+        run_kwargs: dict[str, Any] = {"external_functions": async_functions}
+        if inputs:
+            run_kwargs["inputs"] = inputs
+        if self.limits is not None:
+            run_kwargs["limits"] = self.limits
+        return await pydantic_monty.run_monty_async(monty, **run_kwargs)
+
+
 def build_code_mode_transform() -> CodeMode:
     """Build the shared Code Mode transform used by hosted deployments."""
     return CodeMode(
+        sandbox_provider=CompatibleMontySandboxProvider(),
         discovery_tools=[
             ListTools(default_detail="brief"),
             Search(default_detail="detailed", default_limit=12),

--- a/tests/unit/test_code_mode_module.py
+++ b/tests/unit/test_code_mode_module.py
@@ -1,11 +1,15 @@
 """Tests for Rootly Code Mode helpers."""
 
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
+import pytest
 from fastmcp.experimental.transforms.code_mode import CodeMode
 
 from rootly_mcp_server.code_mode import (
     DEFAULT_CODE_MODE_PATH,
+    CompatibleMontySandboxProvider,
     build_code_mode_transform,
     code_mode_enabled_from_env,
     code_mode_path_from_env,
@@ -40,6 +44,7 @@ def test_build_code_mode_transform_uses_expected_discovery_tools():
     transform = build_code_mode_transform()
 
     assert isinstance(transform, CodeMode)
+    assert isinstance(transform.sandbox_provider, CompatibleMontySandboxProvider)
     discovery_names = [tool.name for tool in transform._build_discovery_tools()]  # noqa: SLF001
     assert discovery_names == ["list_tools", "search", "get_schema", "tags"]
 
@@ -72,3 +77,73 @@ def test_create_rootly_codemode_server_adds_code_mode_transform():
         base_url="https://api.rootly.com",
         transport="streamable-http",
     )
+
+
+@pytest.mark.asyncio
+async def test_compatible_monty_provider_falls_back_for_legacy_constructor():
+    class LegacyMonty:
+        def __init__(self, code, *, inputs=None):
+            self.code = code
+            self.inputs = inputs
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run_monty_async(monty_runner, **kwargs):
+        captured["monty_runner"] = monty_runner
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    fake_module = SimpleNamespace(Monty=LegacyMonty, run_monty_async=fake_run_monty_async)
+
+    provider = CompatibleMontySandboxProvider()
+
+    async def fake_call_tool():
+        return "done"
+
+    with patch("rootly_mcp_server.code_mode.importlib.import_module", return_value=fake_module):
+        result = await provider.run(
+            "return await call_tool()",
+            inputs={"incident_id": "123"},
+            external_functions={"call_tool": fake_call_tool},
+        )
+
+    assert result == "ok"
+    monty_runner = captured["monty_runner"]
+    assert isinstance(monty_runner, LegacyMonty)
+    assert monty_runner.inputs == ["incident_id"]
+    kwargs = captured["kwargs"]
+    assert kwargs["inputs"] == {"incident_id": "123"}
+    assert list(kwargs["external_functions"]) == ["call_tool"]
+
+
+@pytest.mark.asyncio
+async def test_compatible_monty_provider_uses_modern_constructor_when_supported():
+    class ModernMonty:
+        def __init__(self, code, *, inputs=None, external_functions=None):
+            self.code = code
+            self.inputs = inputs
+            self.external_functions = external_functions
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run_monty_async(monty_runner, **kwargs):
+        captured["monty_runner"] = monty_runner
+        captured["kwargs"] = kwargs
+        return {"status": "ok"}
+
+    fake_module = SimpleNamespace(Monty=ModernMonty, run_monty_async=fake_run_monty_async)
+    provider = CompatibleMontySandboxProvider()
+
+    def fake_call_tool():
+        return "done"
+
+    with patch("rootly_mcp_server.code_mode.importlib.import_module", return_value=fake_module):
+        result = await provider.run(
+            "return call_tool()",
+            external_functions={"call_tool": fake_call_tool},
+        )
+
+    assert result == {"status": "ok"}
+    monty_runner = captured["monty_runner"]
+    assert isinstance(monty_runner, ModernMonty)
+    assert monty_runner.external_functions == ["call_tool"]


### PR DESCRIPTION
## Summary
- add a compatibility sandbox provider for Code Mode execute
- fall back when the Monty constructor does not accept external_functions
- cover both legacy and modern Monty signatures in unit tests

## Why
Production Code Mode execute is currently failing with:
`Monty.__new__() got an unexpected keyword argument 'external_functions'`

FastMCP 3.1.0 now passes `external_functions` into the Monty constructor. Some deployed runtimes appear to have an older Monty constructor shape even though `run_monty_async` still supports external functions. This patch makes our Code Mode path tolerant of both signatures so execute can keep working during mixed-version or drifted deployments.

## Validation
- uv run ruff check src/rootly_mcp_server/code_mode.py tests/unit/test_code_mode_module.py tests/unit/test_transport_module.py tests/unit/test_server.py
- uv run pyright src/rootly_mcp_server/code_mode.py tests/unit/test_code_mode_module.py tests/unit/test_transport_module.py tests/unit/test_server.py
- uv run pytest tests/unit/test_code_mode_module.py tests/unit/test_transport_module.py tests/unit/test_server.py -q
- pre-commit unit suite on commit (325 passed)
