### PR TITLE
feat: identify mcpcat users from hosted auth

### DIFF
--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -99,10 +99,10 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
         )
         return
 
-    options = mcpcat_types.MCPCatOptions(
-        identify=build_mcpcat_identify_callback(mcpcat_types.UserIdentity),
-    )
     try:
+        options = mcpcat_types.MCPCatOptions(
+            identify=build_mcpcat_identify_callback(mcpcat_types.UserIdentity),
+        )
         mcpcat.track(server, project_id, options)
     except Exception:
         logger.warning("MCPcat tracking could not be enabled; skipping", exc_info=True)

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -13,7 +13,7 @@ import os
 import sys
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from .code_mode import (
     code_mode_enabled_from_env,
@@ -25,6 +25,7 @@ from .exceptions import RootlyConfigurationError, RootlyMCPError
 from .security import validate_api_token
 from .server import create_rootly_mcp_server, get_hosted_auth_middleware
 from .server_defaults import enabled_tools_from_env, write_tools_enabled_from_env
+from .transport import get_hosted_authenticated_user
 
 TransportName = Literal["stdio", "sse", "streamable-http", "both"]
 TRANSPORT_ALIASES: dict[str, TransportName] = {
@@ -91,15 +92,37 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
 
     try:
         mcpcat = importlib.import_module("mcpcat")
+        mcpcat_types = importlib.import_module("mcpcat.types")
     except ImportError:
         logger.warning(
             "ROOTLY_MCPCAT_PROJECT_ID is set but mcpcat is not installed; skipping MCPcat tracking"
         )
         return
+
+    options = mcpcat_types.MCPCatOptions(
+        identify=build_mcpcat_identify_callback(mcpcat_types.UserIdentity),
+    )
     try:
-        mcpcat.track(server, project_id)
+        mcpcat.track(server, project_id, options)
     except Exception:
         logger.warning("MCPcat tracking could not be enabled; skipping", exc_info=True)
+
+
+def build_mcpcat_identify_callback(user_identity_cls: type[Any]):
+    """Build a lightweight MCPcat identify callback from hosted auth context."""
+
+    def identify(_request: dict[str, Any], _context: Any) -> Any:
+        user = get_hosted_authenticated_user()
+        if not user:
+            return None
+
+        return user_identity_cls(
+            user_id=user["id"],
+            user_name=user.get("email") or user.get("name"),
+            user_data=None,
+        )
+
+    return identify
 
 
 def parse_args():

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -324,7 +324,7 @@ class AuthCaptureMiddleware:
                 else self._NEGATIVE_CACHE_TTL
             )
             if (now - cached_at) < ttl:
-                return dict(authenticated_user) if authenticated_user else None
+                return dict(authenticated_user) if authenticated_user is not None else None
 
         existing = self._inflight.get(token_hash)
         if existing is not None:

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -318,7 +318,11 @@ class AuthCaptureMiddleware:
         cached = self._token_cache.get(token_hash)
         if cached is not None:
             cached_at, authenticated_user = cached
-            ttl = self._POSITIVE_CACHE_TTL if authenticated_user else self._NEGATIVE_CACHE_TTL
+            ttl = (
+                self._POSITIVE_CACHE_TTL
+                if authenticated_user is not None
+                else self._NEGATIVE_CACHE_TTL
+            )
             if (now - cached_at) < ttl:
                 return dict(authenticated_user) if authenticated_user else None
 

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -38,8 +38,8 @@ _session_transport: contextvars.ContextVar[str] = contextvars.ContextVar(
 _session_mcp_mode: contextvars.ContextVar[str] = contextvars.ContextVar(
     "_session_mcp_mode", default=""
 )
-_session_authenticated_user: contextvars.ContextVar[dict[str, str] | None] = (
-    contextvars.ContextVar("_session_authenticated_user", default=None)
+_session_authenticated_user: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+    "_session_authenticated_user", default=None
 )
 _session_error_context: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
     "_session_error_context", default=None

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -38,6 +38,9 @@ _session_transport: contextvars.ContextVar[str] = contextvars.ContextVar(
 _session_mcp_mode: contextvars.ContextVar[str] = contextvars.ContextVar(
     "_session_mcp_mode", default=""
 )
+_session_authenticated_user: contextvars.ContextVar[dict[str, str] | None] = (
+    contextvars.ContextVar("_session_authenticated_user", default=None)
+)
 _session_error_context: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
     "_session_error_context", default=None
 )
@@ -117,6 +120,40 @@ def _merge_error_context(context: dict[str, Any] | None) -> None:
     }
     current.update(mask_sensitive_data(sanitized))
     _session_error_context.set(current)
+
+
+def get_hosted_authenticated_user() -> dict[str, str] | None:
+    """Return the current hosted request's authenticated Rootly user, if available."""
+    user = _session_authenticated_user.get()
+    return dict(user) if user else None
+
+
+def _extract_rootly_user_identity(payload: Any) -> dict[str, str] | None:
+    """Extract a lightweight Rootly user identity from a JSON:API /users/me payload."""
+    if not isinstance(payload, dict):
+        return None
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+
+    user_id = data.get("id")
+    if not isinstance(user_id, str) or not user_id:
+        return None
+
+    attributes = data.get("attributes")
+    attrs = attributes if isinstance(attributes, dict) else {}
+
+    user: dict[str, str] = {"id": user_id}
+    email = attrs.get("email")
+    if isinstance(email, str) and email:
+        user["email"] = email
+
+    name = attrs.get("full_name") or attrs.get("name")
+    if isinstance(name, str) and name:
+        user["name"] = name
+
+    return user
 
 
 def _extract_upstream_url_fields(url: Any) -> tuple[str, str]:
@@ -268,44 +305,44 @@ class AuthCaptureMiddleware:
             self._code_mode_path,
         }
         self._base_url = os.getenv("ROOTLY_BASE_URL", "https://api.rootly.com")
-        # Maps token_hash -> (timestamp, is_valid)
-        self._token_cache: dict[str, tuple[float, bool]] = {}
+        # Maps token_hash -> (timestamp, authenticated user or None if invalid)
+        self._token_cache: dict[str, tuple[float, dict[str, str] | None]] = {}
         # In-flight probes keyed by token_hash to prevent cache stampede
-        self._inflight: dict[str, asyncio.Future[bool]] = {}
+        self._inflight: dict[str, asyncio.Future[dict[str, str] | None]] = {}
 
-    async def _validate_token_upstream(self, auth_header: str) -> bool:
-        """Probe the Rootly API to verify the Bearer token is valid."""
+    async def _validate_token_upstream(self, auth_header: str) -> dict[str, str] | None:
+        """Probe the Rootly API to verify the Bearer token and extract user identity."""
         token_hash = hashlib.sha256(auth_header.encode()).hexdigest()
         now = time.monotonic()
 
         cached = self._token_cache.get(token_hash)
         if cached is not None:
-            cached_at, was_valid = cached
-            ttl = self._POSITIVE_CACHE_TTL if was_valid else self._NEGATIVE_CACHE_TTL
+            cached_at, authenticated_user = cached
+            ttl = self._POSITIVE_CACHE_TTL if authenticated_user else self._NEGATIVE_CACHE_TTL
             if (now - cached_at) < ttl:
-                return was_valid
+                return dict(authenticated_user) if authenticated_user else None
 
         existing = self._inflight.get(token_hash)
         if existing is not None:
             return await existing
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[bool] = loop.create_future()
+        future: asyncio.Future[dict[str, str] | None] = loop.create_future()
         self._inflight[token_hash] = future
 
         try:
-            is_valid = await self._probe_upstream(auth_header)
-            self._token_cache[token_hash] = (time.monotonic(), is_valid)
+            authenticated_user = await self._probe_upstream(auth_header)
+            self._token_cache[token_hash] = (time.monotonic(), authenticated_user)
             self._evict_cache(time.monotonic())
-            future.set_result(is_valid)
-            return is_valid
+            future.set_result(authenticated_user)
+            return authenticated_user
         except Exception:
-            future.set_result(False)
-            return False
+            future.set_result(None)
+            return None
         finally:
             self._inflight.pop(token_hash, None)
 
-    async def _probe_upstream(self, auth_header: str) -> bool:
+    async def _probe_upstream(self, auth_header: str) -> dict[str, str] | None:
         """Make the actual upstream validation request."""
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
@@ -316,19 +353,26 @@ class AuthCaptureMiddleware:
                         "Accept": "application/vnd.api+json",
                     },
                 )
-            return resp.is_success
+            if not resp.is_success:
+                return None
+            return _extract_rootly_user_identity(resp.json())
         except Exception:
             logger.warning("Token validation probe failed, rejecting request")
-            return False
+            return None
 
     def _evict_cache(self, now: float) -> None:
         """Remove expired entries then enforce hard size cap."""
         if len(self._token_cache) <= self._MAX_CACHE_SIZE:
             return
         self._token_cache = {
-            k: (ts, valid)
-            for k, (ts, valid) in self._token_cache.items()
-            if (now - ts) < (self._POSITIVE_CACHE_TTL if valid else self._NEGATIVE_CACHE_TTL)
+            k: (ts, authenticated_user)
+            for k, (ts, authenticated_user) in self._token_cache.items()
+            if (now - ts)
+            < (
+                self._POSITIVE_CACHE_TTL
+                if authenticated_user is not None
+                else self._NEGATIVE_CACHE_TTL
+            )
         }
         if len(self._token_cache) > self._MAX_CACHE_SIZE:
             sorted_entries = sorted(self._token_cache.items(), key=lambda x: x[1][0])
@@ -359,6 +403,7 @@ class AuthCaptureMiddleware:
                 _session_transport.set(effective_transport)
             if mcp_mode:
                 _session_mcp_mode.set(mcp_mode)
+            _session_authenticated_user.set(None)
             auth = request.headers.get("authorization", "")
             if auth:
                 _session_auth_token.set(auth)
@@ -386,7 +431,10 @@ class AuthCaptureMiddleware:
             # Reject unauthenticated, malformed, or invalid tokens on MCP
             # transport paths before FastMCP processes the protocol message.
             auth_state = auth_header_state(auth)
-            if auth_state != "bearer" or not await self._validate_token_upstream(auth):
+            authenticated_user = (
+                await self._validate_token_upstream(auth) if auth_state == "bearer" else None
+            )
+            if auth_state != "bearer" or not authenticated_user:
                 await send(
                     {
                         "type": "http.response.start",
@@ -408,6 +456,7 @@ class AuthCaptureMiddleware:
                     }
                 )
                 return
+            _session_authenticated_user.set(authenticated_user)
 
             async def _send_with_www_authenticate(message):
                 if message.get("type") == "http.response.start" and message.get("status") == 401:

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -143,7 +143,9 @@ def test_maybe_enable_mcpcat_tracking_tracks_when_available():
             return mcpcat_types_module
         raise ImportError(module_name)
 
-    with patch("rootly_mcp_server.__main__.importlib.import_module", side_effect=import_side_effect):
+    with patch(
+        "rootly_mcp_server.__main__.importlib.import_module", side_effect=import_side_effect
+    ):
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
     mcpcat_module.track.assert_called_once()
@@ -168,7 +170,9 @@ def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
             return mcpcat_types_module
         raise ImportError(module_name)
 
-    with patch("rootly_mcp_server.__main__.importlib.import_module", side_effect=import_side_effect):
+    with patch(
+        "rootly_mcp_server.__main__.importlib.import_module", side_effect=import_side_effect
+    ):
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
     assert mcpcat_module.track.call_args.args[:2] == (server, "proj_test_123")

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -8,6 +8,7 @@ import pytest
 
 from rootly_mcp_server.__main__ import (
     _get_sorted_tool_names,
+    build_mcpcat_identify_callback,
     get_server,
     main,
     maybe_enable_mcpcat_tracking,
@@ -130,26 +131,75 @@ def test_maybe_enable_mcpcat_tracking_tracks_when_available():
     server = object()
     logger = Mock()
     mcpcat_module = SimpleNamespace(track=Mock())
+    mcpcat_types_module = SimpleNamespace(
+        MCPCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+        UserIdentity=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
 
-    with patch("rootly_mcp_server.__main__.importlib.import_module", return_value=mcpcat_module):
+    def import_side_effect(module_name: str):
+        if module_name == "mcpcat":
+            return mcpcat_module
+        if module_name == "mcpcat.types":
+            return mcpcat_types_module
+        raise ImportError(module_name)
+
+    with patch("rootly_mcp_server.__main__.importlib.import_module", side_effect=import_side_effect):
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
-    mcpcat_module.track.assert_called_once_with(server, "proj_test_123")
+    mcpcat_module.track.assert_called_once()
+    call = mcpcat_module.track.call_args
+    assert call.args[:2] == (server, "proj_test_123")
+    assert callable(call.args[2].identify)
 
 
 def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
     server = object()
     logger = Mock()
     mcpcat_module = SimpleNamespace(track=Mock(side_effect=RuntimeError("boom")))
+    mcpcat_types_module = SimpleNamespace(
+        MCPCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+        UserIdentity=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
 
-    with patch("rootly_mcp_server.__main__.importlib.import_module", return_value=mcpcat_module):
+    def import_side_effect(module_name: str):
+        if module_name == "mcpcat":
+            return mcpcat_module
+        if module_name == "mcpcat.types":
+            return mcpcat_types_module
+        raise ImportError(module_name)
+
+    with patch("rootly_mcp_server.__main__.importlib.import_module", side_effect=import_side_effect):
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
-    mcpcat_module.track.assert_called_once_with(server, "proj_test_123")
+    assert mcpcat_module.track.call_args.args[:2] == (server, "proj_test_123")
     logger.warning.assert_called_once_with(
         "MCPcat tracking could not be enabled; skipping",
         exc_info=True,
     )
+
+
+def test_build_mcpcat_identify_callback_returns_authenticated_user_identity():
+    user_identity_cls = Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+    callback = build_mcpcat_identify_callback(user_identity_cls)
+
+    with patch(
+        "rootly_mcp_server.__main__.get_hosted_authenticated_user",
+        return_value={"id": "user_123", "email": "spencer@example.com"},
+    ):
+        identity = callback({}, SimpleNamespace())
+
+    assert identity.user_id == "user_123"
+    assert identity.user_name == "spencer@example.com"
+    assert identity.user_data is None
+
+
+def test_build_mcpcat_identify_callback_returns_none_without_authenticated_user():
+    callback = build_mcpcat_identify_callback(SimpleNamespace)
+
+    with patch("rootly_mcp_server.__main__.get_hosted_authenticated_user", return_value=None):
+        identity = callback({}, SimpleNamespace())
+
+    assert identity is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -16,7 +16,7 @@ class TestTransportModule:
         with patch.object(
             transport.AuthCaptureMiddleware,
             "_validate_token_upstream",
-            return_value=True,
+            return_value={"id": "user_123", "email": "spencer@example.com"},
         ):
             yield
 
@@ -36,6 +36,7 @@ class TestTransportModule:
         transport._session_auth_token.set("")
         transport._session_transport.set("")
         transport._session_mcp_mode.set("")
+        transport._session_authenticated_user.set(None)
 
         async def receive():
             return {"type": "http.request"}
@@ -47,6 +48,10 @@ class TestTransportModule:
         assert transport._session_auth_token.get() == "Bearer test-token"
         assert transport._session_transport.get() == "sse"
         assert transport._session_mcp_mode.get() == "classic"
+        assert transport._session_authenticated_user.get() == {
+            "id": "user_123",
+            "email": "spencer@example.com",
+        }
 
     @pytest.mark.asyncio
     async def test_auth_capture_middleware_sets_token_for_streamable_http(self):
@@ -63,6 +68,7 @@ class TestTransportModule:
         transport._session_auth_token.set("")
         transport._session_transport.set("")
         transport._session_mcp_mode.set("")
+        transport._session_authenticated_user.set(None)
 
         async def receive():
             return {"type": "http.request"}
@@ -90,6 +96,7 @@ class TestTransportModule:
         transport._session_auth_token.set("")
         transport._session_transport.set("")
         transport._session_mcp_mode.set("")
+        transport._session_authenticated_user.set(None)
 
         async def receive():
             return {"type": "http.request"}
@@ -117,6 +124,7 @@ class TestTransportModule:
         transport._session_auth_token.set("")
         transport._session_transport.set("")
         transport._session_mcp_mode.set("")
+        transport._session_authenticated_user.set(None)
 
         async def receive():
             return {"type": "http.request"}
@@ -144,6 +152,7 @@ class TestTransportModule:
         transport._session_auth_token.set("")
         transport._session_transport.set("")
         transport._session_mcp_mode.set("")
+        transport._session_authenticated_user.set(None)
 
         async def receive():
             return {"type": "http.request"}
@@ -175,6 +184,7 @@ class TestTransportModule:
         transport._session_auth_token.set("")
         transport._session_transport.set("")
         transport._session_mcp_mode.set("")
+        transport._session_authenticated_user.set(None)
 
         async def receive():
             return {"type": "http.request"}
@@ -237,6 +247,30 @@ class TestTransportModule:
             )
             == "streamable-http"
         )
+
+    def test_extract_rootly_user_identity_returns_lightweight_user(self):
+        payload = {
+            "data": {
+                "id": "user_123",
+                "attributes": {
+                    "email": "spencer@example.com",
+                    "full_name": "Spencer Cheng",
+                },
+            }
+        }
+
+        user = transport._extract_rootly_user_identity(payload)
+
+        assert user == {
+            "id": "user_123",
+            "email": "spencer@example.com",
+            "name": "Spencer Cheng",
+        }
+
+    def test_extract_rootly_user_identity_returns_none_without_id(self):
+        payload = {"data": {"attributes": {"email": "spencer@example.com"}}}
+
+        assert transport._extract_rootly_user_identity(payload) is None
         assert (
             transport._infer_transport_from_path(
                 "/healthz", "/sse", "/messages", "/mcp", "/mcp-codemode"
@@ -856,7 +890,11 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
 
         with (
             patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"),
-            patch.object(middleware, "_validate_token_upstream", return_value=True),
+            patch.object(
+                middleware,
+                "_validate_token_upstream",
+                return_value={"id": "user_123", "email": "spencer@example.com"},
+            ),
         ):
             await middleware(scope, receive, send)
 
@@ -895,7 +933,7 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
 
         with (
             patch("rootly_mcp_server.utils._MCP_SERVER_URL", "https://mcp.example.com"),
-            patch.object(middleware, "_validate_token_upstream", return_value=False),
+            patch.object(middleware, "_validate_token_upstream", return_value=None),
         ):
             await middleware(scope, receive, send)
 


### PR DESCRIPTION
## Summary
- identify MCPcat users from the hosted Rootly auth context instead of anonymous stateless requests
- cache the lightweight Rootly user from the existing /v1/users/me auth probe and reuse it for MCPcat identify()
- add focused tests for auth-context extraction and MCPcat identify behavior

## Testing
- uv run ruff check src/rootly_mcp_server/__main__.py src/rootly_mcp_server/transport.py tests/unit/test_main_transport.py tests/unit/test_transport_module.py
- uv run pyright src/rootly_mcp_server/__main__.py src/rootly_mcp_server/transport.py
- uv run pytest -q tests/unit/test_main_transport.py tests/unit/test_transport_module.py
