### PR TITLE
fix(oncall): paginate schedules in get_oncall_shift_metrics

### DIFF
--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -157,37 +157,13 @@ def register_oncall_tools(
                 "to": end_date,
             }
 
-            # Fetch schedules (schedules don't have team relationship, they have owner_group_ids)
-            schedules_response = await make_authenticated_request(
-                "GET", "/v1/schedules", params={"page[size]": 100}
-            )
-
-            if schedules_response is None:
-                return mcp_error.tool_error(
-                    "Failed to get schedules: API request returned None", "execution_error"
-                )
-
-            schedules_response.raise_for_status()
-            schedules_data = schedules_response.json()
-
-            all_schedules = schedules_data.get("data", [])
-
-            # Collect all unique team IDs from schedules' owner_group_ids
-            team_ids_set = set()
-            for schedule in all_schedules:
-                owner_group_ids = schedule.get("attributes", {}).get("owner_group_ids", [])
-                team_ids_set.update(owner_group_ids)
-
-            # Fetch all teams
-            teams_map = {}
-            if team_ids_set:
-                teams_response = await make_authenticated_request(
-                    "GET", "/v1/teams", params={"page[size]": 100}
-                )
-                if teams_response and teams_response.status_code == 200:
-                    teams_data = teams_response.json()
-                    for team in teams_data.get("data", []):
-                        teams_map[team.get("id")] = team
+            # Fetch all schedules and teams via the shared paginated, cached
+            # helper. The previous direct call to /v1/schedules and /v1/teams
+            # fetched only page 1, silently truncating to 100 records each —
+            # which in workspaces with deeper history produced incomplete
+            # team filtering and missing entries in the schedule→team map.
+            _, schedules_map, teams_map = await _fetch_users_and_schedules_maps()
+            all_schedules = list(schedules_map.values())
 
             # Build schedule -> team mapping
             schedule_to_team_map = {}

--- a/tests/unit/test_oncall_handoff.py
+++ b/tests/unit/test_oncall_handoff.py
@@ -820,9 +820,7 @@ class TestGetOncallShiftMetrics:
             if url == "/v1/teams":
                 return self._ok({"data": [], "meta": {"total_pages": 1}})
             if url == "/v1/shifts":
-                return self._ok(
-                    {"data": [], "included": [], "meta": {"total_pages": 1}}
-                )
+                return self._ok({"data": [], "included": [], "meta": {"total_pages": 1}})
             raise AssertionError(f"unexpected call: {url}")
 
         request.side_effect = responder

--- a/tests/unit/test_oncall_handoff.py
+++ b/tests/unit/test_oncall_handoff.py
@@ -754,3 +754,88 @@ class TestLookupMapsHelper:
         # Three resources fetched once on the first call, zero on the second.
         assert first_lookup_calls == 3
         assert total_lookup_calls == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGetOncallShiftMetrics:
+    """Regression coverage for get_oncall_shift_metrics paginated schedules.
+
+    Before the fix, get_oncall_shift_metrics fetched only page 1 of
+    /v1/schedules (no pagination loop), so workspaces with more than 100
+    schedules silently truncated the schedule->team map. Filtering by a
+    team that owned schedules on page 2+ would drop all of them from the
+    metrics.
+    """
+
+    @staticmethod
+    def _register() -> tuple[dict[str, Any], AsyncMock]:
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_oncall_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            mcp_error=FakeMCPError(),
+        )
+        return mcp.tools, request
+
+    @staticmethod
+    def _ok(payload: dict[str, Any]) -> Mock:
+        r = Mock()
+        r.status_code = 200
+        r.raise_for_status.return_value = None
+        r.json.return_value = payload
+        return r
+
+    async def test_uses_paginated_schedules_for_team_filtering(self):
+        """A schedule owned by the filter team but living on schedules
+        page 2 must still appear in the resulting params."""
+        tools, request = self._register()
+
+        # Page 1: 100 schedules, all owned by team-other.
+        page1 = [
+            {
+                "id": f"sched-page1-{i}",
+                "attributes": {"name": f"S{i}", "owner_group_ids": ["team-other"]},
+            }
+            for i in range(100)
+        ]
+        # Page 2: the schedule we want, owned by the target team.
+        page2 = [
+            {
+                "id": "sched-on-page-2",
+                "attributes": {"name": "Target", "owner_group_ids": ["team-target"]},
+            }
+        ]
+
+        def responder(method, url, params=None, **_):
+            assert params is not None
+            if url == "/v1/schedules":
+                page = params.get("page[number]", 1)
+                if page == 1:
+                    return self._ok({"data": page1, "meta": {"total_pages": 2}})
+                return self._ok({"data": page2, "meta": {"total_pages": 2}})
+            if url == "/v1/users":
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/teams":
+                return self._ok({"data": [], "meta": {"total_pages": 1}})
+            if url == "/v1/shifts":
+                return self._ok(
+                    {"data": [], "included": [], "meta": {"total_pages": 1}}
+                )
+            raise AssertionError(f"unexpected call: {url}")
+
+        request.side_effect = responder
+
+        await tools["get_oncall_shift_metrics"](
+            start_date="2026-05-01",
+            end_date="2026-05-31",
+            team_ids="team-target",
+        )
+
+        # The shifts call must include the page-2 schedule in its filter.
+        shifts_calls = [c for c in request.call_args_list if c.args[1] == "/v1/shifts"]
+        assert len(shifts_calls) >= 1
+        target_call = shifts_calls[0]
+        schedule_ids_param = target_call.kwargs["params"].get("schedule_ids[]", [])
+        assert "sched-on-page-2" in schedule_ids_param


### PR DESCRIPTION
## Summary

\`get_oncall_shift_metrics\` was fetching only **page 1** of \`/v1/schedules\` and \`/v1/teams\` — no pagination loop at all. In workspaces with more than 100 schedules this silently truncated the schedule→team map, causing team-id filtering to drop any schedules owned by teams whose schedules live past page 1.

A metrics tool quietly producing incomplete data is worse than a slow one — there's no error, no warning, just wrong numbers.

## Approach

Delegate to \`_fetch_users_and_schedules_maps()\`, the shared paginated + cached helper. The function gets:
- Correct pagination (via the \`_fetch_all_pages\` helper introduced in #114)
- 5-minute caching across calls
- The parallelism wins from #114 for free

The \`teams_map\` structure and all downstream metric-building logic are unchanged.

Diff is mostly deletions: ~38 lines of single-page-only code replaced with a single call to the helper.

## Test plan

- [x] New regression test \`TestGetOncallShiftMetrics.test_uses_paginated_schedules_for_team_filtering\`:
  - Sets up a workspace where the target schedule is owned by the filter team but lives on schedules page 2
  - Asserts the shifts query includes that schedule in its \`schedule_ids[]\` filter
  - Would fail against the previous one-page implementation
- [x] Full suite: 462 passed, 1 skipped, 0 failed
- [x] Pre-commit checks pass (pyright, ruff)