### PR TITLE
🔒️ Add cooldown to Dependabot to mitigate supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       actions:
         patterns:
@@ -14,6 +16,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       minor-and-patch:
         applies-to: version-updates
@@ -25,3 +30,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7


### PR DESCRIPTION
## Summary

Adds cooldown periods to all three Dependabot package ecosystems (github-actions, pip, docker). This introduces a delay before Dependabot adopts newly published package versions, giving time for malicious packages to be detected and removed before they're pulled in.

- `default-days: 3` on all ecosystems
- `semver-major-days: 7` on pip and docker (higher risk surface)