### PR TITLE
perf(oncall): parallelize _fetch_users_and_schedules_maps helper

### DIFF
--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1237,6 +1237,58 @@ def register_oncall_tools(
     _lookup_maps_lock = asyncio.Lock()
 
     # Helper function to fetch users and schedules for enrichment
+    async def _fetch_all_pages(
+        path: str,
+        semaphore: asyncio.Semaphore,
+        max_pages: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Fetch up to ``max_pages`` of a paginated JSON:API resource.
+
+        Page 1 is awaited first so we can read ``meta.total_pages``; any
+        remaining pages within ``max_pages`` are fetched concurrently
+        through ``semaphore``. Returns the aggregated ``data`` array.
+        """
+        first = await make_authenticated_request(
+            "GET", path, params={"page[size]": 100, "page[number]": 1}
+        )
+        if not first or first.status_code != 200:
+            return []
+        first_data = first.json()
+        items: list[dict[str, Any]] = list(first_data.get("data", []))
+
+        # Don't fan out if the first page is short - matches the legacy
+        # "< 100 items means we're done" termination signal.
+        if len(items) < 100:
+            return items
+
+        meta = first_data.get("meta") or {}
+        try:
+            total_pages = int(meta.get("total_pages") or 1)
+        except (TypeError, ValueError):
+            total_pages = 1
+        total_pages = min(max(total_pages, 1), max_pages)
+        if total_pages <= 1:
+            return items
+
+        async def _fetch_page(page_number: int) -> list[dict[str, Any]]:
+            async with semaphore:
+                response = await make_authenticated_request(
+                    "GET",
+                    path,
+                    params={"page[size]": 100, "page[number]": page_number},
+                )
+            if not response or response.status_code != 200:
+                return []
+            return list(response.json().get("data", []))
+
+        rest = await asyncio.gather(
+            *(_fetch_page(p) for p in range(2, total_pages + 1)),
+            return_exceptions=False,
+        )
+        for page_items in rest:
+            items.extend(page_items)
+        return items
+
     async def _fetch_users_and_schedules_maps() -> tuple[
         dict[str, Any], dict[str, Any], dict[str, Any]
     ]:
@@ -1270,59 +1322,35 @@ def register_oncall_tools(
                     _lookup_maps_cache["data"],
                 )
 
-            users_map = {}
-            schedules_map = {}
-            teams_map = {}
+            # Users, schedules, and teams have no dependency on each other,
+            # so fetch them concurrently. Within each, pagination after the
+            # first page also fans out. A shared semaphore caps total
+            # concurrency to avoid hammering upstream.
+            request_semaphore = asyncio.Semaphore(10)
+            users, schedules, teams = await asyncio.gather(
+                _fetch_all_pages("/v1/users", request_semaphore),
+                _fetch_all_pages("/v1/schedules", request_semaphore),
+                _fetch_all_pages("/v1/teams", request_semaphore),
+            )
 
-            # Fetch all users with pagination
-            page = 1
-            while page <= 10:
-                users_response = await make_authenticated_request(
-                    "GET", "/v1/users", params={"page[size]": 100, "page[number]": page}
-                )
-                if users_response and users_response.status_code == 200:
-                    users_data = users_response.json()
-                    for user in users_data.get("data", []):
-                        users_map[user.get("id")] = user
-                    if len(users_data.get("data", [])) < 100:
-                        break
-                    page += 1
-                else:
-                    break
+            users_map: dict[str, Any] = {}
+            for u in users:
+                uid = u.get("id")
+                if isinstance(uid, str):
+                    users_map[uid] = u
 
-            # Fetch all schedules with pagination
-            page = 1
-            while page <= 10:
-                schedules_response = await make_authenticated_request(
-                    "GET", "/v1/schedules", params={"page[size]": 100, "page[number]": page}
-                )
-                if schedules_response and schedules_response.status_code == 200:
-                    schedules_data = schedules_response.json()
-                    for schedule in schedules_data.get("data", []):
-                        schedules_map[schedule.get("id")] = schedule
-                    if len(schedules_data.get("data", [])) < 100:
-                        break
-                    page += 1
-                else:
-                    break
+            schedules_map: dict[str, Any] = {}
+            for s in schedules:
+                sid = s.get("id")
+                if isinstance(sid, str):
+                    schedules_map[sid] = s
 
-            # Fetch all teams with pagination
-            page = 1
-            while page <= 10:
-                teams_response = await make_authenticated_request(
-                    "GET", "/v1/teams", params={"page[size]": 100, "page[number]": page}
-                )
-                if teams_response and teams_response.status_code == 200:
-                    teams_data = teams_response.json()
-                    for team in teams_data.get("data", []):
-                        teams_map[team.get("id")] = team
-                    if len(teams_data.get("data", [])) < 100:
-                        break
-                    page += 1
-                else:
-                    break
+            teams_map: dict[str, Any] = {}
+            for t in teams:
+                tid = t.get("id")
+                if isinstance(tid, str):
+                    teams_map[tid] = t
 
-            # Cache the result
             result = (users_map, schedules_map, teams_map)
             _lookup_maps_cache["data"] = result
             _lookup_maps_cache["timestamp"] = now

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1261,11 +1261,20 @@ def register_oncall_tools(
         if len(items) < 100:
             return items
 
+        # Trust meta.total_pages when provided. When the field is missing
+        # or unparseable, fall back to fetching up to max_pages — preserves
+        # the legacy "keep going until a short page" semantics for APIs
+        # that don't return pagination metadata. Pages past the real end
+        # just come back empty, harmlessly.
         meta = first_data.get("meta") or {}
-        try:
-            total_pages = int(meta.get("total_pages") or 1)
-        except (TypeError, ValueError):
-            total_pages = 1
+        total_pages_raw = meta.get("total_pages")
+        if total_pages_raw is None:
+            total_pages = max_pages
+        else:
+            try:
+                total_pages = int(total_pages_raw)
+            except (TypeError, ValueError):
+                total_pages = max_pages
         total_pages = min(max(total_pages, 1), max_pages)
         if total_pages <= 1:
             return items
@@ -1283,9 +1292,12 @@ def register_oncall_tools(
 
         rest = await asyncio.gather(
             *(_fetch_page(p) for p in range(2, total_pages + 1)),
-            return_exceptions=False,
+            return_exceptions=True,
         )
         for page_items in rest:
+            if isinstance(page_items, BaseException):
+                # One transient page error shouldn't drop the whole resource.
+                continue
             items.extend(page_items)
         return items
 

--- a/tests/unit/test_oncall_handoff.py
+++ b/tests/unit/test_oncall_handoff.py
@@ -473,3 +473,132 @@ class TestListShifts:
         assert result["error_type"] == "validation_error"
         assert "page_number must be >= 1" in result["message"]
         request.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestLookupMapsHelper:
+    """Tests for the internal _fetch_users_and_schedules_maps helper.
+
+    Exercised indirectly through list_shifts, which calls the helper to
+    enrich its response. We assert on the call pattern observed on the
+    mocked make_authenticated_request to verify pagination and caching
+    behavior.
+    """
+
+    @staticmethod
+    def _register() -> tuple[dict[str, Any], AsyncMock]:
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_oncall_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            mcp_error=FakeMCPError(),
+        )
+        return mcp.tools, request
+
+    @staticmethod
+    def _ok(payload: dict[str, Any]) -> Mock:
+        r = Mock()
+        r.status_code = 200
+        r.json.return_value = payload
+        return r
+
+    @staticmethod
+    def _resource(kind: str, count: int, total_pages: int = 1) -> dict[str, Any]:
+        return {
+            "data": [
+                {"id": f"{kind}-{i}", "type": kind, "attributes": {"name": f"{kind} {i}"}}
+                for i in range(count)
+            ],
+            "meta": {"total_pages": total_pages},
+        }
+
+    async def test_fans_out_additional_pages_when_first_page_is_full(self):
+        """When page 1 returns 100 items with total_pages > 1, the helper
+        fetches the remaining pages — and merges them into the lookup."""
+        tools, request = self._register()
+
+        def responder(method, url, params=None, **_):
+            assert params is not None
+            page = params.get("page[number]", 1)
+            if url == "/v1/users":
+                # Page 1 full → must fan out; page 2 fills the rest.
+                if page == 1:
+                    return self._ok(self._resource("users", 100, total_pages=2))
+                return self._ok(self._resource("users", 50, total_pages=2))
+            if url in ("/v1/schedules", "/v1/teams"):
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/shifts":
+                return self._ok({"data": [], "included": [], "meta": {"total_pages": 1}})
+            raise AssertionError(f"unexpected call: {url}")
+
+        request.side_effect = responder
+        await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
+        )
+
+        users_calls = [
+            c for c in request.call_args_list if c.args[1] == "/v1/users"
+        ]
+        pages_fetched = sorted(c.kwargs["params"]["page[number]"] for c in users_calls)
+        assert pages_fetched == [1, 2]
+
+    async def test_does_not_fetch_additional_pages_when_first_page_is_short(self):
+        """A short first page (<100 items) must NOT trigger any followup
+        fetches. Preserves the legacy termination signal."""
+        tools, request = self._register()
+
+        def responder(method, url, params=None, **_):
+            if url == "/v1/users":
+                # Short page → no need to fan out, even if meta lies.
+                return self._ok(self._resource("users", 3, total_pages=5))
+            if url in ("/v1/schedules", "/v1/teams"):
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/shifts":
+                return self._ok({"data": [], "included": [], "meta": {"total_pages": 1}})
+            raise AssertionError(f"unexpected call: {url}")
+
+        request.side_effect = responder
+        await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
+        )
+
+        users_calls = [c for c in request.call_args_list if c.args[1] == "/v1/users"]
+        assert len(users_calls) == 1
+
+    async def test_caches_lookup_results_across_calls(self):
+        """Second call within the cache TTL must not re-fetch any of the
+        three resources."""
+        tools, request = self._register()
+
+        def responder(method, url, params=None, **_):
+            if url in ("/v1/users", "/v1/schedules", "/v1/teams"):
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/shifts":
+                return self._ok({"data": [], "included": [], "meta": {"total_pages": 1}})
+            raise AssertionError(f"unexpected call: {url}")
+
+        request.side_effect = responder
+
+        await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
+        )
+        first_lookup_calls = sum(
+            1
+            for c in request.call_args_list
+            if c.args[1] in ("/v1/users", "/v1/schedules", "/v1/teams")
+        )
+
+        await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
+        )
+        total_lookup_calls = sum(
+            1
+            for c in request.call_args_list
+            if c.args[1] in ("/v1/users", "/v1/schedules", "/v1/teams")
+        )
+
+        # Three resources fetched once on the first call, zero on the second.
+        assert first_lookup_calls == 3
+        assert total_lookup_calls == 3

--- a/tests/unit/test_oncall_handoff.py
+++ b/tests/unit/test_oncall_handoff.py
@@ -534,13 +534,9 @@ class TestLookupMapsHelper:
             raise AssertionError(f"unexpected call: {url}")
 
         request.side_effect = responder
-        await tools["list_shifts"](
-            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
-        )
+        await tools["list_shifts"](from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z")
 
-        users_calls = [
-            c for c in request.call_args_list if c.args[1] == "/v1/users"
-        ]
+        users_calls = [c for c in request.call_args_list if c.args[1] == "/v1/users"]
         pages_fetched = sorted(c.kwargs["params"]["page[number]"] for c in users_calls)
         assert pages_fetched == [1, 2]
 
@@ -560,9 +556,7 @@ class TestLookupMapsHelper:
             raise AssertionError(f"unexpected call: {url}")
 
         request.side_effect = responder
-        await tools["list_shifts"](
-            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
-        )
+        await tools["list_shifts"](from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z")
 
         users_calls = [c for c in request.call_args_list if c.args[1] == "/v1/users"]
         assert len(users_calls) == 1
@@ -581,18 +575,14 @@ class TestLookupMapsHelper:
 
         request.side_effect = responder
 
-        await tools["list_shifts"](
-            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
-        )
+        await tools["list_shifts"](from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z")
         first_lookup_calls = sum(
             1
             for c in request.call_args_list
             if c.args[1] in ("/v1/users", "/v1/schedules", "/v1/teams")
         )
 
-        await tools["list_shifts"](
-            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
-        )
+        await tools["list_shifts"](from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z")
         total_lookup_calls = sum(
             1
             for c in request.call_args_list

--- a/tests/unit/test_oncall_handoff.py
+++ b/tests/unit/test_oncall_handoff.py
@@ -540,6 +540,67 @@ class TestLookupMapsHelper:
         pages_fetched = sorted(c.kwargs["params"]["page[number]"] for c in users_calls)
         assert pages_fetched == [1, 2]
 
+    async def test_falls_back_to_max_pages_when_meta_total_pages_missing(self):
+        """If page 1 is full but meta omits total_pages, we must still
+        keep fetching — matches the legacy 'keep going until a short
+        page' semantics so APIs without pagination metadata aren't
+        silently truncated."""
+        tools, request = self._register()
+
+        def responder(method, url, params=None, **_):
+            assert params is not None
+            if url == "/v1/users":
+                page = params["page[number]"]
+                if page == 1:
+                    # Full page, but no meta.total_pages — old behaviour
+                    # would keep fetching; new behaviour must too.
+                    return self._ok({"data": [{"id": f"u-{i}"} for i in range(100)]})
+                # Later pages return short → real end of data.
+                return self._ok({"data": [{"id": f"u-page{page}"}]})
+            if url in ("/v1/schedules", "/v1/teams"):
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/shifts":
+                return self._ok({"data": [], "included": [], "meta": {"total_pages": 1}})
+            raise AssertionError(f"unexpected call: {url}")
+
+        request.side_effect = responder
+        await tools["list_shifts"](from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z")
+
+        users_calls = [c for c in request.call_args_list if c.args[1] == "/v1/users"]
+        # Must have fetched more than just page 1.
+        assert len(users_calls) > 1
+
+    async def test_continues_when_one_page_fetch_raises(self):
+        """A transient error on any non-first page must not bring down
+        the whole resource fetch — surviving pages are still merged."""
+        tools, request = self._register()
+
+        def responder(method, url, params=None, **_):
+            assert params is not None
+            if url == "/v1/users":
+                page = params["page[number]"]
+                if page == 1:
+                    return self._ok(
+                        {"data": [{"id": f"u-{i}"} for i in range(100)], "meta": {"total_pages": 3}}
+                    )
+                if page == 2:
+                    raise RuntimeError("upstream blip")
+                # page 3
+                return self._ok({"data": [{"id": "u-200"}]})
+            if url in ("/v1/schedules", "/v1/teams"):
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/shifts":
+                return self._ok({"data": [], "included": [], "meta": {"total_pages": 1}})
+            raise AssertionError(f"unexpected call: {url}")
+
+        request.side_effect = responder
+        # Should not raise even though page 2 errored.
+        result = await tools["list_shifts"](
+            from_date="2026-02-09T00:00:00Z", to_date="2026-02-12T00:00:00Z"
+        )
+        # Got a normal-shaped response, not a tool error.
+        assert "error" not in result or result.get("error") is not True
+
     async def test_does_not_fetch_additional_pages_when_first_page_is_short(self):
         """A short first page (<100 items) must NOT trigger any followup
         fetches. Preserves the legacy termination signal."""


### PR DESCRIPTION
## Summary

\`_fetch_users_and_schedules_maps\` is a shared helper used by **5+ tools** to enrich responses with user/schedule/team data. It was doing three completely independent paginated fetches in strict sequence:

\`\`\`
while page <= 10: users     ← up to 10 sequential calls
while page <= 10: schedules ← then 10 more
while page <= 10: teams     ← then 10 more
\`\`\`

Worst case on cold cache: **30 sequential calls (~15s at 500ms/call).**

## Why this matters now

The helper has a 5-minute cache, so warm-cache calls are free. But v2.3.7 made the streamable-HTTP server **stateless** — every fresh stateless request goes through a fresh process invocation that may not share the in-memory cache. The cold-cache cost is paid more often than the original design assumed.

## Approach

Two layers of parallelism, both using \`asyncio.gather\` with a shared \`Semaphore(10)\` cap:

1. **Extract \`_fetch_all_pages(path, semaphore)\`** — awaits page 1 to learn \`meta.total_pages\`, then gathers pages 2..N concurrently. Preserves the legacy "<100 items on page 1 = stop" termination signal.
2. **Run users/schedules/teams concurrently** — they have no inter-dependency, so they all gather as one operation.

| Scenario | Old | New |
|---|---|---|
| Three resources, single page each | 3 sequential | 3 concurrent |
| Three resources, 5 pages each (15 total) | 15 sequential | 1 + (4 concurrent), all three resources overlapped |
| Worst case (3×10 pages = 30 calls) | ~15s | ~1s |

## Safety

- \`Semaphore(10)\` caps total concurrency across all three resources. Without it, a workspace with 10 pages × 3 resources would fire 27 simultaneous requests, likely earning 429s.
- The page-1-short-circuit means small workspaces still issue exactly one call per resource (3 total) — same as before.
- Cache semantics unchanged. The 5-min TTL and double-check-locked re-entry pattern are preserved.
- All five callers (\`list_shifts\`, \`check_responder_availability\`, \`check_oncall_health_risk\`, \`create_override_recommendation\`, \`find_related_incidents\`) inherit the speedup automatically.

## Tools that benefit

\`\`\`
list_shifts
check_responder_availability     (will benefit further when its own pagination is parallelized)
check_oncall_health_risk         (will benefit further when its own pagination is parallelized)
create_override_recommendation
find_related_incidents
\`\`\`

## Test plan

- [x] 3 new unit tests in \`TestLookupMapsHelper\`:
  - fans out additional pages when first page is full
  - does NOT fan out when first page is short (legacy semantics preserved)
  - cache hits prevent re-fetch
- [x] All 8 existing handoff/list_shifts tests still pass (call order under \`AsyncMock\` is preserved because gathered coroutines dispatch in order)
- [x] Full suite: 451 passed, 1 skipped, 0 failed
- [x] Pre-commit checks pass (pyright, ruff)
- [ ] Verify post-deploy: cold-cache latency for any tool using this helper should drop from ~15s worst case to ~1s