### PR TITLE
fix(incidents): collapse listIncidents/list_incidents tool duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ With 150+ tools available, you may want to configure focused subsets for optimal
 *Essential tools for emergency responders and incident commanders*
 
 ```bash
-ROOTLY_MCP_ENABLED_TOOLS="listIncidents,getIncident,createIncident,updateIncident,search_incidents,find_related_incidents,suggest_solutions,createIncidentActionItem,listIncidentActionItems,updateIncidentFormFieldSelection,listTeams,getCurrentUser,listServices,listSeverities,getAlert,listAlerts,updateAlert,listEscalationPolicies,getEscalationPolicy,listOnCallRoles,listSchedules,getScheduleShifts,get_oncall_handoff_summary,get_shift_incidents,list_endpoints"
+ROOTLY_MCP_ENABLED_TOOLS="list_incidents,getIncident,createIncident,updateIncident,search_incidents,find_related_incidents,suggest_solutions,createIncidentActionItem,listIncidentActionItems,updateIncidentFormFieldSelection,listTeams,getCurrentUser,listServices,listSeverities,getAlert,listAlerts,updateAlert,listEscalationPolicies,getEscalationPolicy,listOnCallRoles,listSchedules,getScheduleShifts,get_oncall_handoff_summary,get_shift_incidents,list_endpoints"
 ```
 
 ### 📅 On-Call Management (35 tools)  
@@ -408,7 +408,7 @@ ROOTLY_MCP_ENABLED_TOOLS="getIncident,updateIncident,find_related_incidents,sugg
 *For leadership and metrics teams (read-only focus)*
 
 ```bash
-ROOTLY_MCP_ENABLED_TOOLS="listIncidents,search_incidents,collect_incidents,listTeams,listServices,listSchedules,get_oncall_shift_metrics,get_shift_incidents,listDashboards,getDashboard,listAlerts,listHeartbeats,listPulses,getCurrentUser,list_endpoints"
+ROOTLY_MCP_ENABLED_TOOLS="list_incidents,search_incidents,collect_incidents,listTeams,listServices,listSchedules,get_oncall_shift_metrics,get_shift_incidents,listDashboards,getDashboard,listAlerts,listHeartbeats,listPulses,getCurrentUser,list_endpoints"
 ```
 
 ### Multiple MCP Instances for Different Teams
@@ -422,7 +422,7 @@ You can run multiple MCP instances with different tool subsets:
       "command": "uvx", "args": ["--from", "rootly-mcp-server", "rootly-mcp-server"],
       "env": {
         "ROOTLY_API_TOKEN": "<token>",
-        "ROOTLY_MCP_ENABLED_TOOLS": "listIncidents,getIncident,createIncident,find_related_incidents,suggest_solutions..."
+        "ROOTLY_MCP_ENABLED_TOOLS": "list_incidents,getIncident,createIncident,find_related_incidents,suggest_solutions..."
       }
     },
     "rootly-oncall-management": {
@@ -566,7 +566,7 @@ listIncidentActionItems
 listIncidentAlerts
 listIncidentFormFieldSelections
 listIncident_Types
-listIncidents
+listIncidents  (deprecated alias — use `list_incidents`)
 listOnCallRoles
 listOnCallShadows
 listOverrideShifts

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -100,9 +100,7 @@ def _strip_curated_override_operations(
         ]
         for method in methods_to_drop:
             path_item.pop(method, None)
-        if not any(
-            m.lower() in ("get", "post", "put", "patch", "delete") for m in path_item
-        ):
+        if not any(m.lower() in ("get", "post", "put", "patch", "delete") for m in path_item):
             paths_to_drop.append(path)
     for path in paths_to_drop:
         del paths[path]
@@ -463,10 +461,13 @@ def create_rootly_mcp_server(
     swagger_spec = _load_swagger_spec(swagger_path)
     logger.info(f"Loaded Swagger spec with {len(swagger_spec.get('paths', {}))} total paths")
 
-    # When an allowlist is provided, restrict the OpenAPI spec filter to entries that
-    # are real operationIds. Curated tool names (registered later via @mcp.tool) won't
-    # appear in the spec — we let them through to the post-registration validation step
-    # below instead of wiping the autogen spec to empty here.
+    # When an allowlist is provided, build the subset that matches real OpenAPI
+    # operationIds; curated tool names (registered later via @mcp.tool) won't appear
+    # in the spec and are validated separately after registration.
+    #
+    # An empty subset is meaningful: it tells `_filter_openapi_spec` to drop every
+    # autogen operation, which is the right behavior when the caller asked only for
+    # curated tools (e.g. `ROOTLY_MCP_ENABLED_TOOLS=list_incidents`).
     autogen_allowlist: set[str] | None = None
     if enabled_tools:
         all_op_ids = server_defaults.collect_operation_ids(swagger_spec.get("paths", {}))

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -77,6 +77,37 @@ DEFAULT_WRITE_ALLOWED_PATHS = server_defaults.DEFAULT_WRITE_ALLOWED_PATHS
 RootlyMCPServer = legacy_server.RootlyMCPServer
 
 
+def _strip_curated_override_operations(
+    spec: dict[str, Any], override_ids: frozenset[str] | set[str]
+) -> None:
+    """Remove operations from `spec.paths` whose operationId is in `override_ids`.
+
+    Mutates the spec in place. Paths that end up with no operations are also removed.
+    """
+    if not override_ids:
+        return
+    paths = spec.get("paths", {})
+    paths_to_drop: list[str] = []
+    for path, path_item in paths.items():
+        if not isinstance(path_item, dict):
+            continue
+        methods_to_drop = [
+            method
+            for method, op in path_item.items()
+            if method.lower() in ("get", "post", "put", "patch", "delete")
+            and isinstance(op, dict)
+            and op.get("operationId") in override_ids
+        ]
+        for method in methods_to_drop:
+            path_item.pop(method, None)
+        if not any(
+            m.lower() in ("get", "post", "put", "patch", "delete") for m in path_item
+        ):
+            paths_to_drop.append(path)
+    for path in paths_to_drop:
+        del paths[path]
+
+
 def _fingerprint_auth_header(auth_header: str) -> str:
     """Hash auth header token for non-reversible identity correlation."""
     if not auth_header:
@@ -408,6 +439,8 @@ def create_rootly_mcp_server(
         enable_write_tools = server_defaults.write_tools_enabled_from_env(default=True)
     if enabled_tools is None:
         enabled_tools = server_defaults.enabled_tools_from_env()
+    if enabled_tools:
+        enabled_tools = server_defaults.canonicalize_tool_names(enabled_tools)
     if delete_allowed_paths is None:
         delete_allowed_paths = []
     if write_allowed_paths is None:
@@ -430,6 +463,15 @@ def create_rootly_mcp_server(
     swagger_spec = _load_swagger_spec(swagger_path)
     logger.info(f"Loaded Swagger spec with {len(swagger_spec.get('paths', {}))} total paths")
 
+    # When an allowlist is provided, restrict the OpenAPI spec filter to entries that
+    # are real operationIds. Curated tool names (registered later via @mcp.tool) won't
+    # appear in the spec — we let them through to the post-registration validation step
+    # below instead of wiping the autogen spec to empty here.
+    autogen_allowlist: set[str] | None = None
+    if enabled_tools:
+        all_op_ids = server_defaults.collect_operation_ids(swagger_spec.get("paths", {}))
+        autogen_allowlist = enabled_tools & all_op_ids
+
     # Filter the OpenAPI spec to only include allowed paths
     filtered_spec = _filter_openapi_spec(
         swagger_spec,
@@ -437,47 +479,16 @@ def create_rootly_mcp_server(
         delete_allowed_paths=delete_allowed_paths_v1,
         write_allowed_paths=write_allowed_paths_v1,
         enable_write_tools=enable_write_tools,
-        enabled_operation_ids=enabled_tools,
+        enabled_operation_ids=autogen_allowlist,
     )
 
-    # Validate enabled tools against the filtered spec (after path filtering)
-    if enabled_tools:
-        valid_tools, invalid_tools = server_defaults.validate_tool_names(
-            enabled_tools, filtered_spec.get("paths", {})
-        )
+    # Drop operations whose operationId is provided by a curated `@mcp.tool(name=...)`
+    # registration. Without this, FastMCP's OpenAPIProvider would register an autogen
+    # tool with the same name as our curated tool, producing duplicate entries.
+    _strip_curated_override_operations(
+        filtered_spec, server_defaults.CURATED_OVERRIDE_OPERATION_IDS
+    )
 
-        if invalid_tools:
-            audit.audit.log_configuration_error(
-                "invalid_tool_names",
-                f"Invalid tool names in allowlist after filtering: {', '.join(invalid_tools)}",
-                {"invalid_tools": invalid_tools, "valid_tools": list(valid_tools)},
-            )
-            logger.warning(
-                "Invalid tool names in allowlist (will be ignored): %s. "
-                "Use --list-tools to see available options.",
-                ", ".join(sorted(invalid_tools)),
-            )
-
-        if not valid_tools and enabled_tools:
-            error_msg = "No valid tools found in allowlist after path filtering"
-            audit.audit.log_configuration_error(
-                "no_valid_tools", error_msg, {"requested_tools": list(enabled_tools)}
-            )
-            raise ValueError(error_msg)
-
-        # Log validation results
-        audit.audit.log_tool_validation(enabled_tools, valid_tools, invalid_tools)
-
-        # Update the filtered spec to only include valid tools
-        if valid_tools != enabled_tools:
-            filtered_spec = _filter_openapi_spec(
-                swagger_spec,
-                allowed_paths_v1,
-                delete_allowed_paths=delete_allowed_paths_v1,
-                write_allowed_paths=write_allowed_paths_v1,
-                enable_write_tools=enable_write_tools,
-                enabled_operation_ids=valid_tools,
-            )
     logger.info(f"Filtered spec to {len(filtered_spec.get('paths', {}))} allowed paths")
 
     # Log server configuration for audit trail
@@ -742,18 +753,65 @@ def create_rootly_mcp_server(
         mcp_error=MCPError,
     )
 
+    # Validate the allowlist against the fully-registered tool set (autogen + curated).
+    # This must happen after all register_*_tools() calls so curated tool names — which
+    # aren't OpenAPI operationIds — are recognized as valid.
     if enabled_tools is not None:
-        component_names = [
-            component.name
-            for component_key, component in mcp._local_provider._components.items()  # noqa: SLF001
-            if component_key.startswith("tool:") and getattr(component, "name", None)
-        ]
-        for tool_name in component_names:
-            if tool_name not in enabled_tools:
+        registered_names: set[str] = set()
+        for provider in mcp.providers:
+            # LocalProvider stores curated tools in `_components` keyed `tool:<name>`.
+            components = getattr(provider, "_components", None)
+            if components:
+                for component_key, component in components.items():
+                    if component_key.startswith("tool:") and getattr(component, "name", None):
+                        registered_names.add(component.name)
+            # OpenAPIProvider stores autogen tools in `_tools` keyed by name.
+            autogen_tools = getattr(provider, "_tools", None)
+            if isinstance(autogen_tools, dict):
+                registered_names.update(autogen_tools.keys())
+
+        valid_tools = enabled_tools & registered_names
+        invalid_tools = sorted(enabled_tools - registered_names)
+
+        if invalid_tools:
+            audit.audit.log_configuration_error(
+                "invalid_tool_names",
+                f"Invalid tool names in allowlist: {', '.join(invalid_tools)}",
+                {"invalid_tools": invalid_tools, "valid_tools": sorted(valid_tools)},
+            )
+            logger.warning(
+                "Invalid tool names in allowlist (will be ignored): %s. "
+                "Use --list-tools to see available options.",
+                ", ".join(invalid_tools),
+            )
+
+        if not valid_tools:
+            error_msg = "No valid tools found in allowlist"
+            audit.audit.log_configuration_error(
+                "no_valid_tools", error_msg, {"requested_tools": sorted(enabled_tools)}
+            )
+            raise ValueError(error_msg)
+
+        audit.audit.log_tool_validation(enabled_tools, valid_tools, invalid_tools)
+
+        # `remove_tool` operates on the LocalProvider only — curated tools live there.
+        # Autogen OpenAPI tools were already constrained by `enabled_operation_ids` at
+        # spec-filter time, so they shouldn't appear here outside `valid_tools`. If one
+        # does (e.g. a future code path adds tools via another provider), skip it
+        # rather than crash on KeyError from a provider that doesn't own the name.
+        for tool_name in registered_names:
+            if tool_name in valid_tools:
+                continue
+            try:
                 mcp.local_provider.remove_tool(tool_name)
+            except KeyError:
+                logger.debug(
+                    "Skipping removal of %r — not owned by LocalProvider",
+                    tool_name,
+                )
         logger.info(
             "Applied MCP tool allowlist: %s",
-            ", ".join(sorted(enabled_tools)),
+            ", ".join(sorted(valid_tools)),
         )
 
     # In hosted HTTP modes, configure ASGI middleware for auth token capture.

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -135,38 +135,6 @@ def collect_operation_ids(paths: dict) -> set[str]:
     return op_ids
 
 
-def validate_tool_names(
-    enabled_tools: set[str],
-    available_operations: dict,
-    extra_known_tools: set[str] | None = None,
-) -> tuple[set[str], list[str]]:
-    """
-    Validate tool names against available OpenAPI operations and any curated extras.
-
-    Args:
-        enabled_tools: Set of tool names to validate
-        available_operations: OpenAPI paths dict from swagger spec
-        extra_known_tools: Additional valid tool names registered outside the OpenAPI
-            spec (e.g. curated `@mcp.tool()` registrations). Curated tools won't have
-            an operationId in the spec, so they must be passed in here to avoid being
-            flagged as invalid.
-
-    Returns:
-        tuple: (valid_tools, invalid_tools)
-    """
-    if not enabled_tools:
-        return set(), []
-
-    available_tool_names = collect_operation_ids(available_operations)
-    if extra_known_tools:
-        available_tool_names |= extra_known_tools
-
-    valid_tools = enabled_tools & available_tool_names
-    invalid_tools = list(enabled_tools - available_tool_names)
-
-    return valid_tools, invalid_tools
-
-
 def enabled_tools_from_env() -> set[str] | None:
     """Return an optional explicit allowlist of MCP tool names to expose."""
     return _parse_csv_set(os.getenv(EnvVars.ENABLED_TOOLS))

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -33,6 +33,50 @@ def _parse_csv_set(raw: str | None) -> set[str] | None:
     return parsed or None
 
 
+# Legacy tool names that have been replaced by curated equivalents.
+# Kept callable via proxy registration; allowlists referencing the legacy name
+# are transparently resolved to the canonical name with a deprecation warning.
+LEGACY_TOOL_ALIASES: dict[str, str] = {
+    "listIncidents": "list_incidents",
+}
+
+
+# OpenAPI operationIds that must be removed from the autogen spec because a
+# curated `@mcp.tool(name=...)` registration provides the implementation for
+# that exact name. Without this exclusion, FastMCP's OpenAPIProvider and
+# LocalProvider would each register a tool under the same name, producing
+# duplicate entries in `tools/list`.
+CURATED_OVERRIDE_OPERATION_IDS: frozenset[str] = frozenset(
+    {
+        "listIncidents",  # overridden by the deprecated proxy in tools/incidents.py
+    }
+)
+
+
+def canonicalize_tool_names(enabled_tools: set[str]) -> set[str]:
+    """Expand legacy tool names in an allowlist to also include their canonical replacements.
+
+    Under posture A (deprecated-proxy) the legacy name remains callable; we keep it
+    in the allowlist alongside the canonical so both the proxy and the new tool stay
+    exposed. A deprecation warning is emitted per legacy name encountered.
+    """
+    if not enabled_tools:
+        return enabled_tools
+    resolved: set[str] = set(enabled_tools)
+    for name in enabled_tools:
+        canonical = LEGACY_TOOL_ALIASES.get(name)
+        if canonical:
+            logger.warning(
+                "ROOTLY_MCP_ENABLED_TOOLS entry %r is deprecated; %r will be exposed alongside it. "
+                "Update your configuration to use %r directly — the legacy name will be removed in a future release.",
+                name,
+                canonical,
+                canonical,
+            )
+            resolved.add(canonical)
+    return resolved
+
+
 def _generate_recommendation(solution_data: dict) -> str:
     """Generate a high-level recommendation based on solution analysis."""
     solutions = solution_data.get("solutions", [])
@@ -79,15 +123,33 @@ def write_tools_enabled_from_env(default: bool = False) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
+def collect_operation_ids(paths: dict) -> set[str]:
+    """Return the set of operationIds defined in an OpenAPI paths object."""
+    op_ids: set[str] = set()
+    for path_data in paths.values():
+        if not isinstance(path_data, dict):
+            continue
+        for method_data in path_data.values():
+            if isinstance(method_data, dict) and (operation_id := method_data.get("operationId")):
+                op_ids.add(operation_id)
+    return op_ids
+
+
 def validate_tool_names(
-    enabled_tools: set[str], available_operations: dict
+    enabled_tools: set[str],
+    available_operations: dict,
+    extra_known_tools: set[str] | None = None,
 ) -> tuple[set[str], list[str]]:
     """
-    Validate tool names against available OpenAPI operations.
+    Validate tool names against available OpenAPI operations and any curated extras.
 
     Args:
         enabled_tools: Set of tool names to validate
         available_operations: OpenAPI paths dict from swagger spec
+        extra_known_tools: Additional valid tool names registered outside the OpenAPI
+            spec (e.g. curated `@mcp.tool()` registrations). Curated tools won't have
+            an operationId in the spec, so they must be passed in here to avoid being
+            flagged as invalid.
 
     Returns:
         tuple: (valid_tools, invalid_tools)
@@ -95,12 +157,9 @@ def validate_tool_names(
     if not enabled_tools:
         return set(), []
 
-    # Extract all available operation IDs from OpenAPI spec
-    available_tool_names = set()
-    for path_data in available_operations.values():
-        for method_data in path_data.values():
-            if isinstance(method_data, dict) and (operation_id := method_data.get("operationId")):
-                available_tool_names.add(operation_id)
+    available_tool_names = collect_operation_ids(available_operations)
+    if extra_known_tools:
+        available_tool_names |= extra_known_tools
 
     valid_tools = enabled_tools & available_tool_names
     invalid_tools = list(enabled_tools - available_tool_names)

--- a/src/rootly_mcp_server/spec_transform.py
+++ b/src/rootly_mcp_server/spec_transform.py
@@ -457,14 +457,15 @@ def _filter_openapi_spec(
                                 }
                             )
 
-                # Add sparse fieldsets for incidents endpoints to reduce payload size
+                # Add sparse fieldsets for incidents endpoints to reduce payload size.
+                # Optional with a default so LLMs aren't pushed to override it — the default
+                # already produces a compact payload.
                 if "incident" in path.lower():
-                    # Add fields[incidents] parameter with essential fields only - make it required with default
                     operation["parameters"].append(
                         {
                             "name": "fields[incidents]",
                             "in": "query",
-                            "required": True,
+                            "required": False,
                             "schema": {
                                 "type": "string",
                                 "default": "id,title,summary,status,severity,created_at,updated_at,url,started_at",
@@ -473,9 +474,9 @@ def _filter_openapi_spec(
                         }
                     )
 
-                # Add include parameter for incidents endpoints to minimize relationships
+                # Add include parameter for incidents endpoints to minimize relationships.
+                # Optional with an empty default — relationships are heavy and rarely needed.
                 if "incident" in path.lower():
-                    # Check if include parameter already exists
                     include_param_exists = any(
                         param.get("name") == "include" for param in operation["parameters"]
                     )
@@ -484,7 +485,7 @@ def _filter_openapi_spec(
                             {
                                 "name": "include",
                                 "in": "query",
-                                "required": True,
+                                "required": False,
                                 "schema": {
                                     "type": "string",
                                     "default": "",

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Literal, cast
@@ -9,6 +10,8 @@ from typing import Annotated, Any, Literal, cast
 from pydantic import Field
 
 from ..smart_utils import SolutionExtractor, TextSimilarityAnalyzer
+
+logger = logging.getLogger(__name__)
 
 JsonDict = dict[str, Any]
 MakeAuthenticatedRequest = Callable[..., Awaitable[Any]]
@@ -447,6 +450,115 @@ def register_incident_tools(
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(JsonDict, mcp_error.tool_error(error_message, error_type))
+
+    @mcp.tool(name="listIncidents")
+    async def list_incidents_legacy(
+        query: Annotated[
+            str,
+            Field(description="Optional free-text search across incident titles and summaries"),
+        ] = "",
+        teams: Annotated[
+            str,
+            Field(description="Comma-separated team names or slugs to filter incidents"),
+        ] = "",
+        team_ids: Annotated[
+            str,
+            Field(description="Comma-separated Rootly team IDs to filter incidents"),
+        ] = "",
+        service_ids: Annotated[
+            str,
+            Field(description="Comma-separated Rootly service IDs to filter incidents"),
+        ] = "",
+        severity: Annotated[
+            str,
+            Field(description="Optional severity filter (e.g., critical, high, medium, low)"),
+        ] = "",
+        status: Annotated[
+            str,
+            Field(description="Optional incident status filter"),
+        ] = "",
+        started_after: Annotated[
+            str,
+            Field(description="Filter incidents that started at or after this ISO 8601 timestamp"),
+        ] = "",
+        started_before: Annotated[
+            str,
+            Field(description="Filter incidents that started at or before this ISO 8601 timestamp"),
+        ] = "",
+        custom_field_selected_option_ids: Annotated[
+            str,
+            Field(description="Comma-separated custom field option IDs"),
+        ] = "",
+        sort: Annotated[
+            Literal["created_at", "-created_at", "updated_at", "-updated_at"],
+            Field(description="Sort order"),
+        ] = "-created_at",
+        page_size: Annotated[
+            int,
+            Field(description="Number of incidents per page (max: 100)", ge=1, le=100),
+        ] = 25,
+        page_number: Annotated[
+            int,
+            Field(description="Page number to retrieve (1-indexed)", ge=1),
+        ] = 1,
+        fields_incidents: Annotated[
+            str,
+            Field(
+                description="[Deprecated] Sparse fieldset is now handled internally; this parameter is ignored."
+            ),
+        ] = "",
+        include: Annotated[
+            str,
+            Field(
+                description="[Deprecated] Related-resource inclusion is now handled internally; this parameter is ignored."
+            ),
+        ] = "",
+        filter_status: Annotated[
+            str,
+            Field(description="[Legacy] Mapped to `status` if `status` is not provided."),
+        ] = "",
+        filter_severity: Annotated[
+            str,
+            Field(description="[Legacy] Mapped to `severity` if `severity` is not provided."),
+        ] = "",
+        filter_started_at_gte: Annotated[
+            str,
+            Field(description="[Legacy] Mapped to `started_after` if not provided."),
+        ] = "",
+        filter_started_at_lte: Annotated[
+            str,
+            Field(description="[Legacy] Mapped to `started_before` if not provided."),
+        ] = "",
+    ) -> JsonDict:
+        """⚠️ DEPRECATED — use `list_incidents` instead.
+
+        This is a backward-compatibility shim for clients that have the legacy
+        `listIncidents` tool name pinned (e.g. in `ROOTLY_MCP_ENABLED_TOOLS` or
+        cached agent configs). It forwards to `list_incidents` and will be
+        removed in a future release. Update your configuration to call
+        `list_incidents` directly.
+        """
+        logger.warning(
+            "Deprecated tool 'listIncidents' invoked; forwarding to 'list_incidents'. "
+            "Update callers to use 'list_incidents' directly — the legacy name will be removed."
+        )
+        return cast(
+            JsonDict,
+            await list_incidents(
+                query=query,
+                teams=teams,
+                team_ids=team_ids,
+                service_ids=service_ids,
+                severity=severity or filter_severity,
+                status=status or filter_status,
+                started_after=started_after or filter_started_at_gte,
+                started_before=started_before or filter_started_at_lte,
+                custom_field_selected_option_ids=custom_field_selected_option_ids,
+                sort=sort,
+                page_size=page_size,
+                page_number=page_number,
+            ),
+        )
 
     @mcp.tool()
     async def collect_incidents(

--- a/src/rootly_mcp_server/tools/resources.py
+++ b/src/rootly_mcp_server/tools/resources.py
@@ -214,7 +214,7 @@ Updated: {attributes.get("updated_at", "N/A")}"""
         guide_content = """🎯 ROOTLY WORKFLOW GUIDE
 
 🚨 INCIDENT RESPONSE WORKFLOW:
-1️⃣ Check ongoing incidents: listIncidents(status="open,investigating")
+1️⃣ Check ongoing incidents: list_incidents(status="open,investigating")
 2️⃣ Create new incident: createIncident(title="...", summary="...")
 3️⃣ Find similar past incidents: find_related_incidents(incident_description="...")
 4️⃣ Get solution suggestions: suggest_solutions(incident_id="...")

--- a/tests/integration/local/test_tool_allowlists.py
+++ b/tests/integration/local/test_tool_allowlists.py
@@ -84,9 +84,14 @@ def _terminate_process(process: subprocess.Popen[str]) -> str:
     ("enabled_tools", "enable_write_tools", "expected_tools"),
     [
         (
+            "list_incidents,getIncident,listTeams",
+            False,
+            ["getIncident", "listTeams", "list_incidents"],
+        ),
+        (
             "listIncidents,getIncident,listTeams",
             False,
-            ["getIncident", "listIncidents", "listTeams"],
+            ["getIncident", "listIncidents", "listTeams", "list_incidents"],
         ),
         (
             "createIncident,createWorkflowTask,listTeams",

--- a/tests/integration/remote/test_essential.py
+++ b/tests/integration/remote/test_essential.py
@@ -85,9 +85,11 @@ class ContainerClient:
         # based on the Rootly API spec.
 
         # These are the tools that should be available based on our OpenAPI filtering
+        # and curated tool registrations.
         expected_tools = [
-            "search_incidents",  # Our custom tool
-            "listIncidents",  # OpenAPI generated
+            "search_incidents",  # Curated tool
+            "list_incidents",  # Curated tool (canonical name for listing incidents)
+            "listIncidents",  # Curated deprecated proxy forwarding to list_incidents
             "createIncident",
             "listTeams",
             "listAlerts",
@@ -238,8 +240,9 @@ class TestContainerServerEssentials:
         # Verify critical tools that users depend on
         assert "search_incidents" in tool_names, "search_incidents tool missing"
 
-        # Verify some standard OpenAPI tools
-        expected_tools = ["listIncidents", "listTeams"]
+        # Verify canonical curated incident tool and a standard OpenAPI tool.
+        # `listIncidents` is also exposed as a deprecated proxy for backward compat.
+        expected_tools = ["list_incidents", "listTeams"]
         for tool in expected_tools:
             assert tool in tool_names, f"Expected tool {tool} not found"
 

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -469,9 +469,7 @@ class TestBundledIncidentFormFieldSelectionTools:
 
         assert "list_incidents" in tool_names
 
-    async def test_list_incidents_legacy_allowlist_exposes_both_names(
-        self, mock_environment_token
-    ):
+    async def test_list_incidents_legacy_allowlist_exposes_both_names(self, mock_environment_token):
         """Posture A: legacy `listIncidents` in the allowlist must keep both
         the proxy and the canonical name exposed during the deprecation window."""
         server = create_rootly_mcp_server(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -452,6 +452,56 @@ class TestBundledIncidentFormFieldSelectionTools:
 
         assert tool_names == {"listTeams", "listSeverities"}
 
+    async def test_list_incidents_canonical_name_in_allowlist_does_not_raise(
+        self, mock_environment_token
+    ):
+        """Regression: `ROOTLY_MCP_ENABLED_TOOLS=list_incidents` used to raise
+        ValueError because validation ran against OpenAPI operationIds before the
+        curated tool registered. The allowlist now validates against the full
+        registry post-registration."""
+        server = create_rootly_mcp_server(
+            hosted=False,
+            enabled_tools={"list_incidents"},
+        )
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "list_incidents" in tool_names
+
+    async def test_list_incidents_legacy_allowlist_exposes_both_names(
+        self, mock_environment_token
+    ):
+        """Posture A: legacy `listIncidents` in the allowlist must keep both
+        the proxy and the canonical name exposed during the deprecation window."""
+        server = create_rootly_mcp_server(
+            hosted=False,
+            enabled_tools={"listIncidents"},
+        )
+
+        tools = await server.list_tools()
+        tool_names = {tool.name for tool in tools}
+
+        assert "list_incidents" in tool_names
+        assert "listIncidents" in tool_names
+
+    async def test_single_incident_list_tool_invariant(self, mock_environment_token):
+        """Regression: only one canonical incident-list tool should exist.
+        The autogen `listIncidents` is overwritten by the curated proxy; no
+        third copy should sneak in. (`list_incidents` is a separately-named
+        curated tool and is the canonical surface.)"""
+        server = create_rootly_mcp_server(hosted=False)
+
+        tools = await server.list_tools()
+        tool_names = sorted(tool.name for tool in tools)
+
+        # Expect exactly these two names targeting GET /incidents:
+        list_variants = [n for n in tool_names if n in ("list_incidents", "listIncidents")]
+        assert list_variants == ["listIncidents", "list_incidents"], (
+            f"Unexpected incident-list tool surface: {list_variants}. "
+            "Should be exactly ['listIncidents', 'list_incidents'] under posture A."
+        )
+
 
 @pytest.mark.unit
 class TestAuthenticatedHTTPXClient:

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 from rootly_mcp_server.server_defaults import (
     DEFAULT_ALLOWED_PATHS,
+    LEGACY_TOOL_ALIASES,
     _generate_recommendation,
+    canonicalize_tool_names,
     enabled_tools_from_env,
 )
 
@@ -91,3 +93,24 @@ class TestServerDefaultsModule:
             clear=True,
         ):
             assert enabled_tools_from_env() == {"list_incidents", "getIncident", "listTeams"}
+
+    def test_canonicalize_passes_through_canonical_names(self):
+        assert canonicalize_tool_names({"list_incidents", "getIncident"}) == {
+            "list_incidents",
+            "getIncident",
+        }
+
+    def test_canonicalize_expands_legacy_to_include_canonical(self):
+        # Posture A: legacy name stays in the set (so the proxy remains exposed)
+        # AND the canonical name is added (so new clients also see it).
+        assert canonicalize_tool_names({"listIncidents"}) == {"listIncidents", "list_incidents"}
+
+    def test_canonicalize_handles_mixed_allowlist(self):
+        result = canonicalize_tool_names({"listIncidents", "getIncident", "listTeams"})
+        assert result == {"listIncidents", "list_incidents", "getIncident", "listTeams"}
+
+    def test_canonicalize_empty_set(self):
+        assert canonicalize_tool_names(set()) == set()
+
+    def test_legacy_aliases_contains_list_incidents(self):
+        assert LEGACY_TOOL_ALIASES.get("listIncidents") == "list_incidents"

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -707,7 +707,9 @@ class TestStructuredListIncidentsTool:
         )
 
         request.assert_awaited_once()
-        params = request.await_args.kwargs["params"]
+        await_args = request.await_args
+        assert await_args is not None
+        params = await_args.kwargs["params"]
         assert params["filter[status]"] == "investigating"
         assert params["filter[severity]"] == "high"
         assert params["filter[started_at][gte]"] == "2026-01-01T00:00:00Z"

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -648,6 +648,75 @@ class TestStructuredListIncidentsTool:
         assert "list_incidents" in tools
 
     @pytest.mark.asyncio
+    async def test_list_incidents_legacy_proxy_is_registered(self):
+        """The deprecated `listIncidents` name must remain callable as a proxy
+        until the deprecation window closes — see IMPLEMENTATION_PLAN posture A."""
+        tools, _ = self._register_tools()
+
+        assert "listIncidents" in tools, (
+            "listIncidents proxy must be registered alongside list_incidents to keep "
+            "legacy callers working during the deprecation window"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_legacy_proxy_forwards_to_canonical(self):
+        """Calling the deprecated `listIncidents` should produce the same upstream
+        request as calling `list_incidents` with equivalent args."""
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"data": [], "meta": {}}
+        request.return_value = response
+
+        await tools["listIncidents"](
+            status="open",
+            severity="critical",
+            page_size=5,
+            page_number=2,
+        )
+
+        request.assert_awaited_once()
+        await_args = request.await_args
+        assert await_args is not None
+        method, url = await_args.args
+        params = await_args.kwargs["params"]
+        assert method == "GET"
+        assert url == "/v1/incidents"
+        # Curated list_incidents converts these to filter[...] / page[...] form
+        assert params["filter[status]"] == "open"
+        assert params["filter[severity]"] == "critical"
+        assert params["page[size]"] == 5
+        assert params["page[number]"] == 2
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_legacy_proxy_maps_filter_aliases(self):
+        """Legacy `filter_*` autogen-style kwargs should be mapped to curated names
+        when the curated equivalent isn't supplied."""
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"data": [], "meta": {}}
+        request.return_value = response
+
+        await tools["listIncidents"](
+            filter_status="investigating",
+            filter_severity="high",
+            filter_started_at_gte="2026-01-01T00:00:00Z",
+            fields_incidents="this,should,be,ignored",
+            include="should,also,be,ignored",
+        )
+
+        request.assert_awaited_once()
+        params = request.await_args.kwargs["params"]
+        assert params["filter[status]"] == "investigating"
+        assert params["filter[severity]"] == "high"
+        assert params["filter[started_at][gte]"] == "2026-01-01T00:00:00Z"
+        # Deprecated params must NOT leak through to the upstream request — the
+        # curated tool's internal sparse-fieldset value is what should win.
+        assert "this,should,be,ignored" not in params.get("fields[incidents]", "")
+        assert "should,also,be,ignored" not in params.get("include", "")
+
+    @pytest.mark.asyncio
     async def test_list_incidents_passes_structured_filters_and_returns_compact_results(self):
         tools, request = self._register_tools()
         response = Mock()


### PR DESCRIPTION
## Summary

The server was exposing two competing incident-listing tools — a curated `list_incidents` (snake_case) and an auto-generated `listIncidents` (camelCase) with a different schema. LLM clients (observed: VS Code Copilot) conflated the two: calling `list_incidents` with `fields_incidents` (an autogen-only kwarg) raised `Unexpected keyword argument`, and the fallback `listIncidents` returned a 22.4 KB payload that exceeded the client's read limit.

Root cause is twofold:

1. `spec_transform.py` injected `fields[incidents]` and `include` as **required with defaults** on every incident endpoint — a known LLM-confusion pattern that pushed agents to pass params they shouldn't need to set.
2. Curated `list_incidents` and autogen `listIncidents` coexisted in different FastMCP providers (LocalProvider vs OpenAPIProvider), so `@mcp.tool(name="listIncidents")` did not actually overwrite the autogen tool — both showed up in `tools/list`.

## Changes

- **spec_transform**: flip `required: True` → `False` on the injected sparse-fieldset params. Defaults still flow through.
- **tools/incidents**: register a deprecated `listIncidents` proxy that forwards to `list_incidents`, logs a per-call warning, and accepts legacy `filter_*` / `fields_incidents` / `include` kwargs (mapped where possible, ignored otherwise).
- **server_defaults**:
  - `LEGACY_TOOL_ALIASES = {"listIncidents": "list_incidents"}`
  - `canonicalize_tool_names()` — expands legacy allowlist entries to also include the canonical name (additive, so the proxy stays exposed during the deprecation window).
  - `CURATED_OVERRIDE_OPERATION_IDS` — operationIds dropped from the autogen spec before FastMCP registers them, preventing the duplicate.
- **server**:
  - Allowlist validation moved to **after** all curated tool registration. Fixes a latent `ValueError` where `ROOTLY_MCP_ENABLED_TOOLS=list_incidents` raised because the curated name isn't an OpenAPI operationId.
  - Enumerate registered tools across all FastMCP providers (not just LocalProvider).
  - `_strip_curated_override_operations()` removes overridden operations from the filtered spec.
- **Docs**: README and `resources.py` workflow guide now recommend `list_incidents`. `listIncidents` is marked as a deprecated alias.
- **Tests**: unit coverage for `canonicalize_tool_names`, the legacy proxy's parameter mapping/forwarding, the allowlist-validation regression, and a single-tool invariant for the `/incidents` GET surface.

## Compatibility

Posture A (deprecated proxy). Non-breaking for runtime callers and for `ROOTLY_MCP_ENABLED_TOOLS=listIncidents`-style allowlists. The legacy name remains callable for one or two minor releases; the description explicitly directs callers to migrate.

## Test plan

- [x] Unit suite (432 tests) — `pytest tests/unit/ --no-cov`
- [x] Ruff lint clean
- [x] mypy clean on changed files (pre-existing `requests` stub warnings unrelated)
- [ ] Manually verify in a live Copilot/Claude Desktop session that `listIncidents` still works and emits the deprecation warning
- [ ] Manually verify that `ROOTLY_MCP_ENABLED_TOOLS=list_incidents` no longer raises at server start