### PR TITLE
fix: add missing items property to array-type parameter schemas

### DIFF
--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -565,14 +565,23 @@ def _ensure_array_items(schema: dict[str, Any]) -> None:
     for prop_schema in schema.get("properties", {}).values():
         _ensure_array_items(prop_schema)
 
-    # Recurse into items (array element schema)
-    if "items" in schema and isinstance(schema["items"], dict):
-        _ensure_array_items(schema["items"])
+    # Recurse into items (array element schema or tuple-validation list)
+    if "items" in schema:
+        if isinstance(schema["items"], dict):
+            _ensure_array_items(schema["items"])
+        elif isinstance(schema["items"], list):
+            for item_schema in schema["items"]:
+                _ensure_array_items(item_schema)
 
     # Recurse into combination keywords
     for keyword in ("allOf", "anyOf", "oneOf"):
         for sub in schema.get(keyword, []):
             _ensure_array_items(sub)
+
+    # Recurse into `not` schema
+    if_not = schema.get("not")
+    if isinstance(if_not, dict):
+        _ensure_array_items(if_not)
 
     # Recurse into additionalProperties if it is a schema dict
     additional = schema.get("additionalProperties")

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -527,7 +527,57 @@ def _filter_openapi_spec(
                                         f"Cleaned broken reference in {method.upper()} {path} response: {ref_path}"
                                     )
 
+    # Post-process: ensure every array-type schema has an `items` property.
+    # Required by VS Code Copilot Agent Mode and the JSON Schema spec.
+    for path, path_item in filtered_spec.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if method.lower() not in ["get", "post", "put", "delete", "patch"]:
+                continue
+            for param in operation.get("parameters", []):
+                if "schema" in param:
+                    _ensure_array_items(param["schema"])
+            if "requestBody" in operation:
+                for content_info in operation["requestBody"].get("content", {}).values():
+                    if "schema" in content_info:
+                        _ensure_array_items(content_info["schema"])
+
     return filtered_spec
+
+
+def _ensure_array_items(schema: dict[str, Any]) -> None:
+    """Recursively ensure every ``"type": "array"`` node has an ``"items"`` property.
+
+    VS Code GitHub Copilot Agent Mode (and the JSON Schema spec) require that
+    every array-typed schema includes ``items``.  The Rootly OpenAPI spec
+    sometimes omits it, which triggers validation errors in strict MCP clients.
+
+    This function modifies *schema* in-place.  A missing ``items`` is filled
+    with ``{}`` (accepts any element type), which is the minimally-restrictive
+    default recommended by JSON Schema.
+    """
+    if not isinstance(schema, dict):
+        return
+
+    if schema.get("type") == "array" and "items" not in schema:
+        schema["items"] = {}
+
+    # Recurse into object properties
+    for prop_schema in schema.get("properties", {}).values():
+        _ensure_array_items(prop_schema)
+
+    # Recurse into items (array element schema)
+    if "items" in schema and isinstance(schema["items"], dict):
+        _ensure_array_items(schema["items"])
+
+    # Recurse into combination keywords
+    for keyword in ("allOf", "anyOf", "oneOf"):
+        for sub in schema.get(keyword, []):
+            _ensure_array_items(sub)
+
+    # Recurse into additionalProperties if it is a schema dict
+    additional = schema.get("additionalProperties")
+    if isinstance(additional, dict):
+        _ensure_array_items(additional)
 
 
 def _has_broken_references(schema_def: dict[str, Any]) -> bool:

--- a/tests/unit/test_spec_transform.py
+++ b/tests/unit/test_spec_transform.py
@@ -108,6 +108,25 @@ class TestEnsureArrayItems:
         _ensure_array_items(schema)
         assert schema["items"] == {}
 
+    def test_tuple_validation_items_list_recursed(self):
+        """When items is a list (tuple validation), each element schema is recursed."""
+        schema = {
+            "type": "array",
+            "items": [
+                {"type": "string"},
+                {"type": "array"},  # nested array missing items
+            ],
+        }
+        _ensure_array_items(schema)
+        assert schema["items"][0] == {"type": "string"}
+        assert schema["items"][1]["items"] == {}
+
+    def test_not_keyword_recursed(self):
+        """Arrays inside a 'not' schema also get items."""
+        schema = {"not": {"type": "array"}}
+        _ensure_array_items(schema)
+        assert schema["not"]["items"] == {}
+
 
 @pytest.mark.unit
 class TestFilterOpenAPISpecArrayItems:

--- a/tests/unit/test_spec_transform.py
+++ b/tests/unit/test_spec_transform.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for spec_transform module.
+
+Tests cover:
+- _ensure_array_items: adds missing items to array-type schemas
+- _filter_openapi_spec: array types in generated schemas always have items
+"""
+
+import pytest
+
+from rootly_mcp_server.spec_transform import _ensure_array_items, _filter_openapi_spec
+
+
+@pytest.mark.unit
+class TestEnsureArrayItems:
+    """Tests for the _ensure_array_items helper."""
+
+    def test_array_without_items_gets_default(self):
+        """Array type with no items property gets items: {}."""
+        schema = {"type": "array"}
+        _ensure_array_items(schema)
+        assert "items" in schema
+        assert schema["items"] == {}
+
+    def test_array_with_existing_items_unchanged(self):
+        """Array type that already has items is not modified."""
+        schema = {"type": "array", "items": {"type": "string"}}
+        _ensure_array_items(schema)
+        assert schema["items"] == {"type": "string"}
+
+    def test_non_array_type_unchanged(self):
+        """Non-array types are left alone."""
+        schema = {"type": "string"}
+        _ensure_array_items(schema)
+        assert "items" not in schema
+
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        _ensure_array_items(schema)
+        assert "items" not in schema
+
+    def test_nested_array_in_object_properties(self):
+        """Arrays nested inside object properties also get items."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "tags": {"type": "array"},
+                "name": {"type": "string"},
+            },
+        }
+        _ensure_array_items(schema)
+        assert schema["properties"]["tags"]["items"] == {}
+        assert "items" not in schema["properties"]["name"]
+
+    def test_nested_array_in_array_items(self):
+        """Array-of-arrays: inner array also gets items."""
+        schema = {
+            "type": "array",
+            "items": {"type": "array"},
+        }
+        _ensure_array_items(schema)
+        assert schema["items"]["items"] == {}
+
+    def test_deeply_nested_array(self):
+        """Arrays nested multiple levels deep get items at every level."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "ids": {"type": "array"},
+                    },
+                }
+            },
+        }
+        _ensure_array_items(schema)
+        assert schema["properties"]["data"]["properties"]["ids"]["items"] == {}
+
+    def test_array_in_allof_anyof_oneof(self):
+        """Arrays inside allOf/anyOf/oneOf also get items."""
+        schema = {
+            "allOf": [
+                {"type": "array"},
+                {"type": "string"},
+            ]
+        }
+        _ensure_array_items(schema)
+        assert schema["allOf"][0]["items"] == {}
+        assert "items" not in schema["allOf"][1]
+
+        schema = {
+            "anyOf": [{"type": "array"}],
+            "oneOf": [{"type": "array"}],
+        }
+        _ensure_array_items(schema)
+        assert schema["anyOf"][0]["items"] == {}
+        assert schema["oneOf"][0]["items"] == {}
+
+    def test_empty_schema_unchanged(self):
+        """Empty dict doesn't crash and is unchanged."""
+        schema = {}
+        _ensure_array_items(schema)
+        assert schema == {}
+
+    def test_array_with_empty_items_dict_unchanged(self):
+        """Array that already has items: {} is not re-modified."""
+        schema = {"type": "array", "items": {}}
+        _ensure_array_items(schema)
+        assert schema["items"] == {}
+
+
+@pytest.mark.unit
+class TestFilterOpenAPISpecArrayItems:
+    """Tests that _filter_openapi_spec ensures all array params have items."""
+
+    def _make_spec(self, param_schema: dict) -> dict:
+        """Build a minimal spec with one GET endpoint using given parameter schema."""
+        return {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/v1/test": {
+                    "get": {
+                        "operationId": "listTest",
+                        "parameters": [
+                            {
+                                "name": "filter",
+                                "in": "query",
+                                "required": False,
+                                "schema": param_schema,
+                            }
+                        ],
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                }
+            },
+        }
+
+    def test_array_param_without_items_gets_items_after_filter(self):
+        """After filtering, array-type parameter schemas have items."""
+        spec = self._make_spec({"type": "array"})
+        result = _filter_openapi_spec(spec, ["/v1/test"])
+        param_schema = result["paths"]["/v1/test"]["get"]["parameters"][0]["schema"]
+        assert param_schema.get("type") == "array"
+        assert "items" in param_schema
+
+    def test_array_param_with_items_unchanged_after_filter(self):
+        """After filtering, array-type parameter schemas with items are not changed."""
+        spec = self._make_spec({"type": "array", "items": {"type": "string"}})
+        result = _filter_openapi_spec(spec, ["/v1/test"])
+        param_schema = result["paths"]["/v1/test"]["get"]["parameters"][0]["schema"]
+        assert param_schema["items"] == {"type": "string"}
+
+    def test_nested_array_in_request_body_gets_items(self):
+        """Array types inside request body schemas also get items."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0"},
+            "paths": {
+                "/v1/test": {
+                    "post": {
+                        "operationId": "createTest",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "ids": {"type": "array"},
+                                            "name": {"type": "string"},
+                                        },
+                                    }
+                                }
+                            }
+                        },
+                        "responses": {"201": {"description": "created"}},
+                    }
+                }
+            },
+        }
+        result = _filter_openapi_spec(spec, ["/v1/test"])
+        props = result["paths"]["/v1/test"]["post"]["requestBody"]["content"][
+            "application/json"
+        ]["schema"]["properties"]
+        assert "items" in props["ids"]
+        assert "items" not in props["name"]


### PR DESCRIPTION
## Summary

- Fixes VS Code GitHub Copilot Agent Mode validation errors like `tool parameters array type must have items` for all 99+ generated MCP tools
- Adds `_ensure_array_items(schema)` to `spec_transform.py` — a recursive helper that walks any schema dict and fills in `"items": {}` wherever `"type": "array"` appears without a sibling `items` key
- Calls it from `_filter_openapi_spec` as a post-processing pass over every parameter schema and request body schema in the filtered paths
- Adds `tests/unit/test_spec_transform.py` with 12 unit tests

Fixes #82

## Why

The JSON Schema spec (and VS Code Copilot Agent Mode's strict validator) require every `"type": "array"` node to include an `"items"` property. The Rootly OpenAPI spec sometimes omits it, causing errors like:

```
Failed to validate tool mcp_rootly-mcp_createEscalationPath:
Error: tool parameters array type must have items.
```

## Approach

The fix is entirely in the spec normalization layer (`spec_transform.py`), applied before FastMCP generates tools — so no MCP protocol behaviour, tool functionality, or client compatibility with Cursor/Claude Code/other clients is affected.

Missing `items` is filled with `{}` (accepts any element type), which is the minimally-restrictive JSON Schema default.

## Test plan

- [x] 12 new unit tests in `tests/unit/test_spec_transform.py` — all pass
- [x] Full unit suite (360 tests) — no regressions
- [x] Covers: bare array, existing items unchanged, nested in object properties, array-of-arrays, deeply nested, allOf/anyOf/oneOf, request body schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)