### PR TITLE
fix: fill write-path gaps and add plan-gating hint on 404s

### DIFF
--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -373,6 +373,7 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/workflows",
     "/workflows/{workflow_id}",
     "/workflow_groups",
+    "/workflow_groups/{id}",
     "/workflows/{workflow_id}/workflow_tasks",
     "/workflow_tasks/{id}",
     "/workflows/{workflow_id}/form_field_conditions",
@@ -394,6 +395,7 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/live_call_routers",
     "/live_call_routers/{id}",
     # Post-incident and retrospectives - create + update
+    "/post_incident_reviews",
     "/post_incident_reviews/{id}",
     "/retrospective_processes",
     "/retrospective_processes/{id}",
@@ -401,6 +403,7 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/retrospective_process_groups/{id}",
     "/retrospective_processes/{retrospective_process_id}/retrospective_steps",
     "/retrospective_steps/{id}",
+    "/postmortem_templates",
     "/postmortem_templates/{id}",
     # Communications - create + update
     "/communications_groups",
@@ -413,11 +416,15 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/communications_types/{id}",
     # Causes and catalog - create + update
     "/causes",
+    "/causes/{id}",
     "/catalogs",
+    "/catalogs/{id}",
     "/catalogs/{catalog_id}/entities",
+    "/catalog_entities/{id}",
     # Sub-statuses - create + update
     "/sub_statuses",
     "/sub_statuses/{id}",
+    "/incident_sub_statuses",
     "/incident_sub_statuses/{id}",
     # User notification preferences - create + update
     "/users/{user_id}/notification_rules",
@@ -435,13 +442,18 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     # Form and field management - create + update
     "/custom_fields",
     "/custom_fields/{id}",
+    "/custom_field_options",
     "/custom_field_options/{id}",
     "/form_sets",
     "/form_sets/{id}",
     "/form_field_placements/{id}",
     "/form_field_placement_conditions/{id}",
     "/form_set_conditions/{id}",
+    # Status pages - create + update
+    "/status-pages",
+    "/status-pages/{id}",
     # Status page templates
+    "/status_page_templates",
     "/status_page_templates/{id}",
 ]
 

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -743,17 +743,27 @@ class AuthenticatedHTTPXClient:
             return body
         return payload
 
+    # Matches UUID v4 format: 8-4-4-4-12 lowercase hex chars
+    _UUID_RE = re.compile(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+    )
+
     @staticmethod
     def _path_has_id_segment(url: str) -> bool:
         """Return True if the URL path ends with what looks like an ID segment.
 
-        Collection paths (/v1/heartbeats) return False.
+        Collection paths (/v1/heartbeats, /v1/status-pages) return False.
         Individual-resource paths (/v1/heartbeats/123) return True.
+
+        Hyphenated resource names like 'status-pages' must not be confused with
+        UUID-style IDs — the UUID check requires strict hex-only segments.
         """
         path = AuthenticatedHTTPXClient._path_for_url(url)
         last = path.rstrip("/").rsplit("/", 1)[-1]
-        # Numeric IDs or UUID-shaped strings indicate a specific resource
-        return bool(last and (last.isdigit() or (len(last) > 8 and "-" in last)))
+        return bool(
+            last
+            and (last.isdigit() or AuthenticatedHTTPXClient._UUID_RE.match(last))
+        )
 
     @staticmethod
     def _maybe_annotate_404_response(

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -794,7 +794,7 @@ class AuthenticatedHTTPXClient:
             else:
                 body = {"original_response": body, "_plan_gating_hint": hint}
             response._content = json.dumps(body).encode()  # noqa: SLF001
-        except Exception:
+        except Exception:  # nosec B110 - Safe fallback; annotation is best-effort
             pass
         return response
 

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -722,6 +722,7 @@ class AuthenticatedHTTPXClient:
         response = self._maybe_normalize_incident_form_field_selection_response(
             method, url, response
         )
+        response = self._maybe_annotate_404_response(method, url, response)
 
         return response
 
@@ -741,6 +742,61 @@ class AuthenticatedHTTPXClient:
         if len(payload) == 1 and isinstance(body, dict):
             return body
         return payload
+
+    @staticmethod
+    def _path_has_id_segment(url: str) -> bool:
+        """Return True if the URL path ends with what looks like an ID segment.
+
+        Collection paths (/v1/heartbeats) return False.
+        Individual-resource paths (/v1/heartbeats/123) return True.
+        """
+        path = AuthenticatedHTTPXClient._path_for_url(url)
+        last = path.rstrip("/").rsplit("/", 1)[-1]
+        # Numeric IDs or UUID-shaped strings indicate a specific resource
+        return bool(last and (last.isdigit() or (len(last) > 8 and "-" in last)))
+
+    @staticmethod
+    def _maybe_annotate_404_response(
+        method: str, url: str, response: httpx.Response
+    ) -> httpx.Response:
+        """Append a plan-gating hint to 404 responses.
+
+        Rootly returns 404 for endpoints that are locked to a specific subscription
+        tier, even when the request is valid. The response body uses the generic
+        title "Not found or unauthorized" with no plan-specific discriminator.
+
+        Heuristic: a 404 on a collection path (no trailing ID) is almost certainly
+        plan gating regardless of method.  A 404 on an ID path during a write is
+        ambiguous — the resource may simply not exist — so the hint is softened.
+        """
+        if response.status_code != 404:
+            return response
+        has_id = AuthenticatedHTTPXClient._path_has_id_segment(url)
+        is_write = method.upper() in {"POST", "PUT", "PATCH"}
+        # Skip GET on ID paths — those are ordinary "resource not found" responses
+        if has_id and not is_write:
+            return response
+        try:
+            body = response.json()
+            if not has_id:
+                hint = (
+                    "This 404 most likely means the feature is not enabled on your Rootly plan. "
+                    "Contact Rootly support to enable it for your organisation."
+                )
+            else:
+                hint = (
+                    "This 404 may mean the resource does not exist, or that the feature is not "
+                    "enabled on your Rootly plan. Contact Rootly support if the resource exists "
+                    "and the error persists."
+                )
+            if isinstance(body, dict):
+                body.setdefault("_plan_gating_hint", hint)
+            else:
+                body = {"original_response": body, "_plan_gating_hint": hint}
+            response._content = json.dumps(body).encode()  # noqa: SLF001
+        except Exception:
+            pass
+        return response
 
     @staticmethod
     def _is_alert_endpoint(url: str) -> bool:

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -760,10 +760,7 @@ class AuthenticatedHTTPXClient:
         """
         path = AuthenticatedHTTPXClient._path_for_url(url)
         last = path.rstrip("/").rsplit("/", 1)[-1]
-        return bool(
-            last
-            and (last.isdigit() or AuthenticatedHTTPXClient._UUID_RE.match(last))
-        )
+        return bool(last and (last.isdigit() or AuthenticatedHTTPXClient._UUID_RE.match(last)))
 
     @staticmethod
     def _maybe_annotate_404_response(


### PR DESCRIPTION
## Summary

- **10 missing write paths added** to `DEFAULT_WRITE_ALLOWED_PATHS` — each was a half-pair where create existed but update was missing or vice versa:
  - `/workflow_groups/{id}` (had create, missing update)
  - `/post_incident_reviews` (had update, missing create)
  - `/postmortem_templates` (had update, missing create)
  - `/causes/{id}` (had create, missing update)
  - `/catalogs/{id}` and `/catalog_entities/{id}` (had create, missing updates)
  - `/incident_sub_statuses` (had update, missing create)
  - `/custom_field_options` (had update, missing create)
  - `/status-pages` and `/status-pages/{id}` (missing entirely)
  - `/status_page_templates` (had update, missing create)

- **Plan-gating hint on 404s** — `_maybe_annotate_404_response` in `transport.py` appends a `_plan_gating_hint` field to 404 responses so the AI surfaces a clear explanation instead of suggesting payload fixes. Heuristic: collection-path 404s (no trailing ID) are almost certainly plan gating; ID-path write 404s get a softer message since the resource may not exist.

## Test plan

- [ ] All 387 unit tests pass
- [ ] `createWorkflowGroup` / `updateWorkflowGroup` appear as tools when write tools enabled
- [ ] `createStatusPage` / `updateStatusPage` appear as tools when write tools enabled
- [ ] `listHeartbeats` returning 404 now includes `_plan_gating_hint` in response body
- [ ] `updateCause`, `updateCatalog`, `updateCatalogEntity` available as write tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)