### PR TITLE
fix: trim shift incident results and paginate list_shifts

### DIFF
--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -12,6 +12,7 @@ import httpx
 from pydantic import Field
 
 from ..och_client import OnCallHealthClient
+from ..validators import validate_page_params
 
 JsonDict = dict[str, Any]
 MakeAuthenticatedRequest = Callable[..., Awaitable[Any]]
@@ -1346,20 +1347,41 @@ def register_oncall_tools(
             bool,
             Field(description="Include user name and email in response (default: True)"),
         ] = True,
+        page_size: Annotated[
+            int,
+            Field(
+                description="Number of enriched shifts to return per page (max: 100). This paginates the MCP response even when the upstream shifts API does not."
+            ),
+        ] = 25,
+        page_number: Annotated[
+            int,
+            Field(
+                description="Page number of enriched shifts to return (1-indexed). Use this instead of relying on the generated listShifts pagination."
+            ),
+        ] = 1,
     ) -> dict:
         """
-        List on-call shifts with proper user filtering and enriched data.
+        List on-call shifts with reliable filtering, enrichment, and MCP-level pagination.
 
         Unlike the raw API, this tool:
         - Actually filters by user_ids (client-side filtering)
         - Includes user_name, user_email, schedule_name, team_name
         - Calculates total_hours for each shift
+        - Returns a predictable paginated result for MCP clients
 
-        Use this instead of the auto-generated listShifts when you need user filtering.
+        Use this instead of the auto-generated listShifts when you need user filtering
+        or dependable pagination on large tenants.
         """
         try:
             from datetime import datetime
 
+            page_size, page_number = validate_page_params(page_size, page_number)
+            if page_number == 0:
+                return mcp_error.tool_error(
+                    "page_number must be >= 1 for list_shifts",
+                    "validation_error",
+                    details={"page_number": page_number},
+                )
             # Build query parameters
             params: dict[str, Any] = {
                 "from": from_date,
@@ -1488,14 +1510,29 @@ def register_oncall_tools(
 
                 enriched_shifts.append(enriched_shift)
 
+            total_matching_shifts = len(enriched_shifts)
+            start_index = (page_number - 1) * page_size
+            end_index = start_index + page_size
+            paginated_shifts = enriched_shifts[start_index:end_index]
+            has_more = end_index < total_matching_shifts
+
             return {
                 "period": {"from": from_date, "to": to_date},
-                "total_shifts": len(enriched_shifts),
+                "total_shifts": total_matching_shifts,
+                "returned_shifts": len(paginated_shifts),
                 "filters_applied": {
                     "user_ids": list(user_id_filter) if user_id_filter else None,
                     "schedule_ids": schedule_ids if schedule_ids else None,
                 },
-                "shifts": enriched_shifts,
+                "meta": {
+                    "page_size": page_size,
+                    "page_number": page_number,
+                    "total_matching_shifts": total_matching_shifts,
+                    "returned_shifts": len(paginated_shifts),
+                    "has_more": has_more,
+                    "next_page": page_number + 1 if has_more else None,
+                },
+                "shifts": paginated_shifts,
             }
 
         except Exception as e:

--- a/tests/unit/test_oncall_handoff.py
+++ b/tests/unit/test_oncall_handoff.py
@@ -226,3 +226,250 @@ class TestGetShiftIncidents:
         assert first_incident["mitigation"].endswith("…")
         assert first_incident["narrative"] is not None
         assert len(first_incident["narrative"]) <= 400
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestListShifts:
+    """Test list_shifts pagination and filtering behavior."""
+
+    def _register_tools(self) -> tuple[dict[str, Any], AsyncMock]:
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_oncall_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            mcp_error=FakeMCPError(),
+        )
+        return mcp.tools, request
+
+    def _response(self, payload: dict[str, Any]) -> Mock:
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = payload
+        return response
+
+    async def test_list_shifts_returns_requested_page_with_meta(self):
+        tools, request = self._register_tools()
+        request.side_effect = [
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "2381",
+                            "type": "users",
+                            "attributes": {
+                                "full_name": "Quentin Rousseau",
+                                "email": "quentin@example.com",
+                            },
+                        },
+                        {
+                            "id": "94178",
+                            "type": "users",
+                            "attributes": {
+                                "full_name": "Gideon Lapshun",
+                                "email": "gideon@example.com",
+                            },
+                        },
+                    ]
+                }
+            ),
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "schedule-1",
+                            "type": "schedules",
+                            "attributes": {
+                                "name": "Infrastructure - Primary",
+                                "owner_group_ids": ["team-1"],
+                            },
+                        }
+                    ]
+                }
+            ),
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "team-1",
+                            "type": "teams",
+                            "attributes": {"name": "Infrastructure"},
+                        }
+                    ]
+                }
+            ),
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "shift-1",
+                            "type": "shifts",
+                            "attributes": {
+                                "schedule_id": "schedule-1",
+                                "starts_at": "2026-02-09T08:00:00.000-08:00",
+                                "ends_at": "2026-02-09T16:00:00.000-08:00",
+                                "is_override": False,
+                            },
+                            "relationships": {"user": {"data": {"id": "2381", "type": "users"}}},
+                        },
+                        {
+                            "id": "shift-2",
+                            "type": "shifts",
+                            "attributes": {
+                                "schedule_id": "schedule-1",
+                                "starts_at": "2026-02-10T08:00:00.000-08:00",
+                                "ends_at": "2026-02-10T16:00:00.000-08:00",
+                                "is_override": False,
+                            },
+                            "relationships": {"user": {"data": {"id": "94178", "type": "users"}}},
+                        },
+                        {
+                            "id": "shift-3",
+                            "type": "shifts",
+                            "attributes": {
+                                "schedule_id": "schedule-1",
+                                "starts_at": "2026-02-11T08:00:00.000-08:00",
+                                "ends_at": "2026-02-11T16:00:00.000-08:00",
+                                "is_override": False,
+                            },
+                            "relationships": {"user": {"data": {"id": "2381", "type": "users"}}},
+                        },
+                    ],
+                    "included": [],
+                    "meta": {"total_pages": 1},
+                }
+            ),
+        ]
+
+        result = await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z",
+            to_date="2026-02-12T00:00:00Z",
+            page_size=1,
+            page_number=2,
+        )
+
+        assert result["total_shifts"] == 3
+        assert result["returned_shifts"] == 1
+        assert result["meta"] == {
+            "page_size": 1,
+            "page_number": 2,
+            "total_matching_shifts": 3,
+            "returned_shifts": 1,
+            "has_more": True,
+            "next_page": 3,
+        }
+        assert len(result["shifts"]) == 1
+        assert result["shifts"][0]["shift_id"] == "shift-2"
+        assert result["shifts"][0]["user_name"] == "Gideon Lapshun"
+        assert request.await_count == 4
+
+    async def test_list_shifts_filters_before_pagination(self):
+        tools, request = self._register_tools()
+        request.side_effect = [
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "2381",
+                            "type": "users",
+                            "attributes": {
+                                "full_name": "Quentin Rousseau",
+                                "email": "quentin@example.com",
+                            },
+                        },
+                        {
+                            "id": "94178",
+                            "type": "users",
+                            "attributes": {
+                                "full_name": "Gideon Lapshun",
+                                "email": "gideon@example.com",
+                            },
+                        },
+                    ]
+                }
+            ),
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "schedule-1",
+                            "type": "schedules",
+                            "attributes": {
+                                "name": "Infrastructure - Primary",
+                                "owner_group_ids": ["team-1"],
+                            },
+                        }
+                    ]
+                }
+            ),
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "team-1",
+                            "type": "teams",
+                            "attributes": {"name": "Infrastructure"},
+                        }
+                    ]
+                }
+            ),
+            self._response(
+                {
+                    "data": [
+                        {
+                            "id": "shift-1",
+                            "type": "shifts",
+                            "attributes": {
+                                "schedule_id": "schedule-1",
+                                "starts_at": "2026-02-09T08:00:00.000-08:00",
+                                "ends_at": "2026-02-09T16:00:00.000-08:00",
+                                "is_override": False,
+                            },
+                            "relationships": {"user": {"data": {"id": "2381", "type": "users"}}},
+                        },
+                        {
+                            "id": "shift-2",
+                            "type": "shifts",
+                            "attributes": {
+                                "schedule_id": "schedule-1",
+                                "starts_at": "2026-02-10T08:00:00.000-08:00",
+                                "ends_at": "2026-02-10T16:00:00.000-08:00",
+                                "is_override": False,
+                            },
+                            "relationships": {"user": {"data": {"id": "94178", "type": "users"}}},
+                        },
+                    ],
+                    "included": [],
+                    "meta": {"total_pages": 1},
+                }
+            ),
+        ]
+
+        result = await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z",
+            to_date="2026-02-12T00:00:00Z",
+            user_ids="2381",
+            page_size=10,
+            page_number=1,
+        )
+
+        assert result["total_shifts"] == 1
+        assert result["returned_shifts"] == 1
+        assert result["meta"]["has_more"] is False
+        assert result["shifts"][0]["user_id"] == "2381"
+
+    async def test_list_shifts_rejects_page_number_zero(self):
+        tools, request = self._register_tools()
+
+        result = await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z",
+            to_date="2026-02-12T00:00:00Z",
+            page_size=10,
+            page_number=0,
+        )
+
+        assert result["error"] is True
+        assert result["error_type"] == "validation_error"
+        assert "page_number must be >= 1" in result["message"]
+        request.assert_not_awaited()


### PR DESCRIPTION
## Summary
- trim and cap `get_shift_incidents` results so large shift windows do not overflow MCP client context
- keep incidents that resolved during the shift while still slimming the incident payload
- add MCP-level pagination to `list_shifts` with `page_size`, `page_number`, and response metadata
- reject `page_number=0` for `list_shifts` to avoid misleading empty pages

## Why
A live repro showed `get_shift_incidents` was not hanging: it completed, but returned hundreds of incidents with large narrative fields and overflowed the client context. We also confirmed the generated `listShifts` endpoint does not reliably honor pagination on large tenants, so `list_shifts` now provides a dependable paginated alternative for MCP clients.

## Testing
- `uv run pytest tests/unit/test_oncall_handoff.py -q`
- `uv run ruff check src/rootly_mcp_server/tools/oncall.py tests/unit/test_oncall_handoff.py`
- `uv run pyright src/rootly_mcp_server/tools/oncall.py tests/unit/test_oncall_handoff.py`
- pre-commit hook suite on commit (`335 passed`)
