### PR TITLE
Fix array schemas missing items

### DIFF
--- a/.github/openapi-audit-remote-baseline.json
+++ b/.github/openapi-audit-remote-baseline.json
@@ -1,0 +1,6 @@
+{
+  "missing_array_items": [
+    "components.schemas.new_escalation_policy_path.properties.data.properties.attributes.properties.rules.items.anyOf[0].properties.urgency_ids",
+    "components.schemas.update_escalation_policy_path.properties.data.properties.attributes.properties.rules.items.anyOf[0].properties.urgency_ids"
+  ]
+}

--- a/.github/workflows/openapi-audit.yml
+++ b/.github/workflows/openapi-audit.yml
@@ -1,0 +1,80 @@
+name: OpenAPI Audit
+
+on:
+  pull_request:
+    branches: [main, staging]
+    paths:
+      - ".github/workflows/openapi-audit.yml"
+      - ".github/openapi-audit-remote-baseline.json"
+      - "scripts/audit_openapi.py"
+      - "src/rootly_mcp_server/data/swagger.json"
+      - "src/rootly_mcp_server/spec_transform.py"
+      - "tests/unit/test_server.py"
+  push:
+    branches: [main, staging]
+    paths:
+      - ".github/workflows/openapi-audit.yml"
+      - ".github/openapi-audit-remote-baseline.json"
+      - "scripts/audit_openapi.py"
+      - "src/rootly_mcp_server/data/swagger.json"
+      - "src/rootly_mcp_server/spec_transform.py"
+      - "tests/unit/test_server.py"
+  workflow_dispatch:
+  schedule:
+    - cron: "23 12 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openapi-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundled-audit:
+    name: Bundled Swagger Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@7eb50e6e20e1e2009087999ba91242e80253875f # v7
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Audit bundled swagger
+        run: uv run python scripts/audit_openapi.py --filtered-defaults --instantiate-server
+
+  remote-audit:
+    name: Remote Swagger Audit
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@7eb50e6e20e1e2009087999ba91242e80253875f # v7
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Audit remote swagger
+        run: >
+          uv run python scripts/audit_openapi.py
+          --remote
+          --baseline-json .github/openapi-audit-remote-baseline.json
+          --filtered-defaults
+          --instantiate-server

--- a/scripts/audit_openapi.py
+++ b/scripts/audit_openapi.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Audit bundled or remote OpenAPI documents for MCP tool generation issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from rootly_mcp_server.server import create_rootly_mcp_server  # noqa: E402
+from rootly_mcp_server.server_defaults import (  # noqa: E402
+    DEFAULT_ALLOWED_PATHS,
+    DEFAULT_DELETE_ALLOWED_PATHS,
+)
+from rootly_mcp_server.spec_transform import (  # noqa: E402
+    SWAGGER_URL,
+    _fetch_swagger_from_url,
+    _filter_openapi_spec,
+    audit_openapi_spec,
+    has_openapi_audit_findings,
+)
+
+
+def _prefixed_paths(paths: list[str]) -> list[str]:
+    return [f"/v1{path}" if not path.startswith("/v1") else path for path in paths]
+
+
+def _load_source(source_path: Path | None, source_url: str | None) -> tuple[dict[str, Any], str]:
+    if source_url:
+        return _fetch_swagger_from_url(source_url), source_url
+
+    path = source_path or (REPO_ROOT / "src" / "rootly_mcp_server" / "data" / "swagger.json")
+    with path.open(encoding="utf-8") as f:
+        return json.load(f), str(path)
+
+
+def _print_findings(label: str, findings: dict[str, list[Any]]) -> None:
+    print(f"\n[{label}]")
+    if not has_openapi_audit_findings(findings):
+        print("ok")
+        return
+
+    for category, items in findings.items():
+        print(f"{category}: {len(items)}")
+        for item in items[:10]:
+            print(f"  - {item}")
+
+
+def _apply_baseline(
+    findings: dict[str, list[Any]], baseline: dict[str, list[Any]]
+) -> tuple[dict[str, list[Any]], dict[str, int]]:
+    filtered: dict[str, list[Any]] = {}
+    allowed_counts: dict[str, int] = {}
+
+    for category, items in findings.items():
+        allowed = {
+            json.dumps(entry, sort_keys=True) if isinstance(entry, dict) else json.dumps(entry)
+            for entry in baseline.get(category, [])
+        }
+
+        remaining: list[Any] = []
+        allowed_count = 0
+        for item in items:
+            token = json.dumps(item, sort_keys=True) if isinstance(item, dict) else json.dumps(item)
+            if token in allowed:
+                allowed_count += 1
+                continue
+            remaining.append(item)
+
+        filtered[category] = remaining
+        allowed_counts[category] = allowed_count
+
+    return filtered, allowed_counts
+
+
+def _instantiate_server(spec: dict[str, Any]) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
+        json.dump(spec, tmp)
+        temp_path = Path(tmp.name)
+
+    try:
+        create_rootly_mcp_server(swagger_path=str(temp_path), hosted=False)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        help="Audit a local OpenAPI JSON file. Defaults to the bundled swagger.json.",
+    )
+    parser.add_argument(
+        "--url",
+        help=f"Audit a remote OpenAPI JSON URL. Defaults to {SWAGGER_URL!r} when --remote is used.",
+    )
+    parser.add_argument(
+        "--remote",
+        action="store_true",
+        help="Audit the default remote Rootly swagger URL.",
+    )
+    parser.add_argument(
+        "--filtered-defaults",
+        action="store_true",
+        help="Also audit the spec after applying the default MCP path filters.",
+    )
+    parser.add_argument(
+        "--instantiate-server",
+        action="store_true",
+        help="Instantiate FastMCP from the audited spec to catch schema validation failures.",
+    )
+    parser.add_argument(
+        "--baseline-json",
+        type=Path,
+        help="Path to a JSON file containing known findings to ignore.",
+    )
+    args = parser.parse_args()
+
+    source_url = args.url or (SWAGGER_URL if args.remote else None)
+    if source_url and args.path:
+        parser.error("use either --path or --url/--remote, not both")
+
+    spec, source_label = _load_source(args.path, source_url)
+    raw_findings = audit_openapi_spec(spec)
+    baseline: dict[str, list[Any]] = {}
+    if args.baseline_json:
+        with args.baseline_json.open(encoding="utf-8") as f:
+            loaded = json.load(f)
+        baseline = loaded if isinstance(loaded, dict) else {}
+        raw_findings, allowed_counts = _apply_baseline(raw_findings, baseline)
+    else:
+        allowed_counts = {}
+
+    _print_findings(source_label, raw_findings)
+    if any(allowed_counts.values()):
+        print("\n[baseline]")
+        for category, count in allowed_counts.items():
+            if count:
+                print(f"{category}: allowed {count}")
+
+    findings_exist = has_openapi_audit_findings(raw_findings)
+
+    if args.filtered_defaults:
+        filtered_spec = _filter_openapi_spec(
+            spec,
+            _prefixed_paths(DEFAULT_ALLOWED_PATHS),
+            delete_allowed_paths=_prefixed_paths(DEFAULT_DELETE_ALLOWED_PATHS),
+        )
+        filtered_findings = audit_openapi_spec(filtered_spec)
+        _print_findings("filtered-defaults", filtered_findings)
+        findings_exist = findings_exist or has_openapi_audit_findings(filtered_findings)
+    else:
+        filtered_spec = spec
+
+    if args.instantiate_server:
+        try:
+            _instantiate_server(spec if not args.filtered_defaults else filtered_spec)
+            print("\n[server-instantiation]\nok")
+        except Exception as exc:
+            print(f"\n[server-instantiation]\nfailed: {exc}")
+            return 1
+
+    return 1 if findings_exist else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rootly_mcp_server/data/swagger.json
+++ b/src/rootly_mcp_server/data/swagger.json
@@ -56184,7 +56184,10 @@
                             },
                             "urgency_ids": {
                               "type": "array",
-                              "description": "Alert urgency ids for which this escalation path should be used"
+                              "description": "Alert urgency ids for which this escalation path should be used",
+                              "items": {
+                                "type": "string"
+                              }
                             }
                           },
                           "required": [
@@ -56339,7 +56342,10 @@
                             },
                             "urgency_ids": {
                               "type": "array",
-                              "description": "Alert urgency ids for which this escalation path should be used"
+                              "description": "Alert urgency ids for which this escalation path should be used",
+                              "items": {
+                                "type": "string"
+                              }
                             }
                           },
                           "required": [

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -6,11 +6,14 @@ import json
 import logging
 import os
 import re
+from collections import Counter
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
 
 import requests
+
+from .utils import sanitize_parameter_name
 
 logger = logging.getLogger(__name__)
 
@@ -544,6 +547,129 @@ def _ensure_array_items(spec: Any) -> None:
     if isinstance(spec, list):
         for item in spec:
             _ensure_array_items(item)
+
+
+def _walk_openapi_tree(node: Any, visitor: Any, path: str = "") -> None:
+    """Walk an OpenAPI document and invoke a visitor with each node and its path."""
+    visitor(node, path)
+    if isinstance(node, dict):
+        for key, value in node.items():
+            child_path = f"{path}.{key}" if path else key
+            _walk_openapi_tree(value, visitor, child_path)
+        return
+    if isinstance(node, list):
+        for index, value in enumerate(node):
+            _walk_openapi_tree(value, visitor, f"{path}[{index}]")
+
+
+def collect_missing_array_items(spec: dict[str, Any]) -> list[str]:
+    """Collect array schema paths that do not define an items schema."""
+    missing: list[str] = []
+
+    def visitor(node: Any, path: str) -> None:
+        if isinstance(node, dict) and node.get("type") == "array" and "items" not in node:
+            missing.append(path or "<root>")
+
+    _walk_openapi_tree(spec, visitor)
+    return missing
+
+
+def collect_broken_internal_refs(spec: dict[str, Any]) -> list[dict[str, str]]:
+    """Collect broken internal $ref pointers in an OpenAPI document."""
+    broken: list[dict[str, str]] = []
+
+    def visitor(node: Any, path: str) -> None:
+        if not isinstance(node, dict):
+            return
+        ref = node.get("$ref")
+        if not isinstance(ref, str) or not ref.startswith("#/"):
+            return
+
+        current: Any = spec
+        for part in ref[2:].split("/"):
+            if not isinstance(current, dict) or part not in current:
+                broken.append({"path": path or "<root>", "ref": ref})
+                return
+            current = current[part]
+
+    _walk_openapi_tree(spec, visitor)
+    return broken
+
+
+def collect_duplicate_operation_ids(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collect duplicate OpenAPI operationIds."""
+    counts: Counter[str] = Counter()
+    for _path, path_item in spec.get("paths", {}).items():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            operation_id = operation.get("operationId")
+            if isinstance(operation_id, str):
+                counts[operation_id] += 1
+
+    return [
+        {"operationId": operation_id, "count": count}
+        for operation_id, count in sorted(counts.items())
+        if count > 1
+    ]
+
+
+def collect_sanitized_parameter_collisions(spec: dict[str, Any]) -> list[dict[str, str]]:
+    """Collect cases where distinct parameter names sanitize to the same MCP key."""
+    collisions: list[dict[str, str]] = []
+    for path, path_item in spec.get("paths", {}).items():
+        if not isinstance(path_item, dict):
+            continue
+        path_level_params = path_item.get("parameters", [])
+        for method, operation in path_item.items():
+            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            if not isinstance(operation, dict):
+                continue
+
+            seen: dict[str, str] = {}
+            parameters = list(path_level_params) + list(operation.get("parameters", []))
+            for param in parameters:
+                if not isinstance(param, dict):
+                    continue
+                name = param.get("name")
+                if not isinstance(name, str):
+                    continue
+                sanitized = sanitize_parameter_name(name)
+                previous = seen.get(sanitized)
+                if previous and previous != name:
+                    collisions.append(
+                        {
+                            "path": path,
+                            "method": method.upper(),
+                            "sanitized": sanitized,
+                            "first": previous,
+                            "second": name,
+                        }
+                    )
+                else:
+                    seen[sanitized] = name
+
+    return collisions
+
+
+def audit_openapi_spec(spec: dict[str, Any]) -> dict[str, list[Any]]:
+    """Audit an OpenAPI document for schema issues that break MCP tool generation."""
+    return {
+        "missing_array_items": collect_missing_array_items(spec),
+        "broken_internal_refs": collect_broken_internal_refs(spec),
+        "duplicate_operation_ids": collect_duplicate_operation_ids(spec),
+        "sanitized_parameter_collisions": collect_sanitized_parameter_collisions(spec),
+    }
+
+
+def has_openapi_audit_findings(findings: dict[str, list[Any]]) -> bool:
+    """Return True when any audit category contains findings."""
+    return any(findings.values())
 
 
 def _has_broken_references(schema_def: dict[str, Any]) -> bool:

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -527,7 +527,23 @@ def _filter_openapi_spec(
                                         f"Cleaned broken reference in {method.upper()} {path} response: {ref_path}"
                                     )
 
+    _ensure_array_items(filtered_spec)
+
     return filtered_spec
+
+
+def _ensure_array_items(spec: Any) -> None:
+    """Ensure all array schemas define an items schema to satisfy tool validation."""
+    if isinstance(spec, dict):
+        if spec.get("type") == "array" and "items" not in spec:
+            # OpenAPI allows arrays without items, but MCP tool schema validation does not.
+            spec["items"] = {}
+        for value in spec.values():
+            _ensure_array_items(value)
+        return
+    if isinstance(spec, list):
+        for item in spec:
+            _ensure_array_items(item)
 
 
 def _has_broken_references(schema_def: dict[str, Any]) -> bool:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -91,6 +91,31 @@ class TestServerCreation:
 
             assert server is not None
 
+    def test_swagger_arrays_define_items(self):
+        """Ensure bundled swagger defines items for all array schemas."""
+        swagger_path = os.path.join(
+            os.path.dirname(server_module.__file__), "data", "swagger.json"
+        )
+        with open(swagger_path, encoding="utf-8") as f:
+            spec = json.load(f)
+
+        missing: list[str] = []
+
+        def walk(node: Any, path: str = "") -> None:
+            if isinstance(node, dict):
+                if node.get("type") == "array" and "items" not in node:
+                    missing.append(path or "<root>")
+                for key, value in node.items():
+                    walk(value, f"{path}.{key}" if path else key)
+                return
+            if isinstance(node, list):
+                for idx, value in enumerate(node):
+                    walk(value, f"{path}[{idx}]")
+
+        walk(spec)
+
+        assert not missing, f"Array schemas missing items: {missing[:5]}"
+
     def test_create_server_with_custom_paths(self, mock_httpx_client):
         """Test server creation with custom allowed paths."""
         with patch("rootly_mcp_server.server._load_swagger_spec") as mock_load_spec:

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -34,6 +34,7 @@ from rootly_mcp_server.server import (
     _validate_bearer_auth_header,
     create_rootly_mcp_server,
 )
+from rootly_mcp_server.spec_transform import audit_openapi_spec, has_openapi_audit_findings
 
 
 @pytest.mark.unit
@@ -91,30 +92,47 @@ class TestServerCreation:
 
             assert server is not None
 
-    def test_swagger_arrays_define_items(self):
-        """Ensure bundled swagger defines items for all array schemas."""
+    def test_bundled_swagger_audit_passes(self):
+        """Ensure the bundled swagger passes the full schema audit."""
         swagger_path = os.path.join(
             os.path.dirname(server_module.__file__), "data", "swagger.json"
         )
         with open(swagger_path, encoding="utf-8") as f:
             spec = json.load(f)
 
-        missing: list[str] = []
+        findings = audit_openapi_spec(spec)
 
-        def walk(node: Any, path: str = "") -> None:
-            if isinstance(node, dict):
-                if node.get("type") == "array" and "items" not in node:
-                    missing.append(path or "<root>")
-                for key, value in node.items():
-                    walk(value, f"{path}.{key}" if path else key)
-                return
-            if isinstance(node, list):
-                for idx, value in enumerate(node):
-                    walk(value, f"{path}[{idx}]")
+        assert not has_openapi_audit_findings(findings), findings
 
-        walk(spec)
+    def test_filtered_bundled_swagger_audit_passes(self):
+        """Ensure the shipped MCP-filtered spec passes the full schema audit."""
+        swagger_path = os.path.join(
+            os.path.dirname(server_module.__file__), "data", "swagger.json"
+        )
+        with open(swagger_path, encoding="utf-8") as f:
+            spec = json.load(f)
 
-        assert not missing, f"Array schemas missing items: {missing[:5]}"
+        filtered_spec = _filter_openapi_spec(
+            spec,
+            [f"/v1{path}" if not path.startswith("/v1") else path for path in DEFAULT_ALLOWED_PATHS],
+            delete_allowed_paths=[
+                f"/v1{path}" if not path.startswith("/v1") else path
+                for path in DEFAULT_DELETE_ALLOWED_PATHS
+            ],
+        )
+        findings = audit_openapi_spec(filtered_spec)
+
+        assert not has_openapi_audit_findings(findings), findings
+
+    def test_create_server_with_bundled_swagger(self):
+        """Ensure FastMCP can instantiate from the bundled swagger without schema errors."""
+        swagger_path = os.path.join(
+            os.path.dirname(server_module.__file__), "data", "swagger.json"
+        )
+
+        server = create_rootly_mcp_server(swagger_path=swagger_path, hosted=False)
+
+        assert server is not None
 
     def test_create_server_with_custom_paths(self, mock_httpx_client):
         """Test server creation with custom allowed paths."""


### PR DESCRIPTION
## Summary\n- ensure array schemas always include an items schema to satisfy MCP tool validation\n- prevents createEscalationPath from failing when rules.urgency_ids lacks items in the upstream spec\n\n## Testing\n- pytest