### PR TITLE
fix: validate Bearer tokens against upstream API before MCP access

### DIFF
--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import contextvars
+import hashlib
 import json
 import logging
 import os
 import re
+import time
 from typing import Any
 
 import httpx
@@ -248,7 +250,9 @@ class AuthCaptureMiddleware:
     are unavailable in async child contexts.
     """
 
-    _TOKEN_CACHE_TTL = 300
+    _POSITIVE_CACHE_TTL = 300
+    _NEGATIVE_CACHE_TTL = 60
+    _MAX_CACHE_SIZE = 10_000
 
     def __init__(self, app):
         self.app = app
@@ -263,19 +267,20 @@ class AuthCaptureMiddleware:
             self._code_mode_path,
         }
         self._base_url = os.getenv("ROOTLY_BASE_URL", "https://api.rootly.com")
-        self._validated_tokens: dict[str, float] = {}
+        # Maps token_hash -> (timestamp, is_valid)
+        self._token_cache: dict[str, tuple[float, bool]] = {}
 
     async def _validate_token_upstream(self, auth_header: str) -> bool:
         """Probe the Rootly API to verify the Bearer token is valid."""
-        import hashlib
-        import time
-
-        token_hash = hashlib.sha256(auth_header.encode()).hexdigest()[:16]
+        token_hash = hashlib.sha256(auth_header.encode()).hexdigest()
         now = time.monotonic()
 
-        cached_at = self._validated_tokens.get(token_hash)
-        if cached_at is not None and (now - cached_at) < self._TOKEN_CACHE_TTL:
-            return True
+        cached = self._token_cache.get(token_hash)
+        if cached is not None:
+            cached_at, was_valid = cached
+            ttl = self._POSITIVE_CACHE_TTL if was_valid else self._NEGATIVE_CACHE_TTL
+            if (now - cached_at) < ttl:
+                return was_valid
 
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
@@ -286,17 +291,27 @@ class AuthCaptureMiddleware:
                         "Accept": "application/vnd.api+json",
                     },
                 )
-            if resp.is_success:
-                self._validated_tokens[token_hash] = now
-                if len(self._validated_tokens) > 10000:
-                    cutoff = now - self._TOKEN_CACHE_TTL
-                    self._validated_tokens = {
-                        k: v for k, v in self._validated_tokens.items() if v > cutoff
-                    }
-                return True
+            is_valid = resp.is_success
         except Exception:
             logger.warning("Token validation probe failed, rejecting request")
-        return False
+            is_valid = False
+
+        self._token_cache[token_hash] = (now, is_valid)
+        self._evict_cache(now)
+        return is_valid
+
+    def _evict_cache(self, now: float) -> None:
+        """Remove expired entries then enforce hard size cap."""
+        if len(self._token_cache) <= self._MAX_CACHE_SIZE:
+            return
+        self._token_cache = {
+            k: (ts, valid)
+            for k, (ts, valid) in self._token_cache.items()
+            if (now - ts) < (self._POSITIVE_CACHE_TTL if valid else self._NEGATIVE_CACHE_TTL)
+        }
+        if len(self._token_cache) > self._MAX_CACHE_SIZE:
+            sorted_entries = sorted(self._token_cache.items(), key=lambda x: x[1][0])
+            self._token_cache = dict(sorted_entries[-self._MAX_CACHE_SIZE :])
 
     async def __call__(self, scope, receive, send):
         path = _normalize_path(str(scope.get("path", "")))

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -248,6 +248,8 @@ class AuthCaptureMiddleware:
     are unavailable in async child contexts.
     """
 
+    _TOKEN_CACHE_TTL = 300
+
     def __init__(self, app):
         self.app = app
         self._sse_path = _normalize_path(os.getenv("FASTMCP_SSE_PATH", "/sse"))
@@ -260,6 +262,41 @@ class AuthCaptureMiddleware:
             self._streamable_path,
             self._code_mode_path,
         }
+        self._base_url = os.getenv("ROOTLY_BASE_URL", "https://api.rootly.com")
+        self._validated_tokens: dict[str, float] = {}
+
+    async def _validate_token_upstream(self, auth_header: str) -> bool:
+        """Probe the Rootly API to verify the Bearer token is valid."""
+        import hashlib
+        import time
+
+        token_hash = hashlib.sha256(auth_header.encode()).hexdigest()[:16]
+        now = time.monotonic()
+
+        cached_at = self._validated_tokens.get(token_hash)
+        if cached_at is not None and (now - cached_at) < self._TOKEN_CACHE_TTL:
+            return True
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{self._base_url}/v1/users/me",
+                    headers={
+                        "Authorization": auth_header,
+                        "Accept": "application/vnd.api+json",
+                    },
+                )
+            if resp.is_success:
+                self._validated_tokens[token_hash] = now
+                if len(self._validated_tokens) > 10000:
+                    cutoff = now - self._TOKEN_CACHE_TTL
+                    self._validated_tokens = {
+                        k: v for k, v in self._validated_tokens.items() if v > cutoff
+                    }
+                return True
+        except Exception:
+            logger.warning("Token validation probe failed, rejecting request")
+        return False
 
     async def __call__(self, scope, receive, send):
         path = _normalize_path(str(scope.get("path", "")))
@@ -310,10 +347,10 @@ class AuthCaptureMiddleware:
             )
             www_auth_value = f'Bearer resource_metadata="{resource_metadata_url}"'.encode()
 
-            # Reject unauthenticated or malformed requests on MCP transport
-            # paths early, before FastMCP processes the MCP protocol message.
+            # Reject unauthenticated, malformed, or invalid tokens on MCP
+            # transport paths before FastMCP processes the protocol message.
             auth_state = auth_header_state(auth)
-            if auth_state != "bearer":
+            if auth_state != "bearer" or not await self._validate_token_upstream(auth):
                 await send(
                     {
                         "type": "http.response.start",

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import hashlib
 import json
@@ -269,6 +270,8 @@ class AuthCaptureMiddleware:
         self._base_url = os.getenv("ROOTLY_BASE_URL", "https://api.rootly.com")
         # Maps token_hash -> (timestamp, is_valid)
         self._token_cache: dict[str, tuple[float, bool]] = {}
+        # In-flight probes keyed by token_hash to prevent cache stampede
+        self._inflight: dict[str, asyncio.Future[bool]] = {}
 
     async def _validate_token_upstream(self, auth_header: str) -> bool:
         """Probe the Rootly API to verify the Bearer token is valid."""
@@ -282,6 +285,28 @@ class AuthCaptureMiddleware:
             if (now - cached_at) < ttl:
                 return was_valid
 
+        existing = self._inflight.get(token_hash)
+        if existing is not None:
+            return await existing
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[bool] = loop.create_future()
+        self._inflight[token_hash] = future
+
+        try:
+            is_valid = await self._probe_upstream(auth_header)
+            self._token_cache[token_hash] = (time.monotonic(), is_valid)
+            self._evict_cache(time.monotonic())
+            future.set_result(is_valid)
+            return is_valid
+        except Exception:
+            future.set_result(False)
+            return False
+        finally:
+            self._inflight.pop(token_hash, None)
+
+    async def _probe_upstream(self, auth_header: str) -> bool:
+        """Make the actual upstream validation request."""
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 resp = await client.get(
@@ -291,14 +316,10 @@ class AuthCaptureMiddleware:
                         "Accept": "application/vnd.api+json",
                     },
                 )
-            is_valid = resp.is_success
+            return resp.is_success
         except Exception:
             logger.warning("Token validation probe failed, rejecting request")
-            is_valid = False
-
-        self._token_cache[token_hash] = (now, is_valid)
-        self._evict_cache(now)
-        return is_valid
+            return False
 
     def _evict_cache(self, now: float) -> None:
         """Remove expired entries then enforce hard size cap."""

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -11,6 +11,15 @@ from rootly_mcp_server import transport
 class TestTransportModule:
     """Direct tests for extracted transport/auth helpers."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_token_probe(self):
+        with patch.object(
+            transport.AuthCaptureMiddleware,
+            "_validate_token_upstream",
+            return_value=True,
+        ):
+            yield
+
     @pytest.mark.asyncio
     async def test_auth_capture_middleware_sets_token_for_sse(self):
         async def app(scope, receive, send):
@@ -845,12 +854,55 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
         async def send(message):
             sent_messages.append(message)
 
-        with patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"):
+        with (
+            patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"),
+            patch.object(middleware, "_validate_token_upstream", return_value=True),
+        ):
             await middleware(scope, receive, send)
 
         start_msg = sent_messages[0]
         header_dict = dict(start_msg["headers"])
         assert b"www-authenticate" not in header_dict
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_rejected_by_upstream_probe(self):
+        """Bearer token with valid format but rejected by upstream should get 401."""
+
+        async def app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"OK"})
+
+        middleware = transport.AuthCaptureMiddleware(app)
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [(b"authorization", b"Bearer invalid_token_12345")],
+        }
+
+        sent_messages = []
+
+        async def receive():
+            return {"type": "http.request"}
+
+        async def send(message):
+            sent_messages.append(message)
+
+        with (
+            patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"),
+            patch.object(middleware, "_validate_token_upstream", return_value=False),
+        ):
+            await middleware(scope, receive, send)
+
+        start_msg = sent_messages[0]
+        assert start_msg["status"] == 401
+        header_dict = dict(start_msg["headers"])
+        assert b"www-authenticate" in header_dict
 
     @pytest.mark.asyncio
     async def test_unauthenticated_mcp_request_returns_401(self):


### PR DESCRIPTION
## Summary

- Adds upstream token validation probe (`GET /v1/users/me`) in `AuthCaptureMiddleware` before allowing MCP protocol access
- Invalid/revoked Bearer tokens now return 401 + `WWW-Authenticate` at transport layer
- Valid tokens cached 5 min (SHA-256 hash key) to minimize latency overhead
- Cache auto-evicts stale entries at 10k limit

Builds on #101 which added format-level Bearer checks. This closes the gap where `Bearer <garbage>` passed format check but still got `tools/list` responses.

## Test plan

- [ ] `Bearer invalid_token` → 401 (previously returned 200 + tools list)
- [ ] `Bearer <valid_rootly_token>` → passes through to FastMCP
- [ ] Second request with same valid token → no upstream probe (cached)
- [ ] No token → 401 (unchanged)
- [ ] Non-MCP paths (`/health`, `/.well-known/*`) → unaffected
- [ ] `uv run pytest tests/unit/ -x` passes