### PR TITLE
Add .mcp.json for Open Plugins discovery (cursor.directory auto-detect)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,4 +199,3 @@ test_output/
 !CONTRIBUTING.md
 !CHANGELOG.md
 .beads/
-.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "rootly": {
+      "url": "https://mcp.rootly.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ROOTLY_API_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `.mcp.json` file at the repo root and removes the matching line from `.gitignore`. This unblocks Open-Plugins-standard auto-detection in plugin catalogs like [cursor.directory](https://cursor.directory) — specifically, it lets their "Add to Cursor" install button generate correctly from this repo.

## Why

cursor.directory and similar Open-Plugins-aware catalogs scan a submitted GitHub repo for an `.mcp.json` at the root. Without it, the listing renders but the one-click install button can't be generated. This repo currently ships [`server.json`](server.json) (MCP Server Registry schema) instead — that file remains the canonical registry entry, but it's not the file these plugin directories look for.

`.mcp.json` was previously listed in `.gitignore`, presumably to avoid committing per-developer Claude Code plugin configs. For an MCP server's own publishing repo, the file is intended to be public — it documents how clients should connect and is the input format these directories expect.

## What's added

```json
{
  "mcpServers": {
    "rootly": {
      "url": "https://mcp.rootly.com/mcp",
      "headers": {
        "Authorization": "Bearer ${ROOTLY_API_TOKEN}"
      }
    }
  }
}
```

This mirrors the "General Remote Setup" snippet already documented in the README, with `${ROOTLY_API_TOKEN}` as the env-var placeholder so users get prompted on install rather than seeing a hard-coded secret slot.

## After merge

Submit the repo URL at [cursor.directory/plugins/new](https://cursor.directory/plugins/new). Their auto-detect will read `.mcp.json` and generate a working "Add to Cursor" install button on the listing.

## Not changing

- `server.json` — stays as the canonical MCP Server Registry entry. This PR is purely additive.
- README, install instructions — already accurate for the streamable-HTTP endpoint this `.mcp.json` references.