### PR TITLE
fix: remove scopes_supported from OAuth protected resource metadata

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -553,13 +553,6 @@ def create_rootly_mcp_server(
                 {
                     "resource": mcp_server_url,
                     "authorization_servers": [derive_oauth_server_url(base_url)],
-                    "scopes_supported": [
-                        "openid",
-                        "profile",
-                        "email",
-                        "ir.incidents:read",
-                        "oc.alerts:read",
-                    ],
                     "bearer_methods_supported": ["header"],
                 },
                 headers={"Cache-Control": cache},


### PR DESCRIPTION
## Summary

- Removes `scopes_supported` from `/.well-known/oauth-protected-resource` response
- MCP clients will omit `scope` in DCR requests to Rootly, causing Rootly to return its granular default scope set
- Consent screen shows full granular IR/OC permission picker instead of limited pre-selected scopes

## Why

Rootly only shows consent options for scopes the client explicitly requested. When we listed specific scopes, the consent screen was limited. When scope is omitted from DCR, Rootly falls back to its full granular defaults (openid, profile, email, plus individual IR/OC read/write), giving users a broad permission picker they can narrow.

Meta scopes (`all`, `ir.all`, `oc.all`) are intentionally avoided — they lock scope selection on the consent screen.

## Test plan

- [ ] `curl https://mcp.rootly.com/.well-known/oauth-protected-resource` returns no `scopes_supported` field
- [ ] MCP client DCR to Rootly omits `scope` field
- [ ] Rootly consent screen shows granular IR/OC permissions
- [ ] User can narrow permissions on consent screen
- [ ] OAuth flow completes successfully