### PR TITLE
[codex] Add scoped createIncident tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Rootly MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.19] - Pending release
+
+### Features
+
+- **Scoped Incident Creation Tool**: Added a custom `createIncident` tool so agents can create incidents directly from MCP without exposing the full raw `/incidents` OpenAPI surface
+
+### Documentation
+
+- **Custom Tool List Updated**: Added `createIncident` to the README custom tool section with its scoped workflow-oriented behavior
+
 ## [2.2.18] - Released 2026-04-15
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ The default server configuration exposes **110 tools**.
 - `check_oncall_health_risk`
 - `check_responder_availability`
 - `collect_incidents`
+- `createIncident` - create a new incident with a scoped set of fields for agent workflows
 - `create_override_recommendation`
 - `find_related_incidents`
 - `getIncident` - retrieve a single incident for direct verification, including PIR-related fields

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -29,6 +29,14 @@ def _split_csv_values(value: str) -> list[str]:
     return [part.strip() for part in value.split(",") if part.strip()]
 
 
+def _normalize_optional_text(value: str | None) -> str | None:
+    """Normalize optional text inputs by trimming whitespace and empty values."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
 def _extract_incident_severity(severity_value: Any) -> str | None:
     """Normalize severity values from Rootly API responses into a compact string."""
     if severity_value is None:
@@ -637,6 +645,100 @@ def register_incident_tools(
                 JsonDict,
                 mcp_error.tool_error(
                     f"Failed to retrieve incident: {error_message}",
+                    error_type,
+                ),
+            )
+
+    @mcp.tool(name="createIncident")
+    async def create_incident(
+        title: Annotated[
+            str | None,
+            Field(description="Incident title. If omitted, Rootly may autogenerate one."),
+        ] = None,
+        summary: Annotated[
+            str | None,
+            Field(description="Incident summary or short description."),
+        ] = None,
+        severity_id: Annotated[
+            str | None,
+            Field(description="Optional severity ID to attach to the incident."),
+        ] = None,
+        service_ids: Annotated[
+            str | None,
+            Field(description="Comma-separated service IDs to attach to the incident."),
+        ] = None,
+        team_ids: Annotated[
+            str | None,
+            Field(description="Comma-separated team IDs to attach to the incident."),
+        ] = None,
+        environment_ids: Annotated[
+            str | None,
+            Field(description="Comma-separated environment IDs to attach to the incident."),
+        ] = None,
+        incident_type_ids: Annotated[
+            str | None,
+            Field(description="Comma-separated incident type IDs to attach to the incident."),
+        ] = None,
+    ) -> JsonDict:
+        """Create an incident with a scoped set of fields for agent-driven workflows."""
+        normalized_title = _normalize_optional_text(title)
+        normalized_summary = _normalize_optional_text(summary)
+
+        if normalized_title is None and normalized_summary is None:
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    "Must provide at least one of title or summary",
+                    "validation_error",
+                ),
+            )
+
+        attributes: dict[str, Any] = {}
+
+        if normalized_title is not None:
+            attributes["title"] = normalized_title
+        if normalized_summary is not None:
+            attributes["summary"] = normalized_summary
+
+        normalized_severity_id = _normalize_optional_text(severity_id)
+        if normalized_severity_id is not None:
+            attributes["severity_id"] = normalized_severity_id
+
+        csv_attribute_map = (
+            ("service_ids", service_ids),
+            ("group_ids", team_ids),
+            ("environment_ids", environment_ids),
+            ("incident_type_ids", incident_type_ids),
+        )
+        for attribute_name, raw_value in csv_attribute_map:
+            if raw_value is None:
+                continue
+            values = _split_csv_values(raw_value)
+            if values:
+                attributes[attribute_name] = values
+
+        payload = {
+            "data": {
+                "type": "incidents",
+                "attributes": attributes,
+            }
+        }
+
+        try:
+            response = await make_authenticated_request("POST", "/v1/incidents", json=payload)
+            response.raise_for_status()
+
+            response_data = response.json()
+            if isinstance(response_data.get("data"), dict):
+                stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
+                response_data["data"] = stripped["data"][0]
+            return cast(JsonDict, response_data)
+        except Exception as e:
+            error_type, error_message = mcp_error.categorize_error(e)
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to create incident: {error_message}",
                     error_type,
                 ),
             )

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -143,8 +143,73 @@ class TestScopedIncidentUpdateTool:
     async def test_update_incident_tool_is_registered_with_customer_facing_name(self):
         tools, _ = self._register_tools()
 
+        assert "createIncident" in tools
         assert "updateIncident" in tools
         assert "getIncident" in tools
+
+    @pytest.mark.asyncio
+    async def test_create_incident_sends_only_allowed_fields(self):
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {
+                "id": "inc-123",
+                "type": "incidents",
+                "attributes": {
+                    "title": "Database latency spike",
+                    "summary": "Primary API requests timing out",
+                    "severity_id": "sev-1",
+                    "service_ids": ["svc-1", "svc-2"],
+                    "group_ids": ["team-1", "team-2"],
+                    "environment_ids": ["env-1"],
+                    "incident_type_ids": ["type-1"],
+                },
+            }
+        }
+        request.return_value = response
+
+        result = await tools["createIncident"](
+            title="  Database latency spike  ",
+            summary=" Primary API requests timing out ",
+            severity_id=" sev-1 ",
+            service_ids="svc-1, svc-2",
+            team_ids="team-1, team-2",
+            environment_ids="env-1",
+            incident_type_ids="type-1",
+        )
+
+        request.assert_awaited_once_with(
+            "POST",
+            "/v1/incidents",
+            json={
+                "data": {
+                    "type": "incidents",
+                    "attributes": {
+                        "title": "Database latency spike",
+                        "summary": "Primary API requests timing out",
+                        "severity_id": "sev-1",
+                        "service_ids": ["svc-1", "svc-2"],
+                        "group_ids": ["team-1", "team-2"],
+                        "environment_ids": ["env-1"],
+                        "incident_type_ids": ["type-1"],
+                    },
+                }
+            },
+        )
+        assert result["data"]["id"] == "inc-123"
+        assert result["data"]["attributes"]["title"] == "Database latency spike"
+
+    @pytest.mark.asyncio
+    async def test_create_incident_requires_title_or_summary(self):
+        tools, request = self._register_tools()
+
+        result = await tools["createIncident"](title="   ", summary=None)
+
+        request.assert_not_called()
+        assert result["error"] is True
+        assert result["error_type"] == "validation_error"
+        assert "Must provide at least one of title or summary" in result["message"]
 
     @pytest.mark.asyncio
     async def test_get_incident_fetches_single_incident(self):


### PR DESCRIPTION
## Summary

Adds a scoped custom `createIncident` MCP tool so users can create incidents directly from the Rootly MCP server without widening the raw OpenAPI `/incidents` surface.

## Why

The Rootly API and bundled Swagger already support `createIncident`, but it was missing from the MCP tool list. We already expose scoped custom incident tools like `getIncident` and `updateIncident`; this follows the same pattern instead of allowing the full `/incidents` OpenAPI path, which would also introduce broader incident operations and overlap awkwardly with the existing custom incident tooling.

## Changes

- Adds a custom `createIncident` tool in `tools/incidents.py`
- Limits the allowed input fields to:
  - `title`
  - `summary`
  - `severity_id`
  - `service_ids`
  - `team_ids` (mapped to `group_ids`)
  - `environment_ids`
  - `incident_type_ids`
- Requires at least one of `title` or `summary`
- Normalizes whitespace and comma-separated ID inputs
- Returns the same stripped incident response shape used by the other custom incident tools
- Updates the README custom tool list
- Adds focused unit coverage for registration, validation, and request payload shaping

## Why this approach

This keeps incident creation in the MCP surface while avoiding a broader default allowlist change for `/incidents`. It is a narrower and safer product decision than exposing the full raw create/list/update/delete incident path family through OpenAPI.

## Validation

- `uv run ruff check src/rootly_mcp_server/tools/incidents.py tests/unit/test_tools.py`
- `uv run pytest tests/unit/test_tools.py -q`
- Manual tool-list check: `createIncident`, `getIncident`, and `updateIncident` all present; total tool count `110`
- Commit hook full unit suite: `362 passed`

## User impact

Users can now ask their agent to create a Rootly incident directly, with a limited and agent-friendly parameter set, instead of falling back to the raw API.
