### PR TITLE
fix: enforce Bearer auth on MCP transport paths in hosted mode

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -27,6 +27,7 @@ from .tools.oncall import register_oncall_tools
 from .tools.resources import register_resource_handlers
 from .utils import (
     OAUTH_PROTECTED_RESOURCE_PATH,
+    auth_header_state,
     is_mcp_server_url_static,
     resolve_mcp_server_url,
     sanitize_parameters_in_spec,
@@ -89,15 +90,7 @@ def _fingerprint_auth_header(auth_header: str) -> str:
 
 def _auth_header_state(auth_header: str) -> str:
     """Classify Authorization header shape without exposing token contents."""
-    raw = (auth_header or "").strip()
-    if not raw:
-        return "missing"
-    parts = raw.split(None, 1)
-    if not parts or parts[0].lower() != "bearer":
-        return "invalid_format"
-    if len(parts) == 1 or not parts[1].strip():
-        return "missing_token"
-    return "bearer"
+    return auth_header_state(auth_header)
 
 
 def _validate_bearer_auth_header(auth_header: str) -> str:

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -12,7 +12,7 @@ from typing import Any
 import httpx
 
 from .security import mask_sensitive_data
-from .utils import OAUTH_PROTECTED_RESOURCE_PATH, resolve_mcp_server_url
+from .utils import OAUTH_PROTECTED_RESOURCE_PATH, auth_header_state, resolve_mcp_server_url
 
 logger = logging.getLogger(__name__)
 
@@ -309,6 +309,32 @@ class AuthCaptureMiddleware:
                 f"{resolve_mcp_server_url(request)}{OAUTH_PROTECTED_RESOURCE_PATH}"
             )
             www_auth_value = f'Bearer resource_metadata="{resource_metadata_url}"'.encode()
+
+            # Reject unauthenticated or malformed requests on MCP transport
+            # paths early, before FastMCP processes the MCP protocol message.
+            auth_state = auth_header_state(auth)
+            if auth_state != "bearer":
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 401,
+                        "headers": [
+                            (b"content-type", b"application/json"),
+                            (b"www-authenticate", www_auth_value),
+                        ],
+                    }
+                )
+                body = {
+                    "error": "unauthorized",
+                    "message": "Authorization header with a valid Bearer token is required.",
+                }
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": json.dumps(body).encode(),
+                    }
+                )
+                return
 
             async def _send_with_www_authenticate(message):
                 if message.get("type") == "http.response.start" and message.get("status") == 401:

--- a/src/rootly_mcp_server/utils.py
+++ b/src/rootly_mcp_server/utils.py
@@ -30,6 +30,19 @@ def is_mcp_server_url_static() -> bool:
     return bool(_MCP_SERVER_URL)
 
 
+def auth_header_state(auth_header: str) -> str:
+    """Classify Authorization header shape without exposing token contents."""
+    raw = (auth_header or "").strip()
+    if not raw:
+        return "missing"
+    parts = raw.split(None, 1)
+    if not parts or parts[0].lower() != "bearer":
+        return "invalid_format"
+    if len(parts) == 1 or not parts[1].strip():
+        return "missing_token"
+    return "bearer"
+
+
 def sanitize_parameter_name(name: str) -> str:
     """
     Sanitize parameter names to match MCP property key pattern ^[a-zA-Z0-9_.-]{1,64}$.

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -814,7 +814,7 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
 
     @pytest.mark.asyncio
     async def test_200_response_does_not_include_www_authenticate(self):
-        """Non-401 responses should not get WWW-Authenticate header."""
+        """Non-401 responses with valid Bearer should not get WWW-Authenticate header."""
 
         async def app(scope, receive, send):
             await send(
@@ -830,7 +830,7 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
         scope = {
             "type": "http",
             "path": "/mcp",
-            "headers": [],
+            "headers": [(b"authorization", b"Bearer valid_token")],
         }
 
         transport._session_auth_token.set("")
@@ -851,6 +851,78 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
         start_msg = sent_messages[0]
         header_dict = dict(start_msg["headers"])
         assert b"www-authenticate" not in header_dict
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_mcp_request_returns_401(self):
+        """Requests to MCP paths without Bearer token should get 401."""
+
+        async def app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"OK"})
+
+        middleware = transport.AuthCaptureMiddleware(app)
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [],
+        }
+
+        sent_messages = []
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            sent_messages.append(message)
+
+        with patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"):
+            await middleware(scope, receive, send)
+
+        start_msg = sent_messages[0]
+        assert start_msg["status"] == 401
+        header_dict = dict(start_msg["headers"])
+        assert b"www-authenticate" in header_dict
+
+    @pytest.mark.asyncio
+    async def test_invalid_bearer_token_format_returns_401(self):
+        """Requests with malformed auth header should get 401."""
+
+        async def app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"OK"})
+
+        middleware = transport.AuthCaptureMiddleware(app)
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [(b"authorization", b"Token not_bearer_format")],
+        }
+
+        sent_messages = []
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            sent_messages.append(message)
+
+        with patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"):
+            await middleware(scope, receive, send)
+
+        start_msg = sent_messages[0]
+        assert start_msg["status"] == 401
 
     @pytest.mark.asyncio
     async def test_401_on_non_mcp_path_does_not_inject_header(self):


### PR DESCRIPTION
## Summary

- `AuthCaptureMiddleware` now returns 401 + `WWW-Authenticate` header for MCP transport paths (`/mcp`, `/sse`, `/messages`, `/mcp-codemode`) when no valid Bearer token is present
- Non-MCP paths (`/health`, `/healthz`, `/.well-known/*`) remain unauthenticated
- Moves `auth_header_state()` to `utils.py` for reuse across modules (avoids circular import)

## Test plan

- [ ] `curl -X POST http://localhost:8000/mcp` (no auth) → 401 + `WWW-Authenticate` header
- [ ] `curl -X POST http://localhost:8000/mcp -H "Authorization: Token bad"` → 401
- [ ] `curl -X POST http://localhost:8000/mcp -H "Authorization: Bearer valid"` → passes through to FastMCP
- [ ] `curl http://localhost:8000/health` → 200 (no auth required)
- [ ] `curl http://localhost:8000/.well-known/oauth-protected-resource` → 200 (no auth required)
- [ ] `uv run pytest tests/unit/ -x` passes