### PR TITLE
fix: resolve sequential incident references in getIncident

### DIFF
--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -747,7 +747,9 @@ def register_incident_tools(
             resolved_incident_id = await _resolve_incident_reference_to_uuid(
                 incident_id, make_authenticated_request
             )
-            response = await make_authenticated_request("GET", f"/v1/incidents/{resolved_incident_id}")
+            response = await make_authenticated_request(
+                "GET", f"/v1/incidents/{resolved_incident_id}"
+            )
             response.raise_for_status()
 
             response_data = response.json()

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -879,7 +879,12 @@ def register_incident_tools(
 
         @mcp.tool(name="updateIncident")
         async def update_incident(
-            incident_id: Annotated[str, Field(description="Incident ID to update")],
+            incident_id: Annotated[
+                str,
+                Field(
+                    description="Incident reference to update: UUID, bare number like 4460, #4460, or INC-4460"
+                ),
+            ],
             retrospective_progress_status: Annotated[
                 str | None,
                 Field(
@@ -926,8 +931,11 @@ def register_incident_tools(
             }
 
             try:
+                resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                    incident_id, make_authenticated_request
+                )
                 response = await make_authenticated_request(
-                    "PUT", f"/v1/incidents/{incident_id}", json=payload
+                    "PUT", f"/v1/incidents/{resolved_incident_id}", json=payload
                 )
                 response.raise_for_status()
 
@@ -977,11 +985,15 @@ def register_incident_tools(
         """
         try:
             target_incident: dict[str, Any] = {}
+            resolved_incident_id = ""
 
             if incident_id:
                 # Get the target incident details by ID
+                resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                    incident_id, make_authenticated_request
+                )
                 target_response = await make_authenticated_request(
-                    "GET", f"/v1/incidents/{incident_id}"
+                    "GET", f"/v1/incidents/{resolved_incident_id}"
                 )
                 target_response.raise_for_status()
                 target_incident_data = strip_heavy_nested_data(
@@ -1033,7 +1045,9 @@ def register_incident_tools(
             # Filter out the target incident itself if it exists
             if incident_id:
                 historical_incidents = [
-                    inc for inc in historical_incidents if str(inc.get("id")) != str(incident_id)
+                    inc
+                    for inc in historical_incidents
+                    if str(inc.get("id")) != str(resolved_incident_id)
                 ]
 
             if not historical_incidents:
@@ -1042,6 +1056,7 @@ def register_incident_tools(
                     "message": "No historical incidents found for comparison",
                     "target_incident": {
                         "id": incident_id or "synthetic",
+                        "resolved_incident_id": resolved_incident_id or None,
                         "title": target_incident.get("attributes", {}).get(
                             "title", incident_description
                         ),
@@ -1076,6 +1091,7 @@ def register_incident_tools(
             return {
                 "target_incident": {
                     "id": incident_id or "synthetic",
+                    "resolved_incident_id": resolved_incident_id or None,
                     "title": target_incident.get("attributes", {}).get(
                         "title", incident_description
                     ),
@@ -1123,10 +1139,16 @@ def register_incident_tools(
         """
         try:
             target_incident: dict[str, Any] = {}
+            resolved_incident_id = ""
 
             if incident_id:
                 # Get incident details by ID
-                response = await make_authenticated_request("GET", f"/v1/incidents/{incident_id}")
+                resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                    incident_id, make_authenticated_request
+                )
+                response = await make_authenticated_request(
+                    "GET", f"/v1/incidents/{resolved_incident_id}"
+                )
                 response.raise_for_status()
                 incident_data = strip_heavy_nested_data({"data": [response.json().get("data", {})]})
                 target_incident = incident_data.get("data", [{}])[0]
@@ -1174,7 +1196,9 @@ def register_incident_tools(
             # Filter out target incident if it exists
             if incident_id:
                 historical_incidents = [
-                    inc for inc in historical_incidents if str(inc.get("id")) != str(incident_id)
+                    inc
+                    for inc in historical_incidents
+                    if str(inc.get("id")) != str(resolved_incident_id)
                 ]
 
             if not historical_incidents:
@@ -1208,6 +1232,7 @@ def register_incident_tools(
             return {
                 "target_incident": {
                     "id": incident_id or "synthetic",
+                    "resolved_incident_id": resolved_incident_id or None,
                     "title": target_incident.get("attributes", {}).get("title", incident_title),
                     "description": target_incident.get("attributes", {}).get(
                         "summary", incident_description

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Literal, cast
 
@@ -22,6 +23,12 @@ INCIDENT_LIST_FIELDS = (
     "id,sequential_id,title,summary,status,severity,created_at,updated_at,url,"
     "started_at,resolved_at,retrospective_progress_status"
 )
+INCIDENT_REFERENCE_FIELDS = "id,sequential_id"
+INCIDENT_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+INCIDENT_SEQUENTIAL_REF_RE = re.compile(r"^(?:#|INC-)?(\d+)$")
 
 
 def _split_csv_values(value: str) -> list[str]:
@@ -74,6 +81,110 @@ def _summarize_incident_record(incident: dict[str, Any]) -> dict[str, Any]:
         "retrospective_progress_status": attrs.get("retrospective_progress_status"),
         "url": attrs.get("url"),
     }
+
+
+def _extract_sequential_id(incident: dict[str, Any]) -> int | None:
+    """Extract a numeric sequential incident ID from a Rootly incident record."""
+    attrs = incident.get("attributes", {})
+    sequential_id = attrs.get("sequential_id")
+    if sequential_id is None:
+        return None
+    try:
+        return int(sequential_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_incident_reference(reference: str) -> tuple[str, str | int]:
+    """Classify and normalize an incident reference."""
+    normalized = _normalize_optional_text(reference)
+    if normalized is None:
+        raise ValueError("Incident reference is required")
+    if INCIDENT_UUID_RE.match(normalized):
+        return ("uuid", normalized)
+    sequential_match = INCIDENT_SEQUENTIAL_REF_RE.match(normalized)
+    if sequential_match:
+        return ("sequential", int(sequential_match.group(1)))
+    return ("direct", normalized)
+
+
+async def _resolve_incident_reference_to_uuid(
+    incident_reference: str,
+    make_authenticated_request: MakeAuthenticatedRequest,
+) -> str:
+    """Resolve supported incident references to the Rootly incident UUID."""
+    reference_kind, normalized_reference = _normalize_incident_reference(incident_reference)
+    if reference_kind in {"uuid", "direct"}:
+        return cast(str, normalized_reference)
+
+    target_sequential_id = cast(int, normalized_reference)
+    page_cache: dict[int, tuple[list[dict[str, Any]], dict[str, Any]]] = {}
+
+    async def _fetch_page(page_number: int) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        cached = page_cache.get(page_number)
+        if cached is not None:
+            return cached
+
+        response = await make_authenticated_request(
+            "GET",
+            "/v1/incidents",
+            params={
+                "page[size]": 100,
+                "page[number]": page_number,
+                "fields[incidents]": INCIDENT_REFERENCE_FIELDS,
+                "include": "",
+                "sort": "-created_at",
+            },
+        )
+        response.raise_for_status()
+        response_data = response.json()
+        incidents = cast(list[dict[str, Any]], response_data.get("data", []))
+        meta = cast(dict[str, Any], response_data.get("meta", {}))
+        page_cache[page_number] = (incidents, meta)
+        return incidents, meta
+
+    incidents, meta = await _fetch_page(1)
+    total_pages = int(meta.get("total_pages") or 1)
+
+    left = 1
+    right = total_pages
+
+    while left <= right:
+        page_number = (left + right) // 2
+        if page_number == 1:
+            page_incidents, _ = incidents, meta
+        else:
+            page_incidents, _ = await _fetch_page(page_number)
+
+        sequential_ids = [
+            sequential_id
+            for sequential_id in (_extract_sequential_id(incident) for incident in page_incidents)
+            if sequential_id is not None
+        ]
+
+        if not sequential_ids:
+            break
+
+        page_max = max(sequential_ids)
+        page_min = min(sequential_ids)
+
+        if target_sequential_id > page_max:
+            right = page_number - 1
+            continue
+        if target_sequential_id < page_min:
+            left = page_number + 1
+            continue
+
+        for incident in page_incidents:
+            if _extract_sequential_id(incident) == target_sequential_id:
+                incident_uuid = incident.get("id")
+                if isinstance(incident_uuid, str) and incident_uuid:
+                    return incident_uuid
+                break
+
+        raise LookupError(f"Incident reference not found: INC-{target_sequential_id}")
+
+    raise LookupError(f"Incident reference not found: INC-{target_sequential_id}")
 
 
 def register_incident_tools(
@@ -624,11 +735,19 @@ def register_incident_tools(
 
     @mcp.tool(name="getIncident")
     async def get_incident(
-        incident_id: Annotated[str, Field(description="Incident ID to retrieve")],
+        incident_id: Annotated[
+            str,
+            Field(
+                description="Incident reference to retrieve: UUID, bare number like 4460, #4460, or INC-4460"
+            ),
+        ],
     ) -> JsonDict:
         """Retrieve a single incident with PIR-related fields for direct verification."""
         try:
-            response = await make_authenticated_request("GET", f"/v1/incidents/{incident_id}")
+            resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                incident_id, make_authenticated_request
+            )
+            response = await make_authenticated_request("GET", f"/v1/incidents/{resolved_incident_id}")
             response.raise_for_status()
 
             response_data = response.json()
@@ -636,6 +755,22 @@ def register_incident_tools(
                 stripped = strip_heavy_nested_data({"data": [response_data["data"]]})
                 response_data["data"] = stripped["data"][0]
             return cast(JsonDict, response_data)
+        except ValueError as e:
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to retrieve incident: {e}",
+                    "validation_error",
+                ),
+            )
+        except LookupError as e:
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to retrieve incident: {e}",
+                    "not_found",
+                ),
+            )
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(

--- a/src/rootly_mcp_server/tools/resources.py
+++ b/src/rootly_mcp_server/tools/resources.py
@@ -35,7 +35,9 @@ def register_resource_handlers(
             resolved_incident_id = await _resolve_incident_reference_to_uuid(
                 incident_id, make_authenticated_request
             )
-            response = await make_authenticated_request("GET", f"/v1/incidents/{resolved_incident_id}")
+            response = await make_authenticated_request(
+                "GET", f"/v1/incidents/{resolved_incident_id}"
+            )
             response.raise_for_status()
             incident_data = strip_heavy_nested_data({"data": [response.json().get("data", {})]})
 

--- a/src/rootly_mcp_server/tools/resources.py
+++ b/src/rootly_mcp_server/tools/resources.py
@@ -6,6 +6,8 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from typing import Any, Protocol
 
+from .incidents import _resolve_incident_reference_to_uuid
+
 JsonDict = dict[str, Any]
 MakeAuthenticatedRequest = Callable[..., Awaitable[Any]]
 StripHeavyNestedData = Callable[[JsonDict], JsonDict]
@@ -30,14 +32,18 @@ def register_resource_handlers(
     async def get_incident_resource(incident_id: str) -> JsonDict:
         """Expose incident details as an MCP resource for easy reference and context."""
         try:
-            response = await make_authenticated_request("GET", f"/v1/incidents/{incident_id}")
+            resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                incident_id, make_authenticated_request
+            )
+            response = await make_authenticated_request("GET", f"/v1/incidents/{resolved_incident_id}")
             response.raise_for_status()
             incident_data = strip_heavy_nested_data({"data": [response.json().get("data", {})]})
 
             incident = incident_data.get("data", [{}])[0]
             attributes = incident.get("attributes", {})
 
-            text_content = f"""Incident #{incident_id}
+            text_content = f"""Incident Reference: {incident_id}
+Resolved Incident ID: {resolved_incident_id}
 Title: {attributes.get("title", "N/A")}
 Status: {attributes.get("status", "N/A")}
 Severity: {attributes.get("severity", "N/A")}
@@ -48,7 +54,7 @@ URL: {attributes.get("url", "N/A")}"""
 
             return {
                 "uri": f"incident://{incident_id}",
-                "name": f"Incident #{incident_id}",
+                "name": f"Incident {incident_id}",
                 "text": text_content,
                 "mimeType": "text/plain",
             }
@@ -56,7 +62,7 @@ URL: {attributes.get("url", "N/A")}"""
             error_type, error_message = mcp_error.categorize_error(e)
             return {
                 "uri": f"incident://{incident_id}",
-                "name": f"Incident #{incident_id} (Error)",
+                "name": f"Incident {incident_id} (Error)",
                 "text": f"Error ({error_type}): {error_message}",
                 "mimeType": "text/plain",
             }

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -17,6 +17,7 @@ import pytest
 from rootly_mcp_server.server import DEFAULT_ALLOWED_PATHS, create_rootly_mcp_server
 from rootly_mcp_server.server_defaults import _generate_recommendation
 from rootly_mcp_server.tools.incidents import INCIDENT_LIST_FIELDS, register_incident_tools
+from rootly_mcp_server.tools.resources import register_resource_handlers
 
 
 class FakeMCP:
@@ -24,10 +25,18 @@ class FakeMCP:
 
     def __init__(self) -> None:
         self.tools: dict[str, Any] = {}
+        self.resources: dict[str, Any] = {}
 
     def tool(self, name: str | None = None, **_: Any):
         def decorator(fn):
             self.tools[name or fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    def resource(self, uri_template: str, **_: Any):
+        def decorator(fn):
+            self.resources[uri_template] = fn
             return fn
 
         return decorator
@@ -37,8 +46,8 @@ class FakeMCPError:
     """Minimal error helper for custom tool tests."""
 
     @staticmethod
-    def categorize_error(error: Exception) -> tuple[str, str]:
-        return (error.__class__.__name__, str(error))
+    def categorize_error(exception: Exception) -> tuple[str, str]:
+        return (exception.__class__.__name__, str(exception))
 
     @staticmethod
     def tool_error(message: str, error_type: str) -> dict[str, Any]:
@@ -474,6 +483,70 @@ class TestScopedIncidentUpdateTool:
         )
         assert result["data"]["attributes"]["retrospective_progress_status"] == "active"
         assert result["data"]["attributes"]["summary"] == "Updated PIR summary"
+
+    @pytest.mark.asyncio
+    async def test_update_incident_resolves_sequential_reference(self):
+        tools, request = self._register_tools()
+
+        list_response = Mock()
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {
+            "data": [
+                {
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4460},
+                }
+            ],
+            "meta": {"current_page": 1, "next_page": None, "prev_page": None, "total_pages": 1},
+        }
+
+        update_response = Mock()
+        update_response.raise_for_status.return_value = None
+        update_response.json.return_value = {
+            "data": {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "type": "incidents",
+                "attributes": {
+                    "summary": "Updated PIR summary",
+                    "retrospective_progress_status": "active",
+                },
+            }
+        }
+
+        request.side_effect = [list_response, update_response]
+
+        result = await tools["updateIncident"](
+            incident_id="#4460",
+            retrospective_progress_status="active",
+        )
+
+        assert request.await_args_list == [
+            call(
+                "GET",
+                "/v1/incidents",
+                params={
+                    "page[size]": 100,
+                    "page[number]": 1,
+                    "fields[incidents]": "id,sequential_id",
+                    "include": "",
+                    "sort": "-created_at",
+                },
+            ),
+            call(
+                "PUT",
+                "/v1/incidents/11111111-1111-4111-8111-111111111111",
+                json={
+                    "data": {
+                        "type": "incidents",
+                        "attributes": {
+                            "retrospective_progress_status": "active",
+                        },
+                    }
+                },
+            ),
+        ]
+        assert result["data"]["id"] == "11111111-1111-4111-8111-111111111111"
 
     @pytest.mark.asyncio
     async def test_update_incident_allows_skipped_status(self):
@@ -975,3 +1048,182 @@ class TestCollectIncidentsTool:
             "INC-102",
             "INC-103",
         ]
+
+
+@pytest.mark.unit
+class TestIncidentReferenceResolutionAcrossTools:
+    def _register_tools(self):
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=True,
+        )
+        register_resource_handlers(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+        )
+        return mcp, request
+
+    @pytest.mark.asyncio
+    async def test_find_related_incidents_resolves_sequential_reference(self):
+        mcp, request = self._register_tools()
+
+        list_response = Mock()
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {
+            "data": [
+                {
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4460},
+                }
+            ],
+            "meta": {"current_page": 1, "next_page": None, "prev_page": None, "total_pages": 1},
+        }
+
+        incident_response = Mock()
+        incident_response.raise_for_status.return_value = None
+        incident_response.json.return_value = {
+            "data": {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "attributes": {
+                    "title": "Database timeout",
+                    "summary": "Connection pool exhausted",
+                },
+            }
+        }
+
+        historical_response = Mock()
+        historical_response.raise_for_status.return_value = None
+        historical_response.json.return_value = {
+            "data": [
+                {
+                    "id": "other-1",
+                    "attributes": {
+                        "title": "Database timeout",
+                        "summary": "Connection pool exhausted",
+                        "status": "resolved",
+                        "created_at": "2026-04-01T00:00:00Z",
+                        "url": "https://example.com/incidents/other-1",
+                    },
+                }
+            ]
+        }
+
+        request.side_effect = [list_response, incident_response, historical_response]
+
+        result = await mcp.tools["find_related_incidents"](incident_id="INC-4460")
+
+        assert request.await_args_list[1] == call(
+            "GET", "/v1/incidents/11111111-1111-4111-8111-111111111111"
+        )
+        assert result["target_incident"]["resolved_incident_id"] == (
+            "11111111-1111-4111-8111-111111111111"
+        )
+
+    @pytest.mark.asyncio
+    async def test_suggest_solutions_resolves_sequential_reference(self):
+        mcp, request = self._register_tools()
+
+        list_response = Mock()
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {
+            "data": [
+                {
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4460},
+                }
+            ],
+            "meta": {"current_page": 1, "next_page": None, "prev_page": None, "total_pages": 1},
+        }
+
+        incident_response = Mock()
+        incident_response.raise_for_status.return_value = None
+        incident_response.json.return_value = {
+            "data": {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "attributes": {
+                    "title": "Database timeout",
+                    "summary": "Connection pool exhausted",
+                },
+            }
+        }
+
+        historical_response = Mock()
+        historical_response.raise_for_status.return_value = None
+        historical_response.json.return_value = {
+            "data": [
+                {
+                    "id": "other-1",
+                    "attributes": {
+                        "title": "Database timeout",
+                        "summary": "Connection pool exhausted",
+                        "status": "resolved",
+                        "created_at": "2026-04-01T00:00:00Z",
+                        "resolved_at": "2026-04-01T01:00:00Z",
+                    },
+                }
+            ]
+        }
+
+        request.side_effect = [list_response, incident_response, historical_response]
+
+        result = await mcp.tools["suggest_solutions"](incident_id="4460")
+
+        assert request.await_args_list[1] == call(
+            "GET", "/v1/incidents/11111111-1111-4111-8111-111111111111"
+        )
+        assert result["target_incident"]["resolved_incident_id"] == (
+            "11111111-1111-4111-8111-111111111111"
+        )
+
+    @pytest.mark.asyncio
+    async def test_incident_resource_resolves_sequential_reference(self):
+        mcp, request = self._register_tools()
+
+        list_response = Mock()
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {
+            "data": [
+                {
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4460},
+                }
+            ],
+            "meta": {"current_page": 1, "next_page": None, "prev_page": None, "total_pages": 1},
+        }
+
+        incident_response = Mock()
+        incident_response.raise_for_status.return_value = None
+        incident_response.json.return_value = {
+            "data": {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "attributes": {
+                    "title": "Database timeout",
+                    "status": "resolved",
+                    "severity": "critical",
+                    "created_at": "2026-04-01T00:00:00Z",
+                    "updated_at": "2026-04-01T00:05:00Z",
+                    "summary": "Connection pool exhausted",
+                    "url": "https://example.com/incidents/4460",
+                },
+            }
+        }
+
+        request.side_effect = [list_response, incident_response]
+
+        result = await mcp.resources["incident://{incident_id}"]("#4460")
+
+        assert request.await_args_list[1] == call(
+            "GET", "/v1/incidents/11111111-1111-4111-8111-111111111111"
+        )
+        assert "Resolved Incident ID: 11111111-1111-4111-8111-111111111111" in result["text"]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -253,6 +253,189 @@ class TestScopedIncidentUpdateTool:
         assert result["data"]["attributes"]["retrospective_progress_status"] == "active"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("incident_reference"),
+        [
+            "4460",
+            "#4460",
+            "INC-4460",
+        ],
+    )
+    async def test_get_incident_resolves_sequential_references(self, incident_reference: str):
+        tools, request = self._register_tools()
+
+        list_response = Mock()
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {
+            "data": [
+                {
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4460},
+                }
+            ],
+            "meta": {
+                "current_page": 1,
+                "next_page": None,
+                "prev_page": None,
+                "total_pages": 1,
+                "total_count": 1,
+            },
+        }
+
+        incident_response = Mock()
+        incident_response.raise_for_status.return_value = None
+        incident_response.json.return_value = {
+            "data": {
+                "id": "11111111-1111-4111-8111-111111111111",
+                "type": "incidents",
+                "attributes": {
+                    "summary": "Updated PIR summary",
+                    "retrospective_progress_status": "active",
+                },
+            }
+        }
+
+        request.side_effect = [list_response, incident_response]
+
+        result = await tools["getIncident"](incident_id=incident_reference)
+
+        assert request.await_args_list == [
+            call(
+                "GET",
+                "/v1/incidents",
+                params={
+                    "page[size]": 100,
+                    "page[number]": 1,
+                    "fields[incidents]": "id,sequential_id",
+                    "include": "",
+                    "sort": "-created_at",
+                },
+            ),
+            call("GET", "/v1/incidents/11111111-1111-4111-8111-111111111111"),
+        ]
+        assert result["data"]["id"] == "11111111-1111-4111-8111-111111111111"
+
+    @pytest.mark.asyncio
+    async def test_get_incident_returns_clear_error_for_unknown_sequential_reference(self):
+        tools, request = self._register_tools()
+
+        first_page_response = Mock()
+        first_page_response.raise_for_status.return_value = None
+        first_page_response.json.return_value = {
+            "data": [
+                {
+                    "id": "uuid-page-1",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 5000},
+                },
+                {
+                    "id": "uuid-page-1-last",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4901},
+                },
+            ],
+            "meta": {
+                "current_page": 1,
+                "next_page": 2,
+                "prev_page": None,
+                "total_pages": 8,
+                "total_count": 800,
+            },
+        }
+
+        mid_page_response = Mock()
+        mid_page_response.raise_for_status.return_value = None
+        mid_page_response.json.return_value = {
+            "data": [
+                {
+                    "id": "uuid-page-4",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4700},
+                },
+                {
+                    "id": "uuid-page-4-last",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4601},
+                },
+            ],
+            "meta": {
+                "current_page": 4,
+                "next_page": 5,
+                "prev_page": 3,
+                "total_pages": 8,
+                "total_count": 800,
+            },
+        }
+
+        target_range_response = Mock()
+        target_range_response.raise_for_status.return_value = None
+        target_range_response.json.return_value = {
+            "data": [
+                {
+                    "id": "uuid-page-6",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4500},
+                },
+                {
+                    "id": "uuid-page-6-last",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4401},
+                },
+            ],
+            "meta": {
+                "current_page": 6,
+                "next_page": 7,
+                "prev_page": 5,
+                "total_pages": 8,
+                "total_count": 800,
+            },
+        }
+
+        request.side_effect = [first_page_response, mid_page_response, target_range_response]
+
+        result = await tools["getIncident"](incident_id="4460")
+
+        assert result["error"] is True
+        assert result["error_type"] == "not_found"
+        assert "INC-4460" in result["message"]
+        assert request.await_args_list == [
+            call(
+                "GET",
+                "/v1/incidents",
+                params={
+                    "page[size]": 100,
+                    "page[number]": 1,
+                    "fields[incidents]": "id,sequential_id",
+                    "include": "",
+                    "sort": "-created_at",
+                },
+            ),
+            call(
+                "GET",
+                "/v1/incidents",
+                params={
+                    "page[size]": 100,
+                    "page[number]": 4,
+                    "fields[incidents]": "id,sequential_id",
+                    "include": "",
+                    "sort": "-created_at",
+                },
+            ),
+            call(
+                "GET",
+                "/v1/incidents",
+                params={
+                    "page[size]": 100,
+                    "page[number]": 6,
+                    "fields[incidents]": "id,sequential_id",
+                    "include": "",
+                    "sort": "-created_at",
+                },
+            ),
+        ]
+
+    @pytest.mark.asyncio
     async def test_update_incident_sends_only_allowed_fields(self):
         tools, request = self._register_tools()
         response = Mock()


### PR DESCRIPTION
## Summary
- add server-side incident reference resolution for getIncident
- accept UUID, bare number, #number, and INC-number inputs
- resolve sequential references via bounded incident listing lookup on sequential_id before fetching the incident by UUID

## Testing
- uv run ruff check src/rootly_mcp_server/tools/incidents.py tests/unit/test_tools.py
- uv run pytest -q tests/unit/test_tools.py