### PR TITLE
feat: gate write tools behind explicit opt-in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
     open-pull-requests-limit: 20
     cooldown:
       default-days: 3
-      semver-major-days: 7
     groups:
       minor-and-patch:
         applies-to: version-updates
@@ -42,7 +41,6 @@ updates:
     open-pull-requests-limit: 20
     cooldown:
       default-days: 3
-      semver-major-days: 7
     groups:
       minor-and-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,11 @@
 version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 3
-    groups:
-      actions:
-        patterns:
-          - "*"
 
+updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     cooldown:
       default-days: 3
       semver-major-days: 7
@@ -25,10 +15,39 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20
     cooldown:
       default-days: 3
+      semver-major-days: 7
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,4 +32,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
-      semver-major-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -90,10 +90,10 @@ jobs:
     if: ${{ github.repository == 'Rootly-AI-Labs/rootly-mcp-server' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -135,10 +135,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -161,10 +161,10 @@ jobs:
     needs: [quality, test, security]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -175,7 +175,7 @@ jobs:
         run: uv build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/.github/workflows/openapi-audit.yml
+++ b/.github/workflows/openapi-audit.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -58,10 +58,10 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Rootly MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.20] - Released 2026-04-21
+
+### Security
+
+- **Critical Security Updates**: Upgraded vulnerable dependencies to address 3 security advisories
+- **authlib**: Updated from `1.6.9` to `1.7.0` to fix CSRF protection vulnerability (GHSA-jj8c-mmj3-mmgv)
+- **python-dotenv**: Updated from `1.1.0` to `1.2.2` to fix symlink attack vulnerability (GHSA-m8f7-34r5-grfg) 
+- **python-multipart**: Updated from `0.0.22` to `0.0.26` to fix denial of service vulnerability (CVE-2026-40347)
+- **Dependabot Configuration**: Fixed unsupported `semver-major-days` property for docker and github-actions ecosystems
+
+### Dependencies
+
+- **joserfc**: Added `1.6.4` as new dependency (required by updated authlib)
+- **Security Scanning**: All known vulnerabilities resolved as confirmed by pip-audit
+
 ## [2.2.19] - Released 2026-04-17
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -312,6 +312,31 @@ Hosted/remote deployments keep the existing write surface by default for backwar
 
 To expose only a specific subset of MCP tools on a self-hosted deployment, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names, for example `list_incidents,getIncident,get_server_version`.
 
+Smoke-test a self-hosted allowlist:
+
+```bash
+ROOTLY_API_TOKEN=<YOUR_ROOTLY_API_TOKEN> \
+ROOTLY_MCP_ENABLED_TOOLS=list_incidents,getIncident,get_server_version \
+uv run python -m rootly_mcp_server --transport streamable-http --log-level ERROR
+```
+
+Then connect an MCP client to `http://127.0.0.1:8000/mcp` and verify `tools/list` returns only:
+
+```text
+get_server_version
+getIncident
+list_incidents
+```
+
+To include specific write tools for self-hosted testing, add both the write flag and the allowlist:
+
+```bash
+ROOTLY_API_TOKEN=<YOUR_ROOTLY_API_TOKEN> \
+ROOTLY_MCP_ENABLE_WRITE_TOOLS=true \
+ROOTLY_MCP_ENABLED_TOOLS=createIncident,createWorkflowTask,listTeams \
+uv run python -m rootly_mcp_server --transport streamable-http --log-level ERROR
+```
+
 Example Docker run (Streamable HTTP):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ Choose one transport per server process:
 
 By default, the self-hosted server exposes read tools only. To enable the curated non-destructive write surface, start the server with `--enable-write-tools` or set `ROOTLY_MCP_ENABLE_WRITE_TOOLS=true`.
 
+Hosted/remote deployments keep the existing write surface by default for backward compatibility.
+
 Example Docker run (Streamable HTTP):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ By default, the self-hosted server exposes read tools only. To enable the curate
 
 Hosted/remote deployments keep the existing write surface by default for backward compatibility.
 
+To expose only a specific subset of MCP tools on a self-hosted deployment, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names, for example `list_incidents,getIncident,get_server_version`.
+
 Example Docker run (Streamable HTTP):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ A **Global API Key** is recommended for organization-wide queries and for action
         "rootly-mcp-server"
       ],
       "env": {
-        "ROOTLY_API_TOKEN": "<YOUR_ROOTLY_API_TOKEN>"
+        "ROOTLY_API_TOKEN": "<YOUR_ROOTLY_API_TOKEN>",
+        "ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"
       }
     }
   }
@@ -305,12 +306,15 @@ Choose one transport per server process:
 - **SSE** endpoint path: `/sse`
 - **Code Mode (experimental)** endpoint path: `/mcp-codemode` in hosted dual-transport mode
 
+By default, the self-hosted server exposes read tools only. To enable the curated non-destructive write surface, start the server with `--enable-write-tools` or set `ROOTLY_MCP_ENABLE_WRITE_TOOLS=true`.
+
 Example Docker run (Streamable HTTP):
 
 ```bash
 docker run -p 8000:8000 \
   -e ROOTLY_TRANSPORT=streamable-http \
   -e ROOTLY_API_TOKEN=<YOUR_ROOTLY_API_TOKEN> \
+  -e ROOTLY_MCP_ENABLE_WRITE_TOOLS=true \
   rootly-mcp-server
 ```
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,15 @@ Hosted/remote deployments keep the existing write surface by default for backwar
 
 To expose only a specific subset of MCP tools on a self-hosted deployment, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names, for example `list_incidents,getIncident,get_server_version`.
 
+To discover the exact tool names available under your current self-hosted configuration, run:
+
+```bash
+ROOTLY_API_TOKEN=<YOUR_ROOTLY_API_TOKEN> \
+uv run python -m rootly_mcp_server --list-tools
+```
+
+This prints the effective MCP tool names after applying your current settings, including `ROOTLY_MCP_ENABLE_WRITE_TOOLS` and `ROOTLY_MCP_ENABLED_TOOLS`.
+
 Smoke-test a self-hosted allowlist:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rootly-mcp-server"
-version = "2.2.19"
+version = "2.2.20"
 description = "Secure Model Context Protocol server for Rootly APIs with AI SRE capabilities, comprehensive error handling, and input validation"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -37,7 +37,9 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp[code-mode]==3.2.0",  # Pin to patched version with Code Mode support
-    "authlib>=1.6.9",  # Override vulnerable transitive authlib from fastmcp
+    "authlib>=1.6.11",  # Override vulnerable transitive authlib (GHSA-jj8c-mmj3-mmgv)
+    "python-dotenv>=1.2.2",  # Override vulnerable transitive python-dotenv (GHSA-m8f7-34r5-grfg)
+    "python-multipart>=0.0.26",  # Override vulnerable transitive python-multipart (CVE-2026-40347)
     "cryptography>=46.0.7",  # Override vulnerable transitive cryptography
     "Pygments>=2.20.0",  # Override vulnerable transitive Pygments
     "requests==2.33.1", # Pin to patched version

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -189,7 +189,7 @@ def get_server():
     hosted = os.getenv("ROOTLY_HOSTED", "false").lower() in ("true", "1", "yes")
     base_url = os.getenv("ROOTLY_BASE_URL")
     transport = normalize_transport_or_default(os.getenv("ROOTLY_TRANSPORT", "stdio"))
-    enable_write_tools = write_tools_enabled_from_env()
+    enable_write_tools = write_tools_enabled_from_env(default=hosted)
 
     # Parse allowed paths from environment variable
     allowed_paths = None
@@ -381,7 +381,9 @@ def main():
         # argparse already normalizes/validates --transport via type=normalize_transport
         normalized_transport = args.transport
         code_mode_enabled = args.enable_code_mode or code_mode_enabled_from_env(default=True)
-        enable_write_tools = args.enable_write_tools or write_tools_enabled_from_env()
+        enable_write_tools = args.enable_write_tools or write_tools_enabled_from_env(
+            default=hosted_mode
+        )
         code_mode_path = (
             normalize_code_mode_path(args.code_mode_path)
             if args.code_mode_path

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -22,6 +22,7 @@ from .code_mode import (
 from .exceptions import RootlyConfigurationError, RootlyMCPError
 from .security import validate_api_token
 from .server import create_rootly_mcp_server, get_hosted_auth_middleware
+from .server_defaults import write_tools_enabled_from_env
 
 TransportName = Literal["stdio", "sse", "streamable-http", "both"]
 TRANSPORT_ALIASES: dict[str, TransportName] = {
@@ -114,6 +115,11 @@ def parse_args():
         help="Expose a separate hosted Code Mode endpoint (HTTP only)",
     )
     parser.add_argument(
+        "--enable-write-tools",
+        action="store_true",
+        help="Expose curated non-destructive write tools in addition to read tools",
+    )
+    parser.add_argument(
         "--code-mode-path",
         type=str,
         help="Hosted path for the Code Mode endpoint. Default: /mcp-codemode",
@@ -183,6 +189,7 @@ def get_server():
     hosted = os.getenv("ROOTLY_HOSTED", "false").lower() in ("true", "1", "yes")
     base_url = os.getenv("ROOTLY_BASE_URL")
     transport = normalize_transport_or_default(os.getenv("ROOTLY_TRANSPORT", "stdio"))
+    enable_write_tools = write_tools_enabled_from_env()
 
     # Parse allowed paths from environment variable
     allowed_paths = None
@@ -198,6 +205,7 @@ def get_server():
         hosted=hosted,
         base_url=base_url,
         transport=transport,
+        enable_write_tools=enable_write_tools,
     )
 
 
@@ -373,6 +381,7 @@ def main():
         # argparse already normalizes/validates --transport via type=normalize_transport
         normalized_transport = args.transport
         code_mode_enabled = args.enable_code_mode or code_mode_enabled_from_env(default=True)
+        enable_write_tools = args.enable_write_tools or write_tools_enabled_from_env()
         code_mode_path = (
             normalize_code_mode_path(args.code_mode_path)
             if args.code_mode_path
@@ -385,6 +394,7 @@ def main():
             hosted=hosted_mode,
             base_url=args.base_url,
             transport=normalized_transport,
+            enable_write_tools=enable_write_tools,
         )
 
         code_mode_server = None
@@ -403,6 +413,7 @@ def main():
                     allowed_paths=allowed_paths,
                     hosted=hosted_mode,
                     base_url=args.base_url,
+                    enable_write_tools=enable_write_tools,
                 )
                 logger.info("Code Mode enabled at path: %s", code_mode_path)
 

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -22,7 +22,7 @@ from .code_mode import (
 from .exceptions import RootlyConfigurationError, RootlyMCPError
 from .security import validate_api_token
 from .server import create_rootly_mcp_server, get_hosted_auth_middleware
-from .server_defaults import write_tools_enabled_from_env
+from .server_defaults import enabled_tools_from_env, write_tools_enabled_from_env
 
 TransportName = Literal["stdio", "sse", "streamable-http", "both"]
 TRANSPORT_ALIASES: dict[str, TransportName] = {
@@ -120,6 +120,11 @@ def parse_args():
         help="Expose curated non-destructive write tools in addition to read tools",
     )
     parser.add_argument(
+        "--enabled-tools",
+        type=str,
+        help="Comma-separated allowlist of exact MCP tool names to expose",
+    )
+    parser.add_argument(
         "--code-mode-path",
         type=str,
         help="Hosted path for the Code Mode endpoint. Default: /mcp-codemode",
@@ -190,6 +195,7 @@ def get_server():
     base_url = os.getenv("ROOTLY_BASE_URL")
     transport = normalize_transport_or_default(os.getenv("ROOTLY_TRANSPORT", "stdio"))
     enable_write_tools = write_tools_enabled_from_env(default=hosted)
+    enabled_tools = enabled_tools_from_env()
 
     # Parse allowed paths from environment variable
     allowed_paths = None
@@ -206,6 +212,7 @@ def get_server():
         base_url=base_url,
         transport=transport,
         enable_write_tools=enable_write_tools,
+        enabled_tools=enabled_tools,
     )
 
 
@@ -376,6 +383,11 @@ def main():
         allowed_paths = None
         if args.allowed_paths:
             allowed_paths = [path.strip() for path in args.allowed_paths.split(",")]
+        enabled_tools = (
+            {tool.strip() for tool in args.enabled_tools.split(",") if tool.strip()}
+            if args.enabled_tools
+            else enabled_tools_from_env()
+        )
 
         logger.info(f"Initializing server with name: {args.name}")
         # argparse already normalizes/validates --transport via type=normalize_transport
@@ -397,6 +409,7 @@ def main():
             base_url=args.base_url,
             transport=normalized_transport,
             enable_write_tools=enable_write_tools,
+            enabled_tools=enabled_tools,
         )
 
         code_mode_server = None
@@ -416,6 +429,7 @@ def main():
                     hosted=hosted_mode,
                     base_url=args.base_url,
                     enable_write_tools=enable_write_tools,
+                    enabled_tools=enabled_tools,
                 )
                 logger.info("Code Mode enabled at path: %s", code_mode_path)
 

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -6,6 +6,7 @@ This module provides the main entry point for the Rootly MCP Server.
 """
 
 import argparse
+import asyncio
 import logging
 import os
 import sys
@@ -125,6 +126,11 @@ def parse_args():
         help="Comma-separated allowlist of exact MCP tool names to expose",
     )
     parser.add_argument(
+        "--list-tools",
+        action="store_true",
+        help="Print the exact MCP tool names exposed by the current configuration, then exit",
+    )
+    parser.add_argument(
         "--code-mode-path",
         type=str,
         help="Hosted path for the Code Mode endpoint. Default: /mcp-codemode",
@@ -214,6 +220,12 @@ def get_server():
         enable_write_tools=enable_write_tools,
         enabled_tools=enabled_tools,
     )
+
+
+async def _get_sorted_tool_names(server) -> list[str]:
+    """Return the effective MCP tool names for the provided server."""
+    tools = await server.list_tools()
+    return sorted(tool.name for tool in tools)
 
 
 # Create the server instance for FastMCP CLI (follows quickstart pattern).
@@ -411,6 +423,11 @@ def main():
             enable_write_tools=enable_write_tools,
             enabled_tools=enabled_tools,
         )
+
+        if args.list_tools:
+            for tool_name in asyncio.run(_get_sorted_tool_names(server)):
+                print(tool_name)
+            return
 
         code_mode_server = None
         if code_mode_enabled:

--- a/src/rootly_mcp_server/audit.py
+++ b/src/rootly_mcp_server/audit.py
@@ -1,0 +1,98 @@
+"""Security audit logging for Rootly MCP Server."""
+
+import json
+import logging
+import time
+from contextvars import ContextVar
+from typing import Any
+
+# Context variables for tracking session info
+current_session: ContextVar[str | None] = ContextVar('current_session', default=None)
+current_user: ContextVar[str | None] = ContextVar('current_user', default=None)
+
+
+class AuditLogger:
+    """Structured audit logger for security-relevant events."""
+
+    def __init__(self, logger_name: str = "rootly_mcp_server.audit"):
+        self.logger = logging.getLogger(logger_name)
+        self.logger.setLevel(logging.INFO)
+
+        # JSON formatter for structured logs
+        formatter = logging.Formatter(
+            '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "audit_event": %(message)s}'
+        )
+
+        # Add console handler if none exists
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+    def log_permission_change(self, action: str, details: dict[str, Any]):
+        """Log permission configuration changes."""
+        event = {
+            "event_type": "permission_change",
+            "action": action,
+            "session_id": current_session.get(),
+            "user_id": current_user.get(),
+            "timestamp": time.time(),
+            **details
+        }
+        self.logger.info(json.dumps(event))
+
+    def log_tool_validation(self, enabled_tools: set[str], valid_tools: set[str], invalid_tools: list[str]):
+        """Log tool name validation results."""
+        event = {
+            "event_type": "tool_validation",
+            "requested_tools_count": len(enabled_tools),
+            "valid_tools_count": len(valid_tools),
+            "invalid_tools_count": len(invalid_tools),
+            "invalid_tools": invalid_tools,
+            "session_id": current_session.get(),
+            "timestamp": time.time()
+        }
+        self.logger.info(json.dumps(event))
+
+    def log_server_start(self, config: dict[str, Any]):
+        """Log server startup with security-relevant configuration."""
+        event = {
+            "event_type": "server_start",
+            "write_tools_enabled": config.get("enable_write_tools", False),
+            "tool_count": config.get("tool_count", 0),
+            "hosted_mode": config.get("hosted", False),
+            "allowlist_enabled": bool(config.get("enabled_tools")),
+            "transport": config.get("transport", "unknown"),
+            "timestamp": time.time()
+        }
+        self.logger.info(json.dumps(event))
+
+    def log_tool_access_attempt(self, tool_name: str, method: str, success: bool, details: dict[str, Any] | None = None):
+        """Log individual tool access attempts."""
+        event = {
+            "event_type": "tool_access",
+            "tool_name": tool_name,
+            "http_method": method,
+            "success": success,
+            "session_id": current_session.get(),
+            "user_id": current_user.get(),
+            "timestamp": time.time(),
+            **(details or {})
+        }
+        self.logger.info(json.dumps(event))
+
+    def log_configuration_error(self, error_type: str, message: str, details: dict[str, Any] | None = None):
+        """Log configuration validation errors."""
+        event = {
+            "event_type": "configuration_error",
+            "error_type": error_type,
+            "message": message,
+            "session_id": current_session.get(),
+            "timestamp": time.time(),
+            **(details or {})
+        }
+        self.logger.warning(json.dumps(event))
+
+
+# Global audit logger instance
+audit = AuditLogger()

--- a/src/rootly_mcp_server/audit.py
+++ b/src/rootly_mcp_server/audit.py
@@ -7,8 +7,8 @@ from contextvars import ContextVar
 from typing import Any
 
 # Context variables for tracking session info
-current_session: ContextVar[str | None] = ContextVar('current_session', default=None)
-current_user: ContextVar[str | None] = ContextVar('current_user', default=None)
+current_session: ContextVar[str | None] = ContextVar("current_session", default=None)
+current_user: ContextVar[str | None] = ContextVar("current_user", default=None)
 
 
 class AuditLogger:
@@ -37,11 +37,13 @@ class AuditLogger:
             "session_id": current_session.get(),
             "user_id": current_user.get(),
             "timestamp": time.time(),
-            **details
+            **details,
         }
         self.logger.info(json.dumps(event))
 
-    def log_tool_validation(self, enabled_tools: set[str], valid_tools: set[str], invalid_tools: list[str]):
+    def log_tool_validation(
+        self, enabled_tools: set[str], valid_tools: set[str], invalid_tools: list[str]
+    ):
         """Log tool name validation results."""
         event = {
             "event_type": "tool_validation",
@@ -50,7 +52,7 @@ class AuditLogger:
             "invalid_tools_count": len(invalid_tools),
             "invalid_tools": invalid_tools,
             "session_id": current_session.get(),
-            "timestamp": time.time()
+            "timestamp": time.time(),
         }
         self.logger.info(json.dumps(event))
 
@@ -63,11 +65,13 @@ class AuditLogger:
             "hosted_mode": config.get("hosted", False),
             "allowlist_enabled": bool(config.get("enabled_tools")),
             "transport": config.get("transport", "unknown"),
-            "timestamp": time.time()
+            "timestamp": time.time(),
         }
         self.logger.info(json.dumps(event))
 
-    def log_tool_access_attempt(self, tool_name: str, method: str, success: bool, details: dict[str, Any] | None = None):
+    def log_tool_access_attempt(
+        self, tool_name: str, method: str, success: bool, details: dict[str, Any] | None = None
+    ):
         """Log individual tool access attempts."""
         event = {
             "event_type": "tool_access",
@@ -77,11 +81,13 @@ class AuditLogger:
             "session_id": current_session.get(),
             "user_id": current_user.get(),
             "timestamp": time.time(),
-            **(details or {})
+            **(details or {}),
         }
         self.logger.info(json.dumps(event))
 
-    def log_configuration_error(self, error_type: str, message: str, details: dict[str, Any] | None = None):
+    def log_configuration_error(
+        self, error_type: str, message: str, details: dict[str, Any] | None = None
+    ):
         """Log configuration validation errors."""
         event = {
             "event_type": "configuration_error",
@@ -89,7 +95,7 @@ class AuditLogger:
             "message": message,
             "session_id": current_session.get(),
             "timestamp": time.time(),
-            **(details or {})
+            **(details or {}),
         }
         self.logger.warning(json.dumps(event))
 

--- a/src/rootly_mcp_server/code_mode.py
+++ b/src/rootly_mcp_server/code_mode.py
@@ -280,6 +280,7 @@ def create_rootly_codemode_server(
     allowed_paths: list[str] | None = None,
     hosted: bool = False,
     base_url: str | None = None,
+    enable_write_tools: bool | None = None,
 ) -> FastMCP:
     """Create a Rootly MCP server instance wrapped with Code Mode."""
     mcp: FastMCP = create_rootly_mcp_server(
@@ -289,6 +290,7 @@ def create_rootly_codemode_server(
         hosted=hosted,
         base_url=base_url,
         transport="streamable-http",
+        enable_write_tools=enable_write_tools,
     )
     mcp.add_transform(build_code_mode_transform())
     return mcp

--- a/src/rootly_mcp_server/code_mode.py
+++ b/src/rootly_mcp_server/code_mode.py
@@ -281,6 +281,7 @@ def create_rootly_codemode_server(
     hosted: bool = False,
     base_url: str | None = None,
     enable_write_tools: bool | None = None,
+    enabled_tools: set[str] | None = None,
 ) -> FastMCP:
     """Create a Rootly MCP server instance wrapped with Code Mode."""
     mcp: FastMCP = create_rootly_mcp_server(
@@ -291,6 +292,7 @@ def create_rootly_codemode_server(
         base_url=base_url,
         transport="streamable-http",
         enable_write_tools=enable_write_tools,
+        enabled_tools=enabled_tools,
     )
     mcp.add_transform(build_code_mode_transform())
     return mcp

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -17,7 +17,7 @@ import fastmcp.server.middleware as fastmcp_middleware
 import mcp.types as mt
 from fastmcp import FastMCP
 
-from . import legacy_server, payload_stripping, server_defaults, spec_transform, transport
+from . import audit, legacy_server, payload_stripping, server_defaults, spec_transform, transport
 from .exceptions import RootlyAuthenticationError
 from .mcp_error import MCPError
 from .security import mask_sensitive_data, sanitize_error_message
@@ -431,6 +431,34 @@ def create_rootly_mcp_server(
     swagger_spec = _load_swagger_spec(swagger_path)
     logger.info(f"Loaded Swagger spec with {len(swagger_spec.get('paths', {}))} total paths")
 
+    # Validate enabled tools if provided
+    if enabled_tools:
+        valid_tools, invalid_tools = server_defaults.validate_tool_names(enabled_tools, swagger_spec.get("paths", {}))
+
+        if invalid_tools:
+            audit.audit.log_configuration_error("invalid_tool_names",
+                f"Invalid tool names in allowlist: {', '.join(invalid_tools)}",
+                {"invalid_tools": invalid_tools, "valid_tools": list(valid_tools)}
+            )
+            logger.warning(
+                "Invalid tool names in allowlist (will be ignored): %s. "
+                "Use --list-tools to see available options.",
+                ", ".join(sorted(invalid_tools))
+            )
+
+        if not valid_tools and enabled_tools:
+            error_msg = "No valid tools found in allowlist"
+            audit.audit.log_configuration_error("no_valid_tools", error_msg,
+                {"requested_tools": list(enabled_tools)}
+            )
+            raise ValueError(error_msg)
+
+        # Log validation results
+        audit.audit.log_tool_validation(enabled_tools, valid_tools, invalid_tools)
+
+        # Use only valid tools
+        enabled_tools = valid_tools if valid_tools else None
+
     # Filter the OpenAPI spec to only include allowed paths
     filtered_spec = _filter_openapi_spec(
         swagger_spec,
@@ -441,6 +469,25 @@ def create_rootly_mcp_server(
         enabled_operation_ids=enabled_tools,
     )
     logger.info(f"Filtered spec to {len(filtered_spec.get('paths', {}))} allowed paths")
+
+    # Log server configuration for audit trail
+    config_info = {
+        "enable_write_tools": enable_write_tools,
+        "tool_count": len(filtered_spec.get("paths", {})),
+        "hosted": hosted,
+        "enabled_tools": list(enabled_tools) if enabled_tools else None,
+        "transport": transport,
+        "server_name": name
+    }
+    audit.audit.log_server_start(config_info)
+
+    # Log permission changes
+    if enable_write_tools:
+        audit.audit.log_permission_change("write_tools_enabled", {
+            "reason": "explicit_configuration",
+            "write_paths_count": len(write_allowed_paths_v1),
+            "hosted_mode": hosted
+        })
 
     # Sanitize all parameter names in the filtered spec to be MCP-compliant
     parameter_mapping = sanitize_parameters_in_spec(filtered_spec)

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -378,6 +378,7 @@ def create_rootly_mcp_server(
     delete_allowed_paths: list[str] | None = None,
     enable_write_tools: bool | None = None,
     write_allowed_paths: list[str] | None = None,
+    enabled_tools: set[str] | None = None,
 ) -> FastMCP:
     """
     Create a Rootly MCP Server using FastMCP's OpenAPI integration.
@@ -395,6 +396,8 @@ def create_rootly_mcp_server(
             If None, uses ROOTLY_MCP_ENABLE_WRITE_TOOLS.
         write_allowed_paths: Path templates where POST/PUT/PATCH operations are exposed
             when write tools are enabled. If None, uses DEFAULT_WRITE_ALLOWED_PATHS.
+        enabled_tools: Optional allowlist of exact MCP tool names to expose.
+            If None, uses ROOTLY_MCP_ENABLED_TOOLS when set.
 
     Returns:
         A FastMCP server instance.
@@ -404,6 +407,8 @@ def create_rootly_mcp_server(
         allowed_paths = DEFAULT_ALLOWED_PATHS
     if enable_write_tools is None:
         enable_write_tools = server_defaults.write_tools_enabled_from_env(default=hosted)
+    if enabled_tools is None:
+        enabled_tools = server_defaults.enabled_tools_from_env()
     if delete_allowed_paths is None:
         delete_allowed_paths = []
     if write_allowed_paths is None:
@@ -433,6 +438,7 @@ def create_rootly_mcp_server(
         delete_allowed_paths=delete_allowed_paths_v1,
         write_allowed_paths=write_allowed_paths_v1,
         enable_write_tools=enable_write_tools,
+        enabled_operation_ids=enabled_tools,
     )
     logger.info(f"Filtered spec to {len(filtered_spec.get('paths', {}))} allowed paths")
 
@@ -596,6 +602,20 @@ def create_rootly_mcp_server(
         make_authenticated_request=make_authenticated_request,
         mcp_error=MCPError,
     )
+
+    if enabled_tools is not None:
+        component_names = [
+            component.name
+            for component_key, component in mcp._local_provider._components.items()  # noqa: SLF001
+            if component_key.startswith("tool:") and getattr(component, "name", None)
+        ]
+        for tool_name in component_names:
+            if tool_name not in enabled_tools:
+                mcp.local_provider.remove_tool(tool_name)
+        logger.info(
+            "Applied MCP tool allowlist: %s",
+            ", ".join(sorted(enabled_tools)),
+        )
 
     # In hosted HTTP modes, configure ASGI middleware for auth token capture.
     # Callers retrieve via get_hosted_auth_middleware() and pass to server.run(middleware=...).

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -403,7 +403,7 @@ def create_rootly_mcp_server(
     if allowed_paths is None:
         allowed_paths = DEFAULT_ALLOWED_PATHS
     if enable_write_tools is None:
-        enable_write_tools = server_defaults.write_tools_enabled_from_env()
+        enable_write_tools = server_defaults.write_tools_enabled_from_env(default=hosted)
     if delete_allowed_paths is None:
         delete_allowed_paths = []
     if write_allowed_paths is None:

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -66,6 +66,7 @@ strip_heavy_nested_data = payload_stripping.strip_heavy_nested_data
 _generate_recommendation = server_defaults._generate_recommendation
 DEFAULT_ALLOWED_PATHS = server_defaults.DEFAULT_ALLOWED_PATHS
 DEFAULT_DELETE_ALLOWED_PATHS = server_defaults.DEFAULT_DELETE_ALLOWED_PATHS
+DEFAULT_WRITE_ALLOWED_PATHS = server_defaults.DEFAULT_WRITE_ALLOWED_PATHS
 RootlyMCPServer = legacy_server.RootlyMCPServer
 
 
@@ -375,6 +376,8 @@ def create_rootly_mcp_server(
     base_url: str | None = None,
     transport: str = "stdio",
     delete_allowed_paths: list[str] | None = None,
+    enable_write_tools: bool | None = None,
+    write_allowed_paths: list[str] | None = None,
 ) -> FastMCP:
     """
     Create a Rootly MCP Server using FastMCP's OpenAPI integration.
@@ -384,10 +387,14 @@ def create_rootly_mcp_server(
         name: Name of the MCP server.
         allowed_paths: List of API paths to include. If None, includes default paths.
         delete_allowed_paths: Path templates where DELETE operations are exposed.
-            If None, uses DEFAULT_DELETE_ALLOWED_PATHS.
+            If None, destructive delete tools remain disabled by default.
         hosted: Whether the server is hosted (affects authentication).
         base_url: Base URL for Rootly API. If None, uses ROOTLY_BASE_URL env var or default.
         transport: Transport protocol (stdio, sse, or streamable-http).
+        enable_write_tools: Whether non-destructive write tools are exposed.
+            If None, uses ROOTLY_MCP_ENABLE_WRITE_TOOLS.
+        write_allowed_paths: Path templates where POST/PUT/PATCH operations are exposed
+            when write tools are enabled. If None, uses DEFAULT_WRITE_ALLOWED_PATHS.
 
     Returns:
         A FastMCP server instance.
@@ -395,8 +402,12 @@ def create_rootly_mcp_server(
     # Set default allowed paths if none provided
     if allowed_paths is None:
         allowed_paths = DEFAULT_ALLOWED_PATHS
+    if enable_write_tools is None:
+        enable_write_tools = server_defaults.write_tools_enabled_from_env()
     if delete_allowed_paths is None:
-        delete_allowed_paths = DEFAULT_DELETE_ALLOWED_PATHS
+        delete_allowed_paths = []
+    if write_allowed_paths is None:
+        write_allowed_paths = DEFAULT_WRITE_ALLOWED_PATHS if enable_write_tools else []
 
     # Add /v1 prefix to paths if not present
     allowed_paths_v1 = [
@@ -404,6 +415,9 @@ def create_rootly_mcp_server(
     ]
     delete_allowed_paths_v1 = [
         f"/v1{path}" if not path.startswith("/v1") else path for path in delete_allowed_paths
+    ]
+    write_allowed_paths_v1 = [
+        f"/v1{path}" if not path.startswith("/v1") else path for path in write_allowed_paths
     ]
 
     logger.info(f"Creating Rootly MCP Server with allowed paths: {allowed_paths_v1}")
@@ -417,6 +431,8 @@ def create_rootly_mcp_server(
         swagger_spec,
         allowed_paths_v1,
         delete_allowed_paths=delete_allowed_paths_v1,
+        write_allowed_paths=write_allowed_paths_v1,
+        enable_write_tools=enable_write_tools,
     )
     logger.info(f"Filtered spec to {len(filtered_spec.get('paths', {}))} allowed paths")
 
@@ -559,6 +575,7 @@ def create_rootly_mcp_server(
         strip_heavy_nested_data=strip_heavy_nested_data,
         mcp_error=MCPError,
         generate_recommendation=_generate_recommendation,
+        enable_write_tools=enable_write_tools,
     )
 
     register_oncall_tools(

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -433,23 +433,26 @@ def create_rootly_mcp_server(
 
     # Validate enabled tools if provided
     if enabled_tools:
-        valid_tools, invalid_tools = server_defaults.validate_tool_names(enabled_tools, swagger_spec.get("paths", {}))
+        valid_tools, invalid_tools = server_defaults.validate_tool_names(
+            enabled_tools, swagger_spec.get("paths", {})
+        )
 
         if invalid_tools:
-            audit.audit.log_configuration_error("invalid_tool_names",
+            audit.audit.log_configuration_error(
+                "invalid_tool_names",
                 f"Invalid tool names in allowlist: {', '.join(invalid_tools)}",
-                {"invalid_tools": invalid_tools, "valid_tools": list(valid_tools)}
+                {"invalid_tools": invalid_tools, "valid_tools": list(valid_tools)},
             )
             logger.warning(
                 "Invalid tool names in allowlist (will be ignored): %s. "
                 "Use --list-tools to see available options.",
-                ", ".join(sorted(invalid_tools))
+                ", ".join(sorted(invalid_tools)),
             )
 
         if not valid_tools and enabled_tools:
             error_msg = "No valid tools found in allowlist"
-            audit.audit.log_configuration_error("no_valid_tools", error_msg,
-                {"requested_tools": list(enabled_tools)}
+            audit.audit.log_configuration_error(
+                "no_valid_tools", error_msg, {"requested_tools": list(enabled_tools)}
             )
             raise ValueError(error_msg)
 
@@ -477,17 +480,20 @@ def create_rootly_mcp_server(
         "hosted": hosted,
         "enabled_tools": list(enabled_tools) if enabled_tools else None,
         "transport": transport,
-        "server_name": name
+        "server_name": name,
     }
     audit.audit.log_server_start(config_info)
 
     # Log permission changes
     if enable_write_tools:
-        audit.audit.log_permission_change("write_tools_enabled", {
-            "reason": "explicit_configuration",
-            "write_paths_count": len(write_allowed_paths_v1),
-            "hosted_mode": hosted
-        })
+        audit.audit.log_permission_change(
+            "write_tools_enabled",
+            {
+                "reason": "explicit_configuration",
+                "write_paths_count": len(write_allowed_paths_v1),
+                "hosted_mode": hosted,
+            },
+        )
 
     # Sanitize all parameter names in the filtered spec to be MCP-compliant
     parameter_mapping = sanitize_parameters_in_spec(filtered_spec)

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -8,10 +8,12 @@ import os
 # Set up logger
 logger = logging.getLogger(__name__)
 
+
 # Environment variable constants
 class EnvVars:
     """Centralized environment variable names for type safety and IDE support."""
-    API_TOKEN = "ROOTLY_API_TOKEN"
+
+    API_TOKEN = "ROOTLY_API_TOKEN"  # nosec B105 - Environment variable name, not password
     BASE_URL = "ROOTLY_BASE_URL"
     SERVER_NAME = "ROOTLY_SERVER_NAME"
     HOSTED = "ROOTLY_HOSTED"
@@ -77,7 +79,9 @@ def write_tools_enabled_from_env(default: bool = False) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
-def validate_tool_names(enabled_tools: set[str], available_operations: dict) -> tuple[set[str], list[str]]:
+def validate_tool_names(
+    enabled_tools: set[str], available_operations: dict
+) -> tuple[set[str], list[str]]:
     """
     Validate tool names against available OpenAPI operations.
 

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -2,7 +2,25 @@
 
 from __future__ import annotations
 
+import logging
 import os
+
+# Set up logger
+logger = logging.getLogger(__name__)
+
+# Environment variable constants
+class EnvVars:
+    """Centralized environment variable names for type safety and IDE support."""
+    API_TOKEN = "ROOTLY_API_TOKEN"
+    BASE_URL = "ROOTLY_BASE_URL"
+    SERVER_NAME = "ROOTLY_SERVER_NAME"
+    HOSTED = "ROOTLY_HOSTED"
+    ENABLE_WRITE_TOOLS = "ROOTLY_MCP_ENABLE_WRITE_TOOLS"
+    ENABLED_TOOLS = "ROOTLY_MCP_ENABLED_TOOLS"
+    TRANSPORT = "ROOTLY_TRANSPORT"
+    ALLOWED_PATHS = "ROOTLY_ALLOWED_PATHS"
+    SWAGGER_PATH = "ROOTLY_SWAGGER_PATH"
+    LOG_LEVEL = "ROOTLY_LOG_LEVEL"
 
 
 def _parse_csv_set(raw: str | None) -> set[str] | None:
@@ -53,15 +71,42 @@ def _generate_recommendation(solution_data: dict) -> str:
 
 def write_tools_enabled_from_env(default: bool = False) -> bool:
     """Return whether non-destructive write tools should be exposed."""
-    raw = os.getenv("ROOTLY_MCP_ENABLE_WRITE_TOOLS")
+    raw = os.getenv(EnvVars.ENABLE_WRITE_TOOLS)
     if raw is None:
         return default
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
+def validate_tool_names(enabled_tools: set[str], available_operations: dict) -> tuple[set[str], list[str]]:
+    """
+    Validate tool names against available OpenAPI operations.
+
+    Args:
+        enabled_tools: Set of tool names to validate
+        available_operations: OpenAPI paths dict from swagger spec
+
+    Returns:
+        tuple: (valid_tools, invalid_tools)
+    """
+    if not enabled_tools:
+        return set(), []
+
+    # Extract all available operation IDs from OpenAPI spec
+    available_tool_names = set()
+    for path_data in available_operations.values():
+        for method_data in path_data.values():
+            if isinstance(method_data, dict) and (operation_id := method_data.get("operationId")):
+                available_tool_names.add(operation_id)
+
+    valid_tools = enabled_tools & available_tool_names
+    invalid_tools = list(enabled_tools - available_tool_names)
+
+    return valid_tools, invalid_tools
+
+
 def enabled_tools_from_env() -> set[str] | None:
     """Return an optional explicit allowlist of MCP tool names to expose."""
-    return _parse_csv_set(os.getenv("ROOTLY_MCP_ENABLED_TOOLS"))
+    return _parse_csv_set(os.getenv(EnvVars.ENABLED_TOOLS))
 
 
 # Default allowed API paths

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import os
 
 
+def _parse_csv_set(raw: str | None) -> set[str] | None:
+    """Parse a comma-separated environment value into a normalized set."""
+    if raw is None:
+        return None
+    parsed = {item.strip() for item in raw.split(",") if item.strip()}
+    return parsed or None
+
+
 def _generate_recommendation(solution_data: dict) -> str:
     """Generate a high-level recommendation based on solution analysis."""
     solutions = solution_data.get("solutions", [])
@@ -49,6 +57,11 @@ def write_tools_enabled_from_env(default: bool = False) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def enabled_tools_from_env() -> set[str] | None:
+    """Return an optional explicit allowlist of MCP tool names to expose."""
+    return _parse_csv_set(os.getenv("ROOTLY_MCP_ENABLED_TOOLS"))
 
 
 # Default allowed API paths

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -115,6 +115,7 @@ def enabled_tools_from_env() -> set[str] | None:
 
 # Default allowed API paths
 DEFAULT_ALLOWED_PATHS = [
+    "/incidents",
     "/incidents/{incident_id}/alerts",
     "/alerts",
     "/alerts/{id}",

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 
 def _generate_recommendation(solution_data: dict) -> str:
     """Generate a high-level recommendation based on solution analysis."""
@@ -39,6 +41,14 @@ def _generate_recommendation(solution_data: dict) -> str:
         if recommendation_parts
         else "Review similar incidents above for resolution guidance."
     )
+
+
+def write_tools_enabled_from_env(default: bool = False) -> bool:
+    """Return whether non-destructive write tools should be exposed."""
+    raw = os.getenv("ROOTLY_MCP_ENABLE_WRITE_TOOLS")
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
 # Default allowed API paths
@@ -107,6 +117,17 @@ DEFAULT_ALLOWED_PATHS = [
     "/on_call_shadows/{on_call_shadow_id}",
     "/on_call_roles",
     "/on_call_roles/{on_call_role_id}",
+]
+
+# Non-destructive write operations are only exposed for these path families when
+# write tools are explicitly enabled. This keeps the default surface focused on
+# read-only workflows and avoids exposing broader admin/config writes.
+DEFAULT_WRITE_ALLOWED_PATHS = [
+    "/incidents/{incident_id}/action_items",
+    "/incidents/{incident_id}/form_field_selections",
+    "/incident_form_field_selections/{id}",
+    "/workflows/{workflow_id}/workflow_tasks",
+    "/workflow_tasks/{id}",
 ]
 
 # DELETE operations are only exposed for these high-priority screenshot families.

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -118,6 +118,8 @@ def _filter_openapi_spec(
     spec: dict[str, Any],
     allowed_paths: list[str],
     delete_allowed_paths: list[str] | None = None,
+    write_allowed_paths: list[str] | None = None,
+    enable_write_tools: bool = True,
 ) -> dict[str, Any]:
     """
     Filter an OpenAPI specification to only include specified paths and clean up schema references.
@@ -126,6 +128,8 @@ def _filter_openapi_spec(
         spec: The original OpenAPI specification.
         allowed_paths: List of paths to include.
         delete_allowed_paths: Path templates where DELETE operations are allowed.
+        write_allowed_paths: Path templates where POST/PUT/PATCH are allowed.
+        enable_write_tools: Whether non-destructive write operations are exposed.
 
     Returns:
         A filtered OpenAPI specification with cleaned schema references.
@@ -156,8 +160,21 @@ def _filter_openapi_spec(
     delete_allowed_normalized_paths = {
         _normalize_path_template(path) for path in delete_allowed_set
     }
+    write_allowed_set = set(write_allowed_paths or allowed_paths)
+    write_allowed_normalized_paths = {
+        _normalize_path_template(path) for path in write_allowed_set
+    }
     paths_to_remove: list[str] = []
     for path, path_item in filtered_paths.items():
+        allow_write = enable_write_tools and (
+            path in write_allowed_set
+            or _normalize_path_template(path) in write_allowed_normalized_paths
+        )
+        if not allow_write:
+            path_item.pop("post", None)
+            path_item.pop("put", None)
+            path_item.pop("patch", None)
+
         allow_delete = path in delete_allowed_set or (
             _normalize_path_template(path) in delete_allowed_normalized_paths
         )

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -120,6 +120,7 @@ def _filter_openapi_spec(
     delete_allowed_paths: list[str] | None = None,
     write_allowed_paths: list[str] | None = None,
     enable_write_tools: bool = True,
+    enabled_operation_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     """
     Filter an OpenAPI specification to only include specified paths and clean up schema references.
@@ -130,6 +131,7 @@ def _filter_openapi_spec(
         delete_allowed_paths: Path templates where DELETE operations are allowed.
         write_allowed_paths: Path templates where POST/PUT/PATCH are allowed.
         enable_write_tools: Whether non-destructive write operations are exposed.
+        enabled_operation_ids: Optional allowlist of OpenAPI operationIds to expose.
 
     Returns:
         A filtered OpenAPI specification with cleaned schema references.
@@ -184,6 +186,25 @@ def _filter_openapi_spec(
             paths_to_remove.append(path)
     for path in paths_to_remove:
         del filtered_paths[path]
+
+    if enabled_operation_ids is not None:
+        paths_to_remove = []
+        for path, path_item in filtered_paths.items():
+            methods_to_remove: list[str] = []
+            for method, operation in path_item.items():
+                if method.lower() not in ["get", "post", "put", "patch", "delete"]:
+                    continue
+                operation_id = operation.get("operationId")
+                if operation_id not in enabled_operation_ids:
+                    methods_to_remove.append(method)
+            for method in methods_to_remove:
+                path_item.pop(method, None)
+            if not any(
+                method.lower() in ["get", "post", "put", "patch", "delete"] for method in path_item
+            ):
+                paths_to_remove.append(path)
+        for path in paths_to_remove:
+            del filtered_paths[path]
 
     # Clean up schema references that might be broken
     # Remove problematic schema references from request bodies and parameters

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -161,9 +161,7 @@ def _filter_openapi_spec(
         _normalize_path_template(path) for path in delete_allowed_set
     }
     write_allowed_set = set(write_allowed_paths or allowed_paths)
-    write_allowed_normalized_paths = {
-        _normalize_path_template(path) for path in write_allowed_set
-    }
+    write_allowed_normalized_paths = {_normalize_path_template(path) for path in write_allowed_set}
     paths_to_remove: list[str] = []
     for path, path_item in filtered_paths.items():
         allow_write = enable_write_tools and (

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -82,6 +82,7 @@ def register_incident_tools(
     strip_heavy_nested_data: StripHeavyNestedData,
     mcp_error: Any,
     generate_recommendation: GenerateRecommendation,
+    enable_write_tools: bool = False,
 ) -> None:
     """Register incident search and recommendation tools on the MCP server."""
 
@@ -639,168 +640,170 @@ def register_incident_tools(
                 ),
             )
 
-    @mcp.tool(name="createIncident")
-    async def create_incident(
-        title: Annotated[
-            str | None,
-            Field(description="Incident title. If omitted, Rootly may autogenerate one."),
-        ] = None,
-        summary: Annotated[
-            str | None,
-            Field(description="Incident summary or short description."),
-        ] = None,
-        severity_id: Annotated[
-            str | None,
-            Field(description="Optional severity ID to attach to the incident."),
-        ] = None,
-        service_ids: Annotated[
-            str | None,
-            Field(description="Comma-separated service IDs to attach to the incident."),
-        ] = None,
-        team_ids: Annotated[
-            str | None,
-            Field(description="Comma-separated team IDs to attach to the incident."),
-        ] = None,
-        environment_ids: Annotated[
-            str | None,
-            Field(description="Comma-separated environment IDs to attach to the incident."),
-        ] = None,
-        incident_type_ids: Annotated[
-            str | None,
-            Field(description="Comma-separated incident type IDs to attach to the incident."),
-        ] = None,
-    ) -> JsonDict:
-        """Create an incident with a scoped set of fields for agent-driven workflows."""
-        normalized_title = _normalize_optional_text(title)
-        normalized_summary = _normalize_optional_text(summary)
+    if enable_write_tools:
 
-        if normalized_title is None and normalized_summary is None:
-            return cast(
-                JsonDict,
-                mcp_error.tool_error(
-                    "Must provide at least one of title or summary",
-                    "validation_error",
-                ),
-            )
+        @mcp.tool(name="createIncident")
+        async def create_incident(
+            title: Annotated[
+                str | None,
+                Field(description="Incident title. If omitted, Rootly may autogenerate one."),
+            ] = None,
+            summary: Annotated[
+                str | None,
+                Field(description="Incident summary or short description."),
+            ] = None,
+            severity_id: Annotated[
+                str | None,
+                Field(description="Optional severity ID to attach to the incident."),
+            ] = None,
+            service_ids: Annotated[
+                str | None,
+                Field(description="Comma-separated service IDs to attach to the incident."),
+            ] = None,
+            team_ids: Annotated[
+                str | None,
+                Field(description="Comma-separated team IDs to attach to the incident."),
+            ] = None,
+            environment_ids: Annotated[
+                str | None,
+                Field(description="Comma-separated environment IDs to attach to the incident."),
+            ] = None,
+            incident_type_ids: Annotated[
+                str | None,
+                Field(description="Comma-separated incident type IDs to attach to the incident."),
+            ] = None,
+        ) -> JsonDict:
+            """Create an incident with a scoped set of fields for agent-driven workflows."""
+            normalized_title = _normalize_optional_text(title)
+            normalized_summary = _normalize_optional_text(summary)
 
-        attributes: dict[str, Any] = {}
-
-        if normalized_title is not None:
-            attributes["title"] = normalized_title
-        if normalized_summary is not None:
-            attributes["summary"] = normalized_summary
-
-        normalized_severity_id = _normalize_optional_text(severity_id)
-        if normalized_severity_id is not None:
-            attributes["severity_id"] = normalized_severity_id
-
-        csv_attribute_map = (
-            ("service_ids", service_ids),
-            ("group_ids", team_ids),
-            ("environment_ids", environment_ids),
-            ("incident_type_ids", incident_type_ids),
-        )
-        for attribute_name, raw_value in csv_attribute_map:
-            if raw_value is None:
-                continue
-            values = _split_csv_values(raw_value)
-            if values:
-                attributes[attribute_name] = values
-
-        payload = {
-            "data": {
-                "type": "incidents",
-                "attributes": attributes,
-            }
-        }
-
-        try:
-            response = await make_authenticated_request("POST", "/v1/incidents", json=payload)
-            response.raise_for_status()
-
-            response_data = response.json()
-            if isinstance(response_data.get("data"), dict):
-                stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
-                response_data["data"] = stripped["data"][0]
-            return cast(JsonDict, response_data)
-        except Exception as e:
-            error_type, error_message = mcp_error.categorize_error(e)
-            return cast(
-                JsonDict,
-                mcp_error.tool_error(
-                    f"Failed to create incident: {error_message}",
-                    error_type,
-                ),
-            )
-
-    @mcp.tool(name="updateIncident")
-    async def update_incident(
-        incident_id: Annotated[str, Field(description="Incident ID to update")],
-        retrospective_progress_status: Annotated[
-            str | None,
-            Field(
-                description="Retrospective/PIR status: one of not_started, active, completed, skipped"
-            ),
-        ] = None,
-        summary: Annotated[
-            str | None,
-            Field(description="Updated incident summary"),
-        ] = None,
-    ) -> JsonDict:
-        """Update scoped incident fields for PIR lifecycle automation."""
-        attributes: dict[str, Any] = {}
-
-        if retrospective_progress_status is not None:
-            if retrospective_progress_status not in RETROSPECTIVE_PROGRESS_STATUSES:
-                allowed = ", ".join(RETROSPECTIVE_PROGRESS_STATUSES)
+            if normalized_title is None and normalized_summary is None:
                 return cast(
                     JsonDict,
                     mcp_error.tool_error(
-                        f"retrospective_progress_status must be one of: {allowed}",
+                        "Must provide at least one of title or summary",
                         "validation_error",
                     ),
                 )
-            attributes["retrospective_progress_status"] = retrospective_progress_status
 
-        if summary is not None:
-            attributes["summary"] = summary
+            attributes: dict[str, Any] = {}
 
-        if not attributes:
-            return cast(
-                JsonDict,
-                mcp_error.tool_error(
-                    "Must provide at least one of retrospective_progress_status or summary",
-                    "validation_error",
-                ),
+            if normalized_title is not None:
+                attributes["title"] = normalized_title
+            if normalized_summary is not None:
+                attributes["summary"] = normalized_summary
+
+            normalized_severity_id = _normalize_optional_text(severity_id)
+            if normalized_severity_id is not None:
+                attributes["severity_id"] = normalized_severity_id
+
+            csv_attribute_map = (
+                ("service_ids", service_ids),
+                ("group_ids", team_ids),
+                ("environment_ids", environment_ids),
+                ("incident_type_ids", incident_type_ids),
             )
+            for attribute_name, raw_value in csv_attribute_map:
+                if raw_value is None:
+                    continue
+                values = _split_csv_values(raw_value)
+                if values:
+                    attributes[attribute_name] = values
 
-        payload = {
-            "data": {
-                "type": "incidents",
-                "attributes": attributes,
+            payload = {
+                "data": {
+                    "type": "incidents",
+                    "attributes": attributes,
+                }
             }
-        }
 
-        try:
-            response = await make_authenticated_request(
-                "PUT", f"/v1/incidents/{incident_id}", json=payload
-            )
-            response.raise_for_status()
+            try:
+                response = await make_authenticated_request("POST", "/v1/incidents", json=payload)
+                response.raise_for_status()
 
-            response_data = response.json()
-            if isinstance(response_data.get("data"), dict):
-                stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
-                response_data["data"] = stripped["data"][0]
-            return cast(JsonDict, response_data)
-        except Exception as e:
-            error_type, error_message = mcp_error.categorize_error(e)
-            return cast(
-                JsonDict,
-                mcp_error.tool_error(
-                    f"Failed to update incident: {error_message}",
-                    error_type,
+                response_data = response.json()
+                if isinstance(response_data.get("data"), dict):
+                    stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
+                    response_data["data"] = stripped["data"][0]
+                return cast(JsonDict, response_data)
+            except Exception as e:
+                error_type, error_message = mcp_error.categorize_error(e)
+                return cast(
+                    JsonDict,
+                    mcp_error.tool_error(
+                        f"Failed to create incident: {error_message}",
+                        error_type,
+                    ),
+                )
+
+        @mcp.tool(name="updateIncident")
+        async def update_incident(
+            incident_id: Annotated[str, Field(description="Incident ID to update")],
+            retrospective_progress_status: Annotated[
+                str | None,
+                Field(
+                    description="Retrospective/PIR status: one of not_started, active, completed, skipped"
                 ),
-            )
+            ] = None,
+            summary: Annotated[
+                str | None,
+                Field(description="Updated incident summary"),
+            ] = None,
+        ) -> JsonDict:
+            """Update scoped incident fields for PIR lifecycle automation."""
+            attributes: dict[str, Any] = {}
+
+            if retrospective_progress_status is not None:
+                if retrospective_progress_status not in RETROSPECTIVE_PROGRESS_STATUSES:
+                    allowed = ", ".join(RETROSPECTIVE_PROGRESS_STATUSES)
+                    return cast(
+                        JsonDict,
+                        mcp_error.tool_error(
+                            f"retrospective_progress_status must be one of: {allowed}",
+                            "validation_error",
+                        ),
+                    )
+                attributes["retrospective_progress_status"] = retrospective_progress_status
+
+            if summary is not None:
+                attributes["summary"] = summary
+
+            if not attributes:
+                return cast(
+                    JsonDict,
+                    mcp_error.tool_error(
+                        "Must provide at least one of retrospective_progress_status or summary",
+                        "validation_error",
+                    ),
+                )
+
+            payload = {
+                "data": {
+                    "type": "incidents",
+                    "attributes": attributes,
+                }
+            }
+
+            try:
+                response = await make_authenticated_request(
+                    "PUT", f"/v1/incidents/{incident_id}", json=payload
+                )
+                response.raise_for_status()
+
+                response_data = response.json()
+                if isinstance(response_data.get("data"), dict):
+                    stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
+                    response_data["data"] = stripped["data"][0]
+                return cast(JsonDict, response_data)
+            except Exception as e:
+                error_type, error_message = mcp_error.categorize_error(e)
+                return cast(
+                    JsonDict,
+                    mcp_error.tool_error(
+                        f"Failed to update incident: {error_message}",
+                        error_type,
+                    ),
+                )
 
     @mcp.tool()
     async def find_related_incidents(

--- a/tests/integration/local/test_tool_allowlists.py
+++ b/tests/integration/local/test_tool_allowlists.py
@@ -84,14 +84,14 @@ def _terminate_process(process: subprocess.Popen[str]) -> str:
     ("enabled_tools", "enable_write_tools", "expected_tools"),
     [
         (
-            "getIncident,getCurrentUser,getTeam",
+            "list_incidents,getIncident,listTeams",
             False,
-            ["getCurrentUser", "getIncident", "getTeam"],
+            ["getIncident", "listTeams", "list_incidents"],
         ),
         (
-            "createIncident,createWorkflowTask,getTeam",
+            "createIncident,createWorkflowTask,listTeams",
             True,
-            ["createIncident", "createWorkflowTask", "getTeam"],
+            ["createIncident", "createWorkflowTask", "listTeams"],
         ),
     ],
 )

--- a/tests/integration/local/test_tool_allowlists.py
+++ b/tests/integration/local/test_tool_allowlists.py
@@ -84,9 +84,9 @@ def _terminate_process(process: subprocess.Popen[str]) -> str:
     ("enabled_tools", "enable_write_tools", "expected_tools"),
     [
         (
-            "list_incidents,getIncident,listTeams",
+            "listIncidents,getIncident,listTeams",
             False,
-            ["getIncident", "listTeams", "list_incidents"],
+            ["getIncident", "listIncidents", "listTeams"],
         ),
         (
             "createIncident,createWorkflowTask,listTeams",

--- a/tests/integration/local/test_tool_allowlists.py
+++ b/tests/integration/local/test_tool_allowlists.py
@@ -1,0 +1,140 @@
+"""Integration tests for self-hosted tool allowlists over live MCP transport."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+
+def _find_free_port() -> int:
+    """Reserve an unused localhost port for a test server process."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _wait_for_health(base_url: str, timeout: float = 15.0) -> None:
+    """Poll the health endpoint until the subprocess server is ready."""
+    deadline = time.monotonic() + timeout
+    async with httpx.AsyncClient(timeout=1.0) as client:
+        while time.monotonic() < deadline:
+            try:
+                response = await client.get(f"{base_url}/health")
+                if response.status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+            await asyncio.sleep(0.25)
+    raise AssertionError(f"Timed out waiting for MCP server health at {base_url}/health")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _server_env(
+    *,
+    port: int,
+    enabled_tools: str,
+    enable_write_tools: bool = False,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "ROOTLY_API_TOKEN": "local_test_token_12345",
+            "ROOTLY_MCP_ENABLED_TOOLS": enabled_tools,
+            "ROOTLY_TRANSPORT": "streamable-http",
+            "FASTMCP_PORT": str(port),
+        }
+    )
+    if enable_write_tools:
+        env["ROOTLY_MCP_ENABLE_WRITE_TOOLS"] = "true"
+    else:
+        env.pop("ROOTLY_MCP_ENABLE_WRITE_TOOLS", None)
+    return env
+
+
+def _terminate_process(process: subprocess.Popen[str]) -> str:
+    """Terminate a subprocess and collect any remaining stderr for diagnostics."""
+    if process.poll() is None:
+        process.terminate()
+        try:
+            _stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            _stdout, stderr = process.communicate(timeout=5)
+        return stderr
+    _stdout, stderr = process.communicate(timeout=5)
+    return stderr
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enabled_tools", "enable_write_tools", "expected_tools"),
+    [
+        (
+            "list_incidents,getIncident,get_server_version",
+            False,
+            ["getIncident", "get_server_version", "list_incidents"],
+        ),
+        (
+            "createIncident,createWorkflowTask,listTeams",
+            True,
+            ["createIncident", "createWorkflowTask", "listTeams"],
+        ),
+    ],
+)
+async def test_self_hosted_allowlists_match_live_mcp_tool_list(
+    enabled_tools: str,
+    enable_write_tools: bool,
+    expected_tools: list[str],
+) -> None:
+    """Boot the server as a subprocess and verify the live tools/list payload."""
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "rootly_mcp_server",
+            "--transport",
+            "streamable-http",
+            "--log-level",
+            "ERROR",
+        ],
+        cwd=_repo_root(),
+        env=_server_env(
+            port=port,
+            enabled_tools=enabled_tools,
+            enable_write_tools=enable_write_tools,
+        ),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        await _wait_for_health(base_url)
+
+        async with streamable_http_client(f"{base_url}/mcp") as (read_stream, write_stream, _):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                tool_names = sorted(tool.name for tool in tools.tools)
+
+        assert tool_names == sorted(expected_tools)
+    finally:
+        stderr = _terminate_process(process)
+        if process.returncode not in (0, -15):
+            pytest.fail(f"Server exited unexpectedly with code {process.returncode}:\n{stderr}")

--- a/tests/integration/local/test_tool_allowlists.py
+++ b/tests/integration/local/test_tool_allowlists.py
@@ -84,9 +84,9 @@ def _terminate_process(process: subprocess.Popen[str]) -> str:
     ("enabled_tools", "enable_write_tools", "expected_tools"),
     [
         (
-            "list_incidents,getIncident,get_server_version",
+            "listIncidents,getIncident,listTeams",
             False,
-            ["getIncident", "get_server_version", "list_incidents"],
+            ["getIncident", "listIncidents", "listTeams"],
         ),
         (
             "createIncident,createWorkflowTask,listTeams",

--- a/tests/integration/local/test_tool_allowlists.py
+++ b/tests/integration/local/test_tool_allowlists.py
@@ -84,14 +84,14 @@ def _terminate_process(process: subprocess.Popen[str]) -> str:
     ("enabled_tools", "enable_write_tools", "expected_tools"),
     [
         (
-            "listIncidents,getIncident,listTeams",
+            "getIncident,getCurrentUser,getTeam",
             False,
-            ["getIncident", "listIncidents", "listTeams"],
+            ["getCurrentUser", "getIncident", "getTeam"],
         ),
         (
-            "createIncident,createWorkflowTask,listTeams",
+            "createIncident,createWorkflowTask,getTeam",
             True,
-            ["createIncident", "createWorkflowTask", "listTeams"],
+            ["createIncident", "createWorkflowTask", "getTeam"],
         ),
     ],
 )

--- a/tests/unit/test_code_mode_module.py
+++ b/tests/unit/test_code_mode_module.py
@@ -83,6 +83,7 @@ def test_create_rootly_codemode_server_adds_code_mode_transform():
             allowed_paths=["/incidents"],
             hosted=True,
             base_url="https://api.rootly.com",
+            enable_write_tools=True,
         )
 
     assert server is mock_transform_server
@@ -94,6 +95,7 @@ def test_create_rootly_codemode_server_adds_code_mode_transform():
         hosted=True,
         base_url="https://api.rootly.com",
         transport="streamable-http",
+        enable_write_tools=True,
     )
 
 

--- a/tests/unit/test_code_mode_module.py
+++ b/tests/unit/test_code_mode_module.py
@@ -84,6 +84,7 @@ def test_create_rootly_codemode_server_adds_code_mode_transform():
             hosted=True,
             base_url="https://api.rootly.com",
             enable_write_tools=True,
+            enabled_tools={"list_incidents", "getIncident"},
         )
 
     assert server is mock_transform_server
@@ -96,6 +97,7 @@ def test_create_rootly_codemode_server_adds_code_mode_transform():
         base_url="https://api.rootly.com",
         transport="streamable-http",
         enable_write_tools=True,
+        enabled_tools={"list_incidents", "getIncident"},
     )
 
 

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -1,10 +1,11 @@
-"""Tests for CLI transport normalization in __main__."""
+"""Tests for CLI transport normalization and config propagation in __main__."""
 
 import argparse
+from unittest.mock import patch
 
 import pytest
 
-from rootly_mcp_server.__main__ import normalize_transport
+from rootly_mcp_server.__main__ import get_server, normalize_transport
 
 
 @pytest.mark.parametrize(
@@ -29,3 +30,16 @@ def test_normalize_transport_supported_aliases(value: str, expected: str):
 def test_normalize_transport_rejects_invalid_value():
     with pytest.raises(argparse.ArgumentTypeError):
         normalize_transport("invalid-transport")
+
+
+def test_get_server_passes_write_tool_env_flag():
+    with patch.dict(
+        "os.environ",
+        {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"},
+        clear=True,
+    ):
+        with patch("rootly_mcp_server.__main__.create_rootly_mcp_server") as mock_create:
+            get_server()
+
+    assert mock_create.call_args is not None
+    assert mock_create.call_args.kwargs["enable_write_tools"] is True

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -45,6 +45,19 @@ def test_get_server_passes_write_tool_env_flag():
     assert mock_create.call_args.kwargs["enable_write_tools"] is True
 
 
+def test_get_server_passes_enabled_tools_env_flag():
+    with patch.dict(
+        "os.environ",
+        {"ROOTLY_MCP_ENABLED_TOOLS": "list_incidents,getIncident"},
+        clear=True,
+    ):
+        with patch("rootly_mcp_server.__main__.create_rootly_mcp_server") as mock_create:
+            get_server()
+
+    assert mock_create.call_args is not None
+    assert mock_create.call_args.kwargs["enabled_tools"] == {"list_incidents", "getIncident"}
+
+
 def test_get_server_defaults_self_hosted_to_read_only():
     with patch.dict("os.environ", {}, clear=True):
         with patch("rootly_mcp_server.__main__.create_rootly_mcp_server") as mock_create:

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -43,3 +43,23 @@ def test_get_server_passes_write_tool_env_flag():
 
     assert mock_create.call_args is not None
     assert mock_create.call_args.kwargs["enable_write_tools"] is True
+
+
+def test_get_server_defaults_self_hosted_to_read_only():
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("rootly_mcp_server.__main__.create_rootly_mcp_server") as mock_create:
+            get_server()
+
+    assert mock_create.call_args is not None
+    assert mock_create.call_args.kwargs["hosted"] is False
+    assert mock_create.call_args.kwargs["enable_write_tools"] is False
+
+
+def test_get_server_keeps_hosted_default_write_surface():
+    with patch.dict("os.environ", {"ROOTLY_HOSTED": "true"}, clear=True):
+        with patch("rootly_mcp_server.__main__.create_rootly_mcp_server") as mock_create:
+            get_server()
+
+    assert mock_create.call_args is not None
+    assert mock_create.call_args.kwargs["hosted"] is True
+    assert mock_create.call_args.kwargs["enable_write_tools"] is True

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -1,11 +1,12 @@
 """Tests for CLI transport normalization and config propagation in __main__."""
 
 import argparse
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from rootly_mcp_server.__main__ import get_server, normalize_transport
+from rootly_mcp_server.__main__ import _get_sorted_tool_names, get_server, main, normalize_transport
 
 
 @pytest.mark.parametrize(
@@ -76,3 +77,59 @@ def test_get_server_keeps_hosted_default_write_surface():
     assert mock_create.call_args is not None
     assert mock_create.call_args.kwargs["hosted"] is True
     assert mock_create.call_args.kwargs["enable_write_tools"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_sorted_tool_names_returns_sorted_names():
+    server = SimpleNamespace(
+        list_tools=AsyncMock(
+            return_value=[
+                SimpleNamespace(name="getIncident"),
+                SimpleNamespace(name="createIncident"),
+                SimpleNamespace(name="listTeams"),
+            ]
+        )
+    )
+
+    names = await _get_sorted_tool_names(server)
+
+    assert names == ["createIncident", "getIncident", "listTeams"]
+
+
+def test_main_list_tools_prints_effective_tool_names_and_exits(capsys):
+    args = SimpleNamespace(
+        swagger_path=None,
+        log_level="ERROR",
+        name="Rootly",
+        transport="stdio",
+        debug=False,
+        base_url=None,
+        allowed_paths=None,
+        hosted=False,
+        enable_code_mode=False,
+        enable_write_tools=False,
+        enabled_tools=None,
+        list_tools=True,
+        code_mode_path=None,
+        host=False,
+    )
+    fake_server = object()
+
+    def fake_asyncio_run(coro):
+        coro.close()
+        return ["get_server_version", "list_incidents"]
+
+    with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
+        with patch("rootly_mcp_server.__main__.setup_logging"):
+            with patch("rootly_mcp_server.__main__.check_api_token"):
+                with patch(
+                    "rootly_mcp_server.__main__.create_rootly_mcp_server", return_value=fake_server
+                ):
+                    with patch(
+                        "rootly_mcp_server.__main__.asyncio.run",
+                        side_effect=fake_asyncio_run,
+                    ) as mock_run:
+                        main()
+
+    assert mock_run.call_count == 1
+    assert capsys.readouterr().out.splitlines() == ["get_server_version", "list_incidents"]

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -350,13 +350,13 @@ class TestBundledIncidentFormFieldSelectionTools:
     ):
         server = create_rootly_mcp_server(
             hosted=False,
-            enabled_tools={"listTeams", "get_server_version"},
+            enabled_tools={"listTeams", "listSeverities"},
         )
 
         tools = await server.list_tools()
         tool_names = {tool.name for tool in tools}
 
-        assert tool_names == {"listTeams", "get_server_version"}
+        assert tool_names == {"listTeams", "listSeverities"}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -190,6 +190,32 @@ class TestServerCreation:
         assert "post" in filtered["paths"]["/v1/workflows/123/workflow_tasks"]
         assert "put" in filtered["paths"]["/v1/workflow_tasks/456"]
 
+    def test_filter_openapi_spec_can_allowlist_specific_operation_ids(self):
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {
+                "/v1/teams": {
+                    "get": {"operationId": "listTeams"},
+                    "post": {"operationId": "createTeam"},
+                },
+                "/v1/users/me": {
+                    "get": {"operationId": "getCurrentUser"},
+                },
+            },
+            "components": {"schemas": {}},
+        }
+
+        filtered = _filter_openapi_spec(
+            spec,
+            ["/v1/teams", "/v1/users/me"],
+            enabled_operation_ids={"listTeams"},
+        )
+
+        assert "get" in filtered["paths"]["/v1/teams"]
+        assert "post" not in filtered["paths"]["/v1/teams"]
+        assert "/v1/users/me" not in filtered["paths"]
+
     def test_create_server_with_bundled_swagger(self):
         """Ensure FastMCP can instantiate from the bundled swagger without schema errors."""
         swagger_path = os.path.join(os.path.dirname(server_module.__file__), "data", "swagger.json")
@@ -318,6 +344,19 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "createIncidentFormFieldSelection" in tool_names
         assert "updateIncidentFormFieldSelection" in tool_names
         assert "deleteWorkflowTask" not in tool_names
+
+    async def test_enabled_tools_allowlist_filters_generated_and_custom_tools(
+        self, mock_environment_token
+    ):
+        server = create_rootly_mcp_server(
+            hosted=False,
+            enabled_tools={"listTeams", "get_server_version"},
+        )
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert tool_names == {"listTeams", "get_server_version"}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -123,6 +123,73 @@ class TestServerCreation:
 
         assert not has_openapi_audit_findings(findings), findings
 
+    def test_filter_openapi_spec_disables_write_methods_by_default(self):
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {
+                "/v1/teams": {
+                    "get": {"operationId": "listTeams"},
+                    "post": {"operationId": "createTeam"},
+                },
+                "/v1/workflows/123/workflow_tasks": {
+                    "get": {"operationId": "listWorkflowTasks"},
+                    "post": {"operationId": "createWorkflowTask"},
+                },
+                "/v1/workflow_tasks/456": {
+                    "get": {"operationId": "getWorkflowTask"},
+                    "put": {"operationId": "updateWorkflowTask"},
+                    "delete": {"operationId": "deleteWorkflowTask"},
+                },
+            },
+            "components": {"schemas": {}},
+        }
+
+        filtered = _filter_openapi_spec(
+            spec,
+            ["/v1/teams", "/v1/workflows/123/workflow_tasks", "/v1/workflow_tasks/456"],
+            delete_allowed_paths=[],
+            write_allowed_paths=["/v1/workflows/123/workflow_tasks", "/v1/workflow_tasks/456"],
+            enable_write_tools=False,
+        )
+
+        assert "post" not in filtered["paths"]["/v1/teams"]
+        assert "post" not in filtered["paths"]["/v1/workflows/123/workflow_tasks"]
+        assert "put" not in filtered["paths"]["/v1/workflow_tasks/456"]
+        assert "delete" not in filtered["paths"]["/v1/workflow_tasks/456"]
+
+    def test_filter_openapi_spec_only_exposes_curated_write_methods_when_enabled(self):
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {
+                "/v1/teams": {
+                    "get": {"operationId": "listTeams"},
+                    "post": {"operationId": "createTeam"},
+                },
+                "/v1/workflows/123/workflow_tasks": {
+                    "get": {"operationId": "listWorkflowTasks"},
+                    "post": {"operationId": "createWorkflowTask"},
+                },
+                "/v1/workflow_tasks/456": {
+                    "get": {"operationId": "getWorkflowTask"},
+                    "put": {"operationId": "updateWorkflowTask"},
+                },
+            },
+            "components": {"schemas": {}},
+        }
+
+        filtered = _filter_openapi_spec(
+            spec,
+            ["/v1/teams", "/v1/workflows/123/workflow_tasks", "/v1/workflow_tasks/456"],
+            write_allowed_paths=["/v1/workflows/123/workflow_tasks", "/v1/workflow_tasks/456"],
+            enable_write_tools=True,
+        )
+
+        assert "post" not in filtered["paths"]["/v1/teams"]
+        assert "post" in filtered["paths"]["/v1/workflows/123/workflow_tasks"]
+        assert "put" in filtered["paths"]["/v1/workflow_tasks/456"]
+
     def test_create_server_with_bundled_swagger(self):
         """Ensure FastMCP can instantiate from the bundled swagger without schema errors."""
         swagger_path = os.path.join(os.path.dirname(server_module.__file__), "data", "swagger.json")
@@ -196,33 +263,47 @@ class TestServerCreation:
 class TestBundledIncidentFormFieldSelectionTools:
     """Verify the bundled swagger exposes the intended incident custom field tools."""
 
-    async def test_incident_form_field_selection_tools_are_available(self, mock_environment_token):
+    async def test_default_server_hides_generated_write_tools(self, mock_environment_token):
         server = create_rootly_mcp_server(hosted=False)
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "listIncidentActionItems" in tool_names
+        assert "listIncidentFormFieldSelections" in tool_names
+        assert "getIncidentFormFieldSelection" in tool_names
+
+        assert "createIncidentActionItem" not in tool_names
+        assert "createIncidentFormFieldSelection" not in tool_names
+        assert "updateIncidentFormFieldSelection" not in tool_names
+        assert "deleteIncidentFormFieldSelection" not in tool_names
+
+    async def test_default_server_hides_workflow_write_tools(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "listWorkflowTasks" in tool_names
+        assert "getWorkflowTask" in tool_names
+
+        assert "createWorkflowTask" not in tool_names
+        assert "updateWorkflowTask" not in tool_names
+        assert "deleteWorkflowTask" not in tool_names
+
+    async def test_enable_write_tools_exposes_curated_generated_write_tools(
+        self, mock_environment_token
+    ):
+        server = create_rootly_mcp_server(hosted=False, enable_write_tools=True)
 
         tools = await server.list_tools()
         tool_names = {tool.name for tool in tools}
 
         assert "createIncidentActionItem" in tool_names
-        assert "listIncidentActionItems" in tool_names
-
         assert "createIncidentFormFieldSelection" in tool_names
-        assert "listIncidentFormFieldSelections" in tool_names
-        assert "getIncidentFormFieldSelection" in tool_names
         assert "updateIncidentFormFieldSelection" in tool_names
-
-        assert "deleteIncidentFormFieldSelection" not in tool_names
-
-    async def test_workflow_task_tools_are_available_without_delete(self, mock_environment_token):
-        server = create_rootly_mcp_server(hosted=False)
-
-        tools = await server.list_tools()
-        tool_names = {tool.name for tool in tools}
-
         assert "createWorkflowTask" in tool_names
-        assert "listWorkflowTasks" in tool_names
-        assert "getWorkflowTask" in tool_names
         assert "updateWorkflowTask" in tool_names
-
         assert "deleteWorkflowTask" not in tool_names
 
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -306,6 +306,19 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "updateWorkflowTask" in tool_names
         assert "deleteWorkflowTask" not in tool_names
 
+    async def test_hosted_server_keeps_curated_write_tools_by_default(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=True)
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "createWorkflowTask" in tool_names
+        assert "updateWorkflowTask" in tool_names
+        assert "createIncidentActionItem" in tool_names
+        assert "createIncidentFormFieldSelection" in tool_names
+        assert "updateIncidentFormFieldSelection" in tool_names
+        assert "deleteWorkflowTask" not in tool_names
+
 
 @pytest.mark.unit
 class TestAuthenticatedHTTPXClient:

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -1,6 +1,12 @@
 """Focused tests for server_defaults module."""
 
-from rootly_mcp_server.server_defaults import DEFAULT_ALLOWED_PATHS, _generate_recommendation
+from unittest.mock import patch
+
+from rootly_mcp_server.server_defaults import (
+    DEFAULT_ALLOWED_PATHS,
+    _generate_recommendation,
+    enabled_tools_from_env,
+)
 
 
 class TestServerDefaultsModule:
@@ -39,3 +45,11 @@ class TestServerDefaultsModule:
         }
         result = _generate_recommendation(solution_data)
         assert "require more time" in result
+
+    def test_enabled_tools_from_env_parses_csv(self):
+        with patch.dict(
+            "os.environ",
+            {"ROOTLY_MCP_ENABLED_TOOLS": "list_incidents, getIncident ,listTeams"},
+            clear=True,
+        ):
+            assert enabled_tools_from_env() == {"list_incidents", "getIncident", "listTeams"}

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -136,6 +136,7 @@ class TestScopedIncidentUpdateTool:
             strip_heavy_nested_data=lambda data: data,
             mcp_error=FakeMCPError(),
             generate_recommendation=_generate_recommendation,
+            enable_write_tools=True,
         )
         return mcp.tools, request
 
@@ -146,6 +147,23 @@ class TestScopedIncidentUpdateTool:
         assert "createIncident" in tools
         assert "updateIncident" in tools
         assert "getIncident" in tools
+
+    @pytest.mark.asyncio
+    async def test_write_tools_are_hidden_when_write_gating_is_disabled(self):
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+
+        assert "getIncident" in mcp.tools
+        assert "createIncident" not in mcp.tools
+        assert "updateIncident" not in mcp.tools
 
     @pytest.mark.asyncio
     async def test_create_incident_sends_only_allowed_fields(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1715,7 +1715,7 @@ wheels = [
 
 [[package]]
 name = "rootly-mcp-server"
-version = "2.2.19"
+version = "2.2.20"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -48,14 +48,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
@@ -720,6 +721,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/fe/0f5a938c54105553436dbff7a61dc4fed4b1b2c98852f8833beaf4d5968f/joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444", size = 330475, upload-time = "2025-05-23T12:04:37.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a", size = 307746, upload-time = "2025-05-23T12:04:35.124Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]
@@ -1517,20 +1530,20 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -1713,6 +1726,8 @@ dependencies = [
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pygments" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "requests" },
     { name = "scikit-learn" },
 ]
@@ -1746,7 +1761,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "authlib", specifier = ">=1.6.9" },
+    { name = "authlib", specifier = ">=1.6.11" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1" },
     { name = "brotli", specifier = ">=1.2.0" },
@@ -1759,6 +1774,8 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pygments", specifier = ">=2.20.0" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0" },


### PR DESCRIPTION
## Summary
- add a single opt-in write gate via --enable-write-tools and ROOTLY_MCP_ENABLE_WRITE_TOOLS
- keep the default tool surface read-only
- expose only a curated non-destructive write surface when write tools are enabled
- apply the same gate to Code Mode so it does not bypass the main server setting

## Details
- OpenAPI-generated POST/PUT/PATCH tools are filtered unless write tools are explicitly enabled
- even when enabled, writes stay limited to curated workflow-task and incident follow-up paths
- scoped custom incident write tools (createIncident, updateIncident) are hidden by default and enabled behind the same flag
- delete tools remain off by default

## Validation
- uv run ruff check src/rootly_mcp_server/server.py src/rootly_mcp_server/spec_transform.py src/rootly_mcp_server/server_defaults.py src/rootly_mcp_server/__main__.py src/rootly_mcp_server/code_mode.py src/rootly_mcp_server/tools/incidents.py tests/unit/test_server.py tests/unit/test_tools.py tests/unit/test_code_mode_module.py tests/unit/test_main_transport.py
- uv run pytest tests/unit/test_server.py tests/unit/test_tools.py tests/unit/test_code_mode_module.py tests/unit/test_main_transport.py -q
- uv run mypy src/rootly_mcp_server
- commit hook full unit suite: 367 passed
- manual tool surface check confirmed write tools are hidden by default and enabled with the flag
