### PR TITLE
perf(alerts): make get_alert_by_short_id a single API call

### DIFF
--- a/src/rootly_mcp_server/tools/alerts.py
+++ b/src/rootly_mcp_server/tools/alerts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Protocol
+from urllib.parse import quote
 
 from pydantic import Field
 
@@ -50,40 +51,34 @@ def register_alert_tools(
             if not alert_short_id:
                 return mcp_error.tool_error("short_id is required", "validation_error")
 
-            # The Rootly API silently ignores filter[short_id], so we use
-            # filter[search] (which works) and verify the match client-side
-            # to guard against fuzzy hits on summary/description.
+            # GET /v1/alerts/{id} accepts the short_id as well as the UUID
+            # (undocumented but supported), so a single point lookup avoids
+            # listing/filtering altogether.
             response = await make_authenticated_request(
-                "GET",
-                "/v1/alerts",
-                params={
-                    "filter[search]": alert_short_id,
-                    "page[size]": 10,
-                    "fields[alerts]": "id,summary,status,started_at,ended_at,short_id,source,description,noise,alert_urgency_id,url,created_at",
-                },
+                "GET", f"/v1/alerts/{quote(alert_short_id, safe='')}"
             )
+            if response.status_code == 404:
+                return mcp_error.tool_error(
+                    f"Alert with short_id '{alert_short_id}' not found",
+                    "not_found",
+                )
             response.raise_for_status()
-            for alert in response.json().get("data", []):
-                attrs = alert.get("attributes", {})
-                if attrs.get("short_id") == alert_short_id:
-                    return {
-                        "id": alert.get("id"),
-                        "short_id": attrs.get("short_id"),
-                        "summary": attrs.get("summary"),
-                        "status": attrs.get("status"),
-                        "source": attrs.get("source"),
-                        "description": attrs.get("description"),
-                        "started_at": attrs.get("started_at"),
-                        "ended_at": attrs.get("ended_at"),
-                        "noise": attrs.get("noise"),
-                        "url": attrs.get("url"),
-                        "created_at": attrs.get("created_at"),
-                    }
 
-            return mcp_error.tool_error(
-                f"Alert with short_id '{alert_short_id}' not found",
-                "not_found",
-            )
+            data = response.json().get("data", {})
+            attrs = data.get("attributes", {})
+            return {
+                "id": data.get("id"),
+                "short_id": attrs.get("short_id"),
+                "summary": attrs.get("summary"),
+                "status": attrs.get("status"),
+                "source": attrs.get("source"),
+                "description": attrs.get("description"),
+                "started_at": attrs.get("started_at"),
+                "ended_at": attrs.get("ended_at"),
+                "noise": attrs.get("noise"),
+                "url": attrs.get("url"),
+                "created_at": attrs.get("created_at"),
+            }
 
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)

--- a/src/rootly_mcp_server/tools/alerts.py
+++ b/src/rootly_mcp_server/tools/alerts.py
@@ -43,7 +43,6 @@ def register_alert_tools(
     ) -> JsonDict:
         """Get alert details by short_id or alert URL. Use this when a user pastes an alert URL or short_id from a pager notification and wants to investigate the alert."""
         try:
-            # Parse short_id from URL if a full URL is provided
             alert_short_id = short_id.strip()
             if "/" in alert_short_id:
                 alert_short_id = alert_short_id.rstrip("/").split("/")[-1]
@@ -51,47 +50,35 @@ def register_alert_tools(
             if not alert_short_id:
                 return mcp_error.tool_error("short_id is required", "validation_error")
 
-            # Paginate through alerts looking for a matching short_id
-            page = 1
-            while page <= 20:
-                response = await make_authenticated_request(
-                    "GET",
-                    "/v1/alerts",
-                    params={
-                        "page[number]": page,
-                        "page[size]": 100,
-                        "fields[alerts]": "id,summary,status,started_at,ended_at,short_id,source,description,noise,alert_urgency_id,url,created_at",
-                    },
-                )
-                response.raise_for_status()
-                data = response.json()
-                alerts = data.get("data", [])
-
-                if not alerts:
-                    break
-
-                for alert in alerts:
-                    attrs = alert.get("attributes", {})
-                    if attrs.get("short_id") == alert_short_id:
-                        return {
-                            "id": alert.get("id"),
-                            "short_id": attrs.get("short_id"),
-                            "summary": attrs.get("summary"),
-                            "status": attrs.get("status"),
-                            "source": attrs.get("source"),
-                            "description": attrs.get("description"),
-                            "started_at": attrs.get("started_at"),
-                            "ended_at": attrs.get("ended_at"),
-                            "noise": attrs.get("noise"),
-                            "url": attrs.get("url"),
-                            "created_at": attrs.get("created_at"),
-                        }
-
-                meta = data.get("meta", {})
-                total_pages = meta.get("total_pages", 1)
-                if page >= total_pages:
-                    break
-                page += 1
+            # The Rootly API silently ignores filter[short_id], so we use
+            # filter[search] (which works) and verify the match client-side
+            # to guard against fuzzy hits on summary/description.
+            response = await make_authenticated_request(
+                "GET",
+                "/v1/alerts",
+                params={
+                    "filter[search]": alert_short_id,
+                    "page[size]": 10,
+                    "fields[alerts]": "id,summary,status,started_at,ended_at,short_id,source,description,noise,alert_urgency_id,url,created_at",
+                },
+            )
+            response.raise_for_status()
+            for alert in response.json().get("data", []):
+                attrs = alert.get("attributes", {})
+                if attrs.get("short_id") == alert_short_id:
+                    return {
+                        "id": alert.get("id"),
+                        "short_id": attrs.get("short_id"),
+                        "summary": attrs.get("summary"),
+                        "status": attrs.get("status"),
+                        "source": attrs.get("source"),
+                        "description": attrs.get("description"),
+                        "started_at": attrs.get("started_at"),
+                        "ended_at": attrs.get("ended_at"),
+                        "noise": attrs.get("noise"),
+                        "url": attrs.get("url"),
+                        "created_at": attrs.get("created_at"),
+                    }
 
             return mcp_error.tool_error(
                 f"Alert with short_id '{alert_short_id}' not found",

--- a/tests/unit/test_alert_tools.py
+++ b/tests/unit/test_alert_tools.py
@@ -34,21 +34,30 @@ class FakeMCPError:
         return {"error": True, "error_type": error_type, "message": error_message}
 
 
-def _alert(short_id: str, alert_id: str = "alert-uuid", **attrs: Any) -> dict:
+def _ok_response(alert: dict) -> Mock:
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"data": alert}
+    return response
+
+
+def _alert_payload(short_id: str = "PhIQtP", alert_id: str = "alert-uuid") -> dict:
     return {
         "id": alert_id,
         "type": "alerts",
         "attributes": {
             "short_id": short_id,
-            "summary": attrs.get("summary", "test summary"),
-            "status": attrs.get("status", "triggered"),
-            "source": attrs.get("source", "datadog"),
-            "description": attrs.get("description", ""),
-            "started_at": attrs.get("started_at"),
-            "ended_at": attrs.get("ended_at"),
-            "noise": attrs.get("noise", False),
-            "url": attrs.get("url"),
-            "created_at": attrs.get("created_at"),
+            "summary": "Disk full on web-01",
+            "status": "triggered",
+            "source": "datadog",
+            "description": "free space below 5%",
+            "started_at": "2026-05-19T17:00:00Z",
+            "ended_at": None,
+            "noise": False,
+            "url": f"https://rootly.com/account/alerts/{short_id}",
+            "created_at": "2026-05-19T17:00:00Z",
+            "alert_urgency_id": "urgency-1",
         },
     }
 
@@ -63,66 +72,50 @@ def _register() -> tuple[dict, AsyncMock]:
 @pytest.mark.unit
 class TestGetAlertByShortId:
     @pytest.mark.asyncio
-    async def test_makes_single_api_call_with_search_filter(self):
+    async def test_uses_direct_point_lookup_endpoint(self):
         tools, request = _register()
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = {"data": [_alert(short_id="PhIQtP")]}
-        request.return_value = response
+        request.return_value = _ok_response(_alert_payload(short_id="PhIQtP"))
 
         result = await tools["get_alert_by_short_id"]("PhIQtP")
 
         assert request.call_count == 1
-        _, kwargs = request.call_args
-        assert kwargs["params"]["filter[search]"] == "PhIQtP"
-        assert "page[number]" not in kwargs["params"]
+        args, kwargs = request.call_args
+        assert args == ("GET", "/v1/alerts/PhIQtP")
+        # No list params, no filter — pure point GET.
+        assert "params" not in kwargs or not kwargs.get("params")
         assert result["short_id"] == "PhIQtP"
+        assert result["summary"] == "Disk full on web-01"
 
     @pytest.mark.asyncio
     async def test_extracts_short_id_from_url(self):
         tools, request = _register()
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = {"data": [_alert(short_id="PhIQtP")]}
-        request.return_value = response
+        request.return_value = _ok_response(_alert_payload(short_id="PhIQtP"))
 
         result = await tools["get_alert_by_short_id"](
             "https://rootly.com/account/alerts/PhIQtP"
         )
 
-        _, kwargs = request.call_args
-        assert kwargs["params"]["filter[search]"] == "PhIQtP"
+        args, _ = request.call_args
+        assert args == ("GET", "/v1/alerts/PhIQtP")
         assert result["short_id"] == "PhIQtP"
 
     @pytest.mark.asyncio
-    async def test_filters_out_fuzzy_search_false_positives(self):
-        """filter[search] is fuzzy across summary/description.
-        We must verify the short_id exactly, not return the first hit.
-        """
+    async def test_url_encodes_short_id(self):
+        """Defensive: even though short_ids are alphanumeric in practice,
+        anything reaching the path segment must be URL-encoded."""
         tools, request = _register()
-        response = Mock()
-        response.raise_for_status.return_value = None
-        # Search returns an alert whose summary contains "PhIQtP" but
-        # whose short_id is different.
-        response.json.return_value = {
-            "data": [
-                _alert(short_id="ABCxyz", summary="related to alert PhIQtP"),
-                _alert(short_id="PhIQtP", summary="the actual one"),
-            ]
-        }
-        request.return_value = response
+        request.return_value = _ok_response(_alert_payload(short_id="x/y"))
 
-        result = await tools["get_alert_by_short_id"]("PhIQtP")
+        await tools["get_alert_by_short_id"]("a b")
 
-        assert result["short_id"] == "PhIQtP"
-        assert result["summary"] == "the actual one"
+        args, _ = request.call_args
+        assert args == ("GET", "/v1/alerts/a%20b")
 
     @pytest.mark.asyncio
-    async def test_returns_not_found_in_a_single_call(self):
+    async def test_returns_not_found_on_404(self):
         tools, request = _register()
         response = Mock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = {"data": []}
+        response.status_code = 404
         request.return_value = response
 
         result = await tools["get_alert_by_short_id"]("DOESNTEXIST")

--- a/tests/unit/test_alert_tools.py
+++ b/tests/unit/test_alert_tools.py
@@ -1,0 +1,144 @@
+"""Unit tests for custom alert MCP tool functions."""
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from rootly_mcp_server.tools.alerts import register_alert_tools
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str | None = None, **_: Any):
+        def decorator(fn):
+            self.tools[name or fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+class FakeMCPError:
+    @staticmethod
+    def categorize_error(exception: Exception) -> tuple[str, str]:
+        return (exception.__class__.__name__, str(exception))
+
+    @staticmethod
+    def tool_error(
+        error_message: str,
+        error_type: str = "execution_error",
+        details: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {"error": True, "error_type": error_type, "message": error_message}
+
+
+def _alert(short_id: str, alert_id: str = "alert-uuid", **attrs: Any) -> dict:
+    return {
+        "id": alert_id,
+        "type": "alerts",
+        "attributes": {
+            "short_id": short_id,
+            "summary": attrs.get("summary", "test summary"),
+            "status": attrs.get("status", "triggered"),
+            "source": attrs.get("source", "datadog"),
+            "description": attrs.get("description", ""),
+            "started_at": attrs.get("started_at"),
+            "ended_at": attrs.get("ended_at"),
+            "noise": attrs.get("noise", False),
+            "url": attrs.get("url"),
+            "created_at": attrs.get("created_at"),
+        },
+    }
+
+
+def _register() -> tuple[dict, AsyncMock]:
+    mcp = FakeMCP()
+    request = AsyncMock()
+    register_alert_tools(mcp=mcp, make_authenticated_request=request, mcp_error=FakeMCPError())
+    return mcp.tools, request
+
+
+@pytest.mark.unit
+class TestGetAlertByShortId:
+    @pytest.mark.asyncio
+    async def test_makes_single_api_call_with_search_filter(self):
+        tools, request = _register()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"data": [_alert(short_id="PhIQtP")]}
+        request.return_value = response
+
+        result = await tools["get_alert_by_short_id"]("PhIQtP")
+
+        assert request.call_count == 1
+        _, kwargs = request.call_args
+        assert kwargs["params"]["filter[search]"] == "PhIQtP"
+        assert "page[number]" not in kwargs["params"]
+        assert result["short_id"] == "PhIQtP"
+
+    @pytest.mark.asyncio
+    async def test_extracts_short_id_from_url(self):
+        tools, request = _register()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"data": [_alert(short_id="PhIQtP")]}
+        request.return_value = response
+
+        result = await tools["get_alert_by_short_id"](
+            "https://rootly.com/account/alerts/PhIQtP"
+        )
+
+        _, kwargs = request.call_args
+        assert kwargs["params"]["filter[search]"] == "PhIQtP"
+        assert result["short_id"] == "PhIQtP"
+
+    @pytest.mark.asyncio
+    async def test_filters_out_fuzzy_search_false_positives(self):
+        """filter[search] is fuzzy across summary/description.
+        We must verify the short_id exactly, not return the first hit.
+        """
+        tools, request = _register()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        # Search returns an alert whose summary contains "PhIQtP" but
+        # whose short_id is different.
+        response.json.return_value = {
+            "data": [
+                _alert(short_id="ABCxyz", summary="related to alert PhIQtP"),
+                _alert(short_id="PhIQtP", summary="the actual one"),
+            ]
+        }
+        request.return_value = response
+
+        result = await tools["get_alert_by_short_id"]("PhIQtP")
+
+        assert result["short_id"] == "PhIQtP"
+        assert result["summary"] == "the actual one"
+
+    @pytest.mark.asyncio
+    async def test_returns_not_found_in_a_single_call(self):
+        tools, request = _register()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"data": []}
+        request.return_value = response
+
+        result = await tools["get_alert_by_short_id"]("DOESNTEXIST")
+
+        assert request.call_count == 1
+        assert result == {
+            "error": True,
+            "error_type": "not_found",
+            "message": "Alert with short_id 'DOESNTEXIST' not found",
+        }
+
+    @pytest.mark.asyncio
+    async def test_validates_empty_short_id(self):
+        tools, request = _register()
+
+        result = await tools["get_alert_by_short_id"]("   ")
+
+        assert request.call_count == 0
+        assert result["error_type"] == "validation_error"

--- a/tests/unit/test_alert_tools.py
+++ b/tests/unit/test_alert_tools.py
@@ -91,9 +91,7 @@ class TestGetAlertByShortId:
         tools, request = _register()
         request.return_value = _ok_response(_alert_payload(short_id="PhIQtP"))
 
-        result = await tools["get_alert_by_short_id"](
-            "https://rootly.com/account/alerts/PhIQtP"
-        )
+        result = await tools["get_alert_by_short_id"]("https://rootly.com/account/alerts/PhIQtP")
 
         args, _ = request.call_args
         assert args == ("GET", "/v1/alerts/PhIQtP")


### PR DESCRIPTION
## Summary

`get_alert_by_short_id` was paginating through up to **20 pages × 100 alerts = 2,000 records** sequentially, scanning each page client-side for a `short_id` match. Replaces the scan with a **single point GET on `/v1/alerts/{short_id}`**.

## Why

Diagnosed from Datadog p95 latency telemetry:

| Tool | Baseline p95 | Worst p95 |
|---|---|---|
| `get_alert_by_short_id` | 2-3s | **41s** (2026-05-19 17:00 UTC) |

The 41s outlier wasn't mysterious — it's `20 × (a slightly-slow upstream call)`. Sequential pagination compounds any single API blip 20×. The same window showed `get_oncall_handoff_summary` spiking too, confirming an upstream slowdown that fanned out through both tools' sequential call patterns.

Three problems with the old design:
1. **Not-found is always slow.** Every miss did 20 round trips before returning the error. Mistyped short_ids cost 10+ seconds.
2. **Silent data loss at scale.** Workspaces with >2,000 alerts silently returned "not found" for older alerts that do exist.
3. **N+1 by design.** A database scan implemented over HTTP.

## Approach

`GET /v1/alerts/{id}` accepts the alert `short_id` in addition to the UUID (verified against the live API — undocumented but supported). One point GET, exact match, no fuzzy filtering, no client-side equality check.

| Approach | Calls | Latency |
|---|---|---|
| Old (scan up to 20 pages) | 1-20 sequential | 2-3s baseline, 41s worst |
| First commit (`filter[search]` + equality check) | 1 list call | ~400ms |
| **Final (`GET /v1/alerts/{short_id}`)** | **1 point GET** | **~150-300ms** |

## Expected impact

- p95 drops from 2-3s → ~200ms
- 41s outliers disappear (one upstream blip ≠ twenty)
- Not-found becomes fast — no more 10s for typos
- No more silent ceiling at 2,000 alerts
- Same code path works for UUIDs (bonus: callers who somehow have the UUID get the same fast path)

## Test plan

- [x] 5 unit tests in `tests/unit/test_alert_tools.py`:
  - uses direct point-lookup endpoint
  - extracts short_id from a full URL
  - URL-encodes the short_id defensively
  - returns not_found on 404
  - validates empty short_id without hitting the API
- [x] Full suite: 453 passed, 1 skipped, 0 failed
- [x] Pre-commit checks pass (pyright, ruff)
- [ ] Verify post-deploy in Datadog: `pc95:@duration_ms` on `@tool_name:get_alert_by_short_id` should plateau well below 1s