### PR TITLE
fix: include resource scopes in OAuth protected resource metadata

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -557,6 +557,8 @@ def create_rootly_mcp_server(
                         "openid",
                         "profile",
                         "email",
+                        "ir.incidents:read",
+                        "oc.alerts:read",
                     ],
                     "bearer_methods_supported": ["header"],
                 },


### PR DESCRIPTION
## Summary
- Adds `ir.incidents:read` and `oc.alerts:read` to `scopes_supported` in the RFC 9728 OAuth Protected Resource Metadata endpoint.
- MCP clients use this metadata to build their Dynamic Client Registration (DCR) payload. Without resource scopes, Rootly's consent screen only shows identity scopes and users cannot grant IR/OC permissions.
- With this change, DCR requests include resource scopes, Rootly renders permission checkboxes, and the full OAuth flow completes successfully.

## Test plan
- [ ] Inspect `POST /oauth/register` network request and confirm `scope` contains `openid profile email ir.incidents:read oc.alerts:read`
- [ ] Verify Rootly consent screen shows IR/OC scope checkboxes
- [ ] Complete OAuth flow end-to-end and confirm connected state is reached