### PR TITLE
[codex] Expose workflow task tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![PyPI version](https://badge.fury.io/py/rootly-mcp-server.svg)](https://pypi.org/project/rootly-mcp-server/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/rootly-mcp-server)](https://pypi.org/project/rootly-mcp-server/)
 [![Python Version](https://img.shields.io/pypi/pyversions/rootly-mcp-server.svg)](https://pypi.org/project/rootly-mcp-server/)
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=rootly&config=eyJ1cmwiOiJodHRwczovL21jcC5yb290bHkuY29tL21jcCIsImhlYWRlcnMiOnsiQXV0aG9yaXphdGlvbiI6IkJlYXJlciA8WU9VUl9ST09UTFlfQVBJX1RPS0VOPiJ9fQo=)
 
 An MCP server for the [Rootly API](https://docs.rootly.com/api-reference/overview) for Cursor, Windsurf, Claude, and other MCP clients.
 
@@ -367,7 +366,7 @@ docker run -p 8000:8000 \
 
 ## Supported Tools
 
-The default server configuration exposes **105 tools**.
+The default server configuration exposes **109 tools**.
 
 ### Custom Agentic Tools
 
@@ -415,6 +414,7 @@ createService
 createSeverity
 createTeam
 createWorkflow
+createWorkflowTask
 deleteEscalationLevel
 deleteEscalationPath
 deleteEscalationPolicy
@@ -440,6 +440,7 @@ getSeverity
 getTeam
 getUser
 getWorkflow
+getWorkflowTask
 listAlerts
 listEnvironments
 listEscalationLevels
@@ -464,6 +465,7 @@ listShifts
 listTeams
 listUsers
 listWorkflows
+listWorkflowTasks
 updateAlert
 updateEnvironment
 updateEscalationLevel
@@ -482,6 +484,7 @@ updateSeverity
 updateTeam
 updateUser
 updateWorkflow
+updateWorkflowTask
 ```
 
 Delete operations are intentionally scoped to screenshot coverage paths:

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -67,6 +67,8 @@ DEFAULT_ALLOWED_PATHS = [
     # Workflows
     "/workflows",
     "/workflows/{workflow_id}",
+    "/workflows/{workflow_id}/workflow_tasks",
+    "/workflow_tasks/{id}",
     # Workflow runs
     "/workflow_runs",
     "/workflow_runs/{workflow_run_id}",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -215,6 +215,19 @@ class TestBundledIncidentFormFieldSelectionTools:
 
         assert "deleteIncidentFormFieldSelection" not in tool_names
 
+    async def test_workflow_task_tools_are_available_without_delete(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "createWorkflowTask" in tool_names
+        assert "listWorkflowTasks" in tool_names
+        assert "getWorkflowTask" in tool_names
+        assert "updateWorkflowTask" in tool_names
+
+        assert "deleteWorkflowTask" not in tool_names
+
 
 @pytest.mark.unit
 class TestAuthenticatedHTTPXClient:

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -11,6 +11,8 @@ class TestServerDefaultsModule:
         assert "/incidents/{incident_id}/alerts" in DEFAULT_ALLOWED_PATHS
         assert "/incidents/{incident_id}/form_field_selections" in DEFAULT_ALLOWED_PATHS
         assert "/incident_form_field_selections/{id}" in DEFAULT_ALLOWED_PATHS
+        assert "/workflows/{workflow_id}/workflow_tasks" in DEFAULT_ALLOWED_PATHS
+        assert "/workflow_tasks/{id}" in DEFAULT_ALLOWED_PATHS
         assert "/shifts" in DEFAULT_ALLOWED_PATHS
         assert "/on_call_roles" in DEFAULT_ALLOWED_PATHS
 


### PR DESCRIPTION
## Summary

Exposes Rootly workflow task interactions through the default MCP tool surface so users can create, list, retrieve, and update workflow tasks/actions without falling back to the raw Rootly API.

## Why

Customers can already access base workflow resources through the MCP server, but workflow actions/tasks live under separate workflow task endpoints. The bundled Swagger already includes these endpoints; they were missing because the default allowed path list did not include them.

## Changes

- Adds workflow task paths to the default allowed OpenAPI paths: /workflows/{workflow_id}/workflow_tasks and /workflow_tasks/{id}
- Exposes createWorkflowTask, listWorkflowTasks, getWorkflowTask, and updateWorkflowTask
- Keeps deleteWorkflowTask hidden because delete operations remain scoped by DEFAULT_DELETE_ALLOWED_PATHS
- Adds generated-tool regression coverage
- Updates README supported-tool count and list
- Removes the broken Cursor install badge

## Validation

- uv run ruff check tests/unit/test_server.py tests/unit/test_server_defaults_module.py src/rootly_mcp_server/server_defaults.py
- uv run pytest tests/unit/test_server.py tests/unit/test_server_defaults_module.py -q
- Commit hook full unit suite: 360 passed
- Manual tool-generation check: 109 tools; workflow task create/list/get/update present; delete absent