### PR TITLE
fix: harden code mode execute errors

### DIFF
--- a/src/rootly_mcp_server/code_mode.py
+++ b/src/rootly_mcp_server/code_mode.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
+from fastmcp.exceptions import NotFoundError
 from fastmcp.experimental.transforms.code_mode import (
     CodeMode,
     GetSchemas,
@@ -15,7 +16,11 @@ from fastmcp.experimental.transforms.code_mode import (
     MontySandboxProvider,
     Search,
     _ensure_async,
+    _unwrap_tool_result,
 )
+from fastmcp.server.context import Context
+from fastmcp.tools.tool import Tool
+from pydantic import Field
 
 from .server import create_rootly_mcp_server
 
@@ -24,6 +29,15 @@ if TYPE_CHECKING:
 
 
 DEFAULT_CODE_MODE_PATH = "/mcp-codemode"
+_TOOL_NAME_PREFIXES = (
+    "mcp__rootly-codemode__",
+    "mcp__rootly__",
+    "rootly-codemode:",
+    "rootly:",
+)
+_TOOL_NAME_ALIASES = {
+    "search": "tool_search",
+}
 
 
 def _normalize_http_path(path: str) -> str:
@@ -55,6 +69,61 @@ def code_mode_enabled_from_env(default: bool = True) -> bool:
 def code_mode_path_from_env() -> str:
     """Return the configured hosted Code Mode path."""
     return normalize_code_mode_path(os.getenv("ROOTLY_CODE_MODE_PATH", DEFAULT_CODE_MODE_PATH))
+
+
+def _normalize_execute_tool_name(tool_name: str) -> str:
+    """Normalize common client-specific Code Mode tool name variants."""
+    normalized = (tool_name or "").strip()
+    for prefix in _TOOL_NAME_PREFIXES:
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    return _TOOL_NAME_ALIASES.get(normalized, normalized)
+
+
+def _format_execute_exception(exc: Exception) -> str | None:
+    """Return a friendlier execute error message for known sandbox failures."""
+    message = str(exc).strip()
+    if not message:
+        return None
+
+    if isinstance(exc, NotFoundError) or "Unknown tool:" in message:
+        return (
+            f"{message}. Use tool_search to discover available tools and call them "
+            "without client prefixes like 'mcp__rootly-codemode__' or 'rootly:'."
+        )
+
+    if isinstance(exc, ModuleNotFoundError) or "No module named" in message:
+        return (
+            f"{message}. Code Mode runs in a restricted sandbox, so imports like "
+            "`json` or `asyncio` are not available. Return native Python dict/list/str "
+            "values and use `await call_tool(name, params)` for Rootly operations."
+        )
+
+    if (
+        isinstance(exc, AttributeError) and "asyncio" in message and "sleep" in message
+    ) or "asyncio' has no attribute 'sleep'" in message:
+        return (
+            f"{message}. Code Mode does not provide `asyncio.sleep()`. Avoid manual "
+            "sleep/retry loops inside execute; call Rootly tools directly and return "
+            "the final result."
+        )
+
+    if message.startswith("Expected ") or "got Subscript(" in message:
+        return (
+            f"{message}. Code Mode supports a restricted Python subset. Keep the block "
+            "simple: assign intermediate values to variables, call `await call_tool(...)`, "
+            "and `return` the final value."
+        )
+
+    if isinstance(exc, TypeError) and "NoneType" in message and "subscriptable" in message:
+        return (
+            f"{message}. Code Mode tried to read a field from a missing result. Check "
+            "that each `call_tool(...)` response contains the keys you expect before "
+            "indexing into it."
+        )
+
+    return None
 
 
 class CompatibleMontySandboxProvider(MontySandboxProvider):
@@ -121,9 +190,66 @@ class CompatibleMontySandboxProvider(MontySandboxProvider):
         return await pydantic_monty.run_monty_async(monty, **run_kwargs)
 
 
+class RootlyCodeMode(CodeMode):
+    """Rootly-specific Code Mode transform with friendlier execute ergonomics."""
+
+    def _make_execute_tool(self) -> Tool:
+        transform = self
+
+        async def execute(
+            code: Annotated[
+                str,
+                Field(
+                    description=(
+                        "Python async code to execute tool calls via call_tool(name, arguments)"
+                    )
+                ),
+            ],
+            ctx: Context = None,  # type: ignore[assignment]
+        ) -> Any:
+            """Execute tool calls using Python code."""
+            cached_tools: list[Tool] | None = None
+
+            async def _get_cached_tools() -> list[Tool]:
+                nonlocal cached_tools
+                if cached_tools is None:
+                    cached_tools = list(await transform.get_tool_catalog(ctx))
+                return cached_tools
+
+            async def call_tool(tool_name: str, params: dict[str, Any]) -> Any:
+                resolved_name = _normalize_execute_tool_name(tool_name)
+                backend_tools = await _get_cached_tools()
+                tool = (
+                    transform._find_tool(resolved_name, transform._build_discovery_tools())
+                    or transform._find_tool(resolved_name, backend_tools)
+                )
+                if tool is None:
+                    raise NotFoundError(f"Unknown tool: {tool_name}")
+
+                result = await ctx.fastmcp.call_tool(tool.name, params)
+                return _unwrap_tool_result(result)
+
+            try:
+                return await transform.sandbox_provider.run(
+                    code,
+                    external_functions={"call_tool": call_tool},
+                )
+            except Exception as exc:
+                friendly_message = _format_execute_exception(exc)
+                if friendly_message is None:
+                    raise
+                raise ValueError(friendly_message) from exc
+
+        return Tool.from_function(
+            fn=execute,
+            name=self.execute_tool_name,
+            description=self._build_execute_description(),
+        )
+
+
 def build_code_mode_transform() -> CodeMode:
     """Build the shared Code Mode transform used by hosted deployments."""
-    return CodeMode(
+    return RootlyCodeMode(
         sandbox_provider=CompatibleMontySandboxProvider(),
         discovery_tools=[
             ListTools(default_detail="brief"),
@@ -138,7 +264,10 @@ def build_code_mode_transform() -> CodeMode:
             "the schema. For paginated data tools, pass pagination arguments like page_size, "
             "page_number, and max_results exactly as documented by that tool instead of inventing "
             "alternatives like per_page. Prefer Rootly's higher-level custom tools when they fit "
-            "the task, then fall back to lower-level API tools as needed. Example: "
+            "the task, then fall back to lower-level API tools as needed. Do not use client "
+            "prefixes like mcp__rootly-codemode__tool_search or rootly:getCurrentUser inside "
+            "execute; call tool_search or the raw Rootly tool name directly. Avoid imports "
+            "such as json or asyncio inside the sandbox and return native Python values instead. Example: "
             "await call_tool('search_incidents', {'query': '', 'page_size': 1, 'page_number': 1, "
             "'max_results': 1}). Use return to emit the final result."
         ),

--- a/tests/unit/test_code_mode_module.py
+++ b/tests/unit/test_code_mode_module.py
@@ -1,15 +1,18 @@
 """Tests for Rootly Code Mode helpers."""
 
 from types import SimpleNamespace
-from typing import Any
-from unittest.mock import patch
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastmcp.experimental.transforms.code_mode import CodeMode
+from fastmcp.tools.function_tool import FunctionTool
 
 from rootly_mcp_server.code_mode import (
     DEFAULT_CODE_MODE_PATH,
     CompatibleMontySandboxProvider,
+    _format_execute_exception,
+    _normalize_execute_tool_name,
     build_code_mode_transform,
     code_mode_enabled_from_env,
     code_mode_path_from_env,
@@ -56,6 +59,9 @@ def test_build_code_mode_transform_includes_pagination_guidance():
     assert "tool_search only to discover tools" in transform.execute_description
     assert "page_size, page_number, and max_results" in transform.execute_description
     assert "per_page" in transform.execute_description
+    assert "mcp__rootly-codemode__tool_search" in transform.execute_description
+    assert "rootly:getCurrentUser" in transform.execute_description
+    assert "Avoid imports such as json or asyncio" in transform.execute_description
     assert "await call_tool('search_incidents'" in transform.execute_description
 
 
@@ -157,3 +163,111 @@ async def test_compatible_monty_provider_uses_modern_constructor_when_supported(
     monty_runner = captured["monty_runner"]
     assert isinstance(monty_runner, ModernMonty)
     assert monty_runner.external_functions == ["call_tool"]
+
+
+def test_normalize_execute_tool_name_handles_prefixes_and_aliases():
+    assert _normalize_execute_tool_name("mcp__rootly-codemode__tool_search") == "tool_search"
+    assert _normalize_execute_tool_name("rootly:getCurrentUser") == "getCurrentUser"
+    assert _normalize_execute_tool_name("search") == "tool_search"
+
+
+def test_format_execute_exception_returns_friendlier_messages():
+    unknown_tool = _format_execute_exception(
+        Exception("Unknown tool: mcp__rootly-codemode__tool_search")
+    )
+    assert unknown_tool is not None
+    assert "Use tool_search to discover available tools" in unknown_tool
+
+    missing_import = _format_execute_exception(
+        Exception("ModuleNotFoundError: No module named 'json'")
+    )
+    assert missing_import is not None
+    assert "restricted sandbox" in missing_import
+
+    asyncio_sleep = _format_execute_exception(
+        Exception("AttributeError: module 'asyncio' has no attribute 'sleep'")
+    )
+    assert asyncio_sleep is not None
+    assert "does not provide `asyncio.sleep()`" in asyncio_sleep
+
+    parser_error = _format_execute_exception(Exception("Expected name, got Subscript(...)"))
+    assert parser_error is not None
+    assert "restricted Python subset" in parser_error
+
+
+@pytest.mark.asyncio
+async def test_execute_normalizes_namespaced_discovery_tool_calls():
+    class FakeSandboxProvider:
+        async def run(self, code, *, inputs=None, external_functions=None):
+            assert external_functions is not None
+            return await external_functions["call_tool"](
+                "mcp__rootly-codemode__tool_search",
+                {"query": "alerts"},
+            )
+
+    transform = build_code_mode_transform()
+    transform.sandbox_provider = FakeSandboxProvider()
+    execute_tool = cast(FunctionTool, transform._get_execute_tool())  # noqa: SLF001
+
+    fake_fastmcp = SimpleNamespace(
+        list_tools=AsyncMock(return_value=[]),
+        call_tool=AsyncMock(return_value=SimpleNamespace(structured_content={"ok": True}, content=[])),
+    )
+    ctx = SimpleNamespace(fastmcp=fake_fastmcp)
+
+    result = await execute_tool.fn("return 1", ctx=ctx)
+
+    assert result == {"ok": True}
+    fake_fastmcp.call_tool.assert_awaited_once_with("tool_search", {"query": "alerts"})
+
+
+@pytest.mark.asyncio
+async def test_execute_normalizes_namespaced_backend_tool_calls():
+    class FakeSandboxProvider:
+        async def run(self, code, *, inputs=None, external_functions=None):
+            assert external_functions is not None
+            return await external_functions["call_tool"]("rootly:getCurrentUser", {})
+
+    transform = build_code_mode_transform()
+    transform.sandbox_provider = FakeSandboxProvider()
+    execute_tool = cast(FunctionTool, transform._get_execute_tool())  # noqa: SLF001
+
+    backend_tools = [SimpleNamespace(name="getCurrentUser")]
+    fake_fastmcp = SimpleNamespace(
+        list_tools=AsyncMock(return_value=backend_tools),
+        call_tool=AsyncMock(
+            return_value=SimpleNamespace(structured_content={"id": "u_1"}, content=[])
+        ),
+    )
+    ctx = SimpleNamespace(fastmcp=fake_fastmcp)
+
+    result = await execute_tool.fn("return 1", ctx=ctx)
+
+    assert result == {"id": "u_1"}
+    fake_fastmcp.call_tool.assert_awaited_once_with("getCurrentUser", {})
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_friendlier_unknown_tool_errors():
+    class FakeSandboxProvider:
+        async def run(self, code, *, inputs=None, external_functions=None):
+            assert external_functions is not None
+            return await external_functions["call_tool"](
+                "mcp__rootly-codemode__missing_tool",
+                {},
+            )
+
+    transform = build_code_mode_transform()
+    transform.sandbox_provider = FakeSandboxProvider()
+    execute_tool = cast(FunctionTool, transform._get_execute_tool())  # noqa: SLF001
+
+    fake_fastmcp = SimpleNamespace(
+        list_tools=AsyncMock(return_value=[]),
+        call_tool=AsyncMock(),
+    )
+    ctx = SimpleNamespace(fastmcp=fake_fastmcp)
+
+    with pytest.raises(ValueError, match="Use tool_search to discover available tools"):
+        await execute_tool.fn("return 1", ctx=ctx)
+
+    fake_fastmcp.call_tool.assert_not_awaited()


### PR DESCRIPTION
## Summary
- normalize common client-prefixed tool names inside Code Mode execute
- allow execute to resolve discovery tools like tool_search in addition to backend Rootly tools
- turn common sandbox/runtime failures into clearer actionable Code Mode error messages
- add end-to-end tests for namespaced tool calls and friendly error formatting

## Why
Recent error logs showed a concentrated cluster of Code Mode execute failures from one client session, including prefixed tool names like `mcp__rootly-codemode__tool_search`, import-related sandbox errors, and raw parser/runtime exceptions. This change makes execute more forgiving and gives users guidance they can act on.

## Validation
- uv run ruff check src/rootly_mcp_server/code_mode.py tests/unit/test_code_mode_module.py
- uv run pyright src/rootly_mcp_server/code_mode.py tests/unit/test_code_mode_module.py
- uv run pytest tests/unit/test_code_mode_module.py -q
- uv run pytest tests/unit -q
