### PR TITLE
feat: add optional mcpcat tracking hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ COPY . .
 # Install the package and its dependencies
 RUN uv pip install --system --no-cache-dir -e .
 
+# Install MCPcat for hosted telemetry without changing the repo dependency graph.
+# MCPcat's current package metadata pins an older Pydantic range, but the SDK
+# imports successfully with our runtime pin, so we restore the server's pinned
+# version after installation.
+RUN pip install --no-cache-dir mcpcat==0.1.14 \
+    && pip install --no-cache-dir pydantic==2.13.4
+
 # Create non-root user
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN uv pip install --system --no-cache-dir -e .
 # MCPcat's current package metadata pins an older Pydantic range, but the SDK
 # imports successfully with our runtime pin, so we restore the server's pinned
 # version after installation.
-RUN pip install --no-cache-dir mcpcat==0.1.14 \
-    && pip install --no-cache-dir pydantic==2.13.4
+RUN uv pip install --system --no-cache-dir mcpcat==0.1.14 \
+    && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -7,6 +7,7 @@ This module provides the main entry point for the Rootly MCP Server.
 
 import argparse
 import asyncio
+import importlib
 import logging
 import os
 import sys
@@ -75,6 +76,28 @@ def streamable_http_stateless_enabled(*, hosted: bool, fastmcp_stateless_http: b
     if "FASTMCP_STATELESS_HTTP" in os.environ:
         return fastmcp_stateless_http
     return hosted
+
+
+def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging.Logger) -> None:
+    """Enable MCPcat tracking when configured and available.
+
+    The Python MCPcat package is currently deployed separately from the core
+    server dependency set, so we load it lazily and only when a project ID is
+    configured. This keeps the base server behavior unchanged for self-hosted
+    users and local development environments that do not install MCPcat.
+    """
+    if not project_id:
+        return
+
+    try:
+        mcpcat = importlib.import_module("mcpcat")
+    except ImportError:
+        logger.warning(
+            "ROOTLY_MCPCAT_PROJECT_ID is set but mcpcat is not installed; skipping MCPcat tracking"
+        )
+        return
+
+    mcpcat.track(server, project_id)
 
 
 def parse_args():
@@ -434,6 +457,7 @@ def main():
             if args.code_mode_path
             else code_mode_path_from_env()
         )
+        mcpcat_project_id = os.getenv("ROOTLY_MCPCAT_PROJECT_ID")
         server = create_rootly_mcp_server(
             swagger_path=args.swagger_path,
             name=args.name,
@@ -470,6 +494,10 @@ def main():
                     enabled_tools=enabled_tools,
                 )
                 logger.info("Code Mode enabled at path: %s", code_mode_path)
+
+        maybe_enable_mcpcat_tracking(server, mcpcat_project_id, logger)
+        if code_mode_server is not None:
+            maybe_enable_mcpcat_tracking(code_mode_server, mcpcat_project_id, logger)
 
         logger.info(f"Running server with transport: {normalized_transport}...")
         direct_streamable_stateless_http = streamable_http_stateless_enabled(

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -96,8 +96,10 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
             "ROOTLY_MCPCAT_PROJECT_ID is set but mcpcat is not installed; skipping MCPcat tracking"
         )
         return
-
-    mcpcat.track(server, project_id)
+    try:
+        mcpcat.track(server, project_id)
+    except Exception:
+        logger.warning("MCPcat tracking could not be enabled; skipping", exc_info=True)
 
 
 def parse_args():

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -10,6 +10,7 @@ from rootly_mcp_server.__main__ import (
     _get_sorted_tool_names,
     get_server,
     main,
+    maybe_enable_mcpcat_tracking,
     normalize_transport,
     streamable_http_stateless_enabled,
 )
@@ -99,6 +100,41 @@ def test_streamable_http_respects_explicit_fastmcp_setting():
 
     with patch.dict("os.environ", {"FASTMCP_STATELESS_HTTP": "true"}, clear=True):
         assert streamable_http_stateless_enabled(hosted=False, fastmcp_stateless_http=True) is True
+
+
+def test_maybe_enable_mcpcat_tracking_is_noop_without_project_id():
+    server = object()
+    logger = Mock()
+
+    with patch("rootly_mcp_server.__main__.importlib.import_module") as mock_import:
+        maybe_enable_mcpcat_tracking(server, None, logger)
+
+    mock_import.assert_not_called()
+
+
+def test_maybe_enable_mcpcat_tracking_logs_when_package_missing():
+    server = object()
+    logger = Mock()
+
+    with patch(
+        "rootly_mcp_server.__main__.importlib.import_module",
+        side_effect=ImportError,
+    ) as mock_import:
+        maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
+
+    mock_import.assert_called_once_with("mcpcat")
+    logger.warning.assert_called_once()
+
+
+def test_maybe_enable_mcpcat_tracking_tracks_when_available():
+    server = object()
+    logger = Mock()
+    mcpcat_module = SimpleNamespace(track=Mock())
+
+    with patch("rootly_mcp_server.__main__.importlib.import_module", return_value=mcpcat_module):
+        maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
+
+    mcpcat_module.track.assert_called_once_with(server, "proj_test_123")
 
 
 @pytest.mark.asyncio
@@ -191,3 +227,45 @@ def test_main_hosted_streamable_http_passes_stateless_default():
     fake_server.run.assert_called_once()
     assert fake_server.run.call_args.kwargs["transport"] == "streamable-http"
     assert fake_server.run.call_args.kwargs["stateless_http"] is True
+
+
+def test_main_tracks_main_and_code_mode_servers_when_mcpcat_project_id_set():
+    args = SimpleNamespace(
+        swagger_path=None,
+        log_level="ERROR",
+        name="Rootly",
+        transport="both",
+        debug=False,
+        base_url=None,
+        allowed_paths=None,
+        hosted=True,
+        enable_code_mode=True,
+        enable_write_tools=True,
+        enabled_tools=None,
+        list_tools=False,
+        code_mode_path=None,
+        host=False,
+    )
+    main_server = SimpleNamespace()
+    code_mode_server = SimpleNamespace()
+
+    with patch.dict("os.environ", {"ROOTLY_MCPCAT_PROJECT_ID": "proj_test_123"}, clear=True):
+        with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
+            with patch("rootly_mcp_server.__main__.setup_logging"):
+                with patch(
+                    "rootly_mcp_server.__main__.create_rootly_mcp_server",
+                    return_value=main_server,
+                ):
+                    with patch(
+                        "rootly_mcp_server.__main__.create_rootly_codemode_server",
+                        return_value=code_mode_server,
+                    ):
+                        with patch("rootly_mcp_server.__main__.run_dual_http_server"):
+                            with patch(
+                                "rootly_mcp_server.__main__.maybe_enable_mcpcat_tracking"
+                            ) as mock_track:
+                                main()
+
+    assert len(mock_track.call_args_list) == 2
+    assert mock_track.call_args_list[0].args[:2] == (main_server, "proj_test_123")
+    assert mock_track.call_args_list[1].args[:2] == (code_mode_server, "proj_test_123")

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -137,6 +137,21 @@ def test_maybe_enable_mcpcat_tracking_tracks_when_available():
     mcpcat_module.track.assert_called_once_with(server, "proj_test_123")
 
 
+def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
+    server = object()
+    logger = Mock()
+    mcpcat_module = SimpleNamespace(track=Mock(side_effect=RuntimeError("boom")))
+
+    with patch("rootly_mcp_server.__main__.importlib.import_module", return_value=mcpcat_module):
+        maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
+
+    mcpcat_module.track.assert_called_once_with(server, "proj_test_123")
+    logger.warning.assert_called_once_with(
+        "MCPcat tracking could not be enabled; skipping",
+        exc_info=True,
+    )
+
+
 @pytest.mark.asyncio
 async def test_get_sorted_tool_names_returns_sorted_names():
     server = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add an optional MCPcat tracking hook for the main MCP server and Code Mode server
- keep the hook env-gated and resilient when mcpcat is not installed
- install mcpcat in the hosted Docker image and restore the runtime pydantic pin afterward

## Testing
- uv run ruff check src/rootly_mcp_server/__main__.py tests/unit/test_main_transport.py
- uv run pyright src/rootly_mcp_server/__main__.py
- uv run pytest -q tests/unit/test_main_transport.py
- pre-commit unit suite (436 passed)
- docker build -t rootly-mcp-mcpcat-test .
- docker run --rm rootly-mcp-mcpcat-test python -c "import mcpcat, pydantic; print(pydantic.__version__)"
