### PR TITLE
Use full_name_with_team for MCPcat identities

### DIFF
--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -118,11 +118,7 @@ def build_mcpcat_identify_callback(user_identity_cls: type[Any]):
 
         return user_identity_cls(
             user_id=user["id"],
-            user_name=(
-                user.get("full_name_with_team")
-                or user.get("name")
-                or user.get("email")
-            ),
+            user_name=(user.get("full_name_with_team") or user.get("name") or user.get("email")),
             user_data=None,
         )
 

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -118,7 +118,11 @@ def build_mcpcat_identify_callback(user_identity_cls: type[Any]):
 
         return user_identity_cls(
             user_id=user["id"],
-            user_name=user.get("email") or user.get("name"),
+            user_name=(
+                user.get("full_name_with_team")
+                or user.get("name")
+                or user.get("email")
+            ),
             user_data=None,
         )
 

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -149,6 +149,10 @@ def _extract_rootly_user_identity(payload: Any) -> dict[str, str] | None:
     if isinstance(email, str) and email:
         user["email"] = email
 
+    full_name_with_team = attrs.get("full_name_with_team")
+    if isinstance(full_name_with_team, str) and full_name_with_team:
+        user["full_name_with_team"] = full_name_with_team
+
     name = attrs.get("full_name") or attrs.get("name")
     if isinstance(name, str) and name:
         user["name"] = name

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -188,12 +188,17 @@ def test_build_mcpcat_identify_callback_returns_authenticated_user_identity():
 
     with patch(
         "rootly_mcp_server.__main__.get_hosted_authenticated_user",
-        return_value={"id": "user_123", "email": "spencer@example.com"},
+        return_value={
+            "id": "user_123",
+            "email": "spencer@example.com",
+            "name": "Spencer Cheng",
+            "full_name_with_team": "[FailWhale Tales] Spencer Cheng",
+        },
     ):
         identity = callback({}, SimpleNamespace())
 
     assert identity.user_id == "user_123"
-    assert identity.user_name == "spencer@example.com"
+    assert identity.user_name == "[FailWhale Tales] Spencer Cheng"
     assert identity.user_data is None
 
 

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -190,15 +190,15 @@ def test_build_mcpcat_identify_callback_returns_authenticated_user_identity():
         "rootly_mcp_server.__main__.get_hosted_authenticated_user",
         return_value={
             "id": "user_123",
-            "email": "spencer@example.com",
-            "name": "Spencer Cheng",
-            "full_name_with_team": "[FailWhale Tales] Spencer Cheng",
+            "email": "example.user@example.test",
+            "name": "Example User",
+            "full_name_with_team": "[Acme Reliability] Example User",
         },
     ):
         identity = callback({}, SimpleNamespace())
 
     assert identity.user_id == "user_123"
-    assert identity.user_name == "[FailWhale Tales] Spencer Cheng"
+    assert identity.user_name == "[Acme Reliability] Example User"
     assert identity.user_data is None
 
 

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -255,6 +255,7 @@ class TestTransportModule:
                 "attributes": {
                     "email": "spencer@example.com",
                     "full_name": "Spencer Cheng",
+                    "full_name_with_team": "[FailWhale Tales] Spencer Cheng",
                 },
             }
         }
@@ -264,6 +265,7 @@ class TestTransportModule:
         assert user == {
             "id": "user_123",
             "email": "spencer@example.com",
+            "full_name_with_team": "[FailWhale Tales] Spencer Cheng",
             "name": "Spencer Cheng",
         }
 

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -16,7 +16,7 @@ class TestTransportModule:
         with patch.object(
             transport.AuthCaptureMiddleware,
             "_validate_token_upstream",
-            return_value={"id": "user_123", "email": "spencer@example.com"},
+            return_value={"id": "user_123", "email": "example.user@example.test"},
         ):
             yield
 
@@ -50,7 +50,7 @@ class TestTransportModule:
         assert transport._session_mcp_mode.get() == "classic"
         assert transport._session_authenticated_user.get() == {
             "id": "user_123",
-            "email": "spencer@example.com",
+            "email": "example.user@example.test",
         }
 
     @pytest.mark.asyncio
@@ -253,9 +253,9 @@ class TestTransportModule:
             "data": {
                 "id": "user_123",
                 "attributes": {
-                    "email": "spencer@example.com",
-                    "full_name": "Spencer Cheng",
-                    "full_name_with_team": "[FailWhale Tales] Spencer Cheng",
+                    "email": "example.user@example.test",
+                    "full_name": "Example User",
+                    "full_name_with_team": "[Acme Reliability] Example User",
                 },
             }
         }
@@ -264,13 +264,13 @@ class TestTransportModule:
 
         assert user == {
             "id": "user_123",
-            "email": "spencer@example.com",
-            "full_name_with_team": "[FailWhale Tales] Spencer Cheng",
-            "name": "Spencer Cheng",
+            "email": "example.user@example.test",
+            "full_name_with_team": "[Acme Reliability] Example User",
+            "name": "Example User",
         }
 
     def test_extract_rootly_user_identity_returns_none_without_id(self):
-        payload = {"data": {"attributes": {"email": "spencer@example.com"}}}
+        payload = {"data": {"attributes": {"email": "example.user@example.test"}}}
 
         assert transport._extract_rootly_user_identity(payload) is None
         assert (
@@ -683,8 +683,8 @@ class TestTransportModule:
                     "id": "u-1",
                     "type": "users",
                     "attributes": {
-                        "full_name": "Spencer Cheng",
-                        "email": "spencer@example.com",
+                        "full_name": "Example User",
+                        "email": "example.user@example.test",
                         "time_zone": "UTC",
                         "created_at": "2026-03-18T00:00:00Z",
                         "updated_at": "2026-03-18T01:00:00Z",
@@ -710,8 +710,8 @@ class TestTransportModule:
 
         result = transport.strip_heavy_user_data(data)
         attrs = result["data"][0]["attributes"]
-        assert attrs["full_name"] == "Spencer Cheng"
-        assert attrs["email"] == "spencer@example.com"
+        assert attrs["full_name"] == "Example User"
+        assert attrs["email"] == "example.user@example.test"
         assert "avatar_url" not in attrs
         assert result["data"][0]["relationships"]["email_addresses"] == {"count": 2}
         assert result["data"][0]["relationships"]["role"] == {
@@ -786,8 +786,8 @@ class TestTransportModule:
                     "id": "u-1",
                     "type": "users",
                     "attributes": {
-                        "full_name": "Spencer Cheng",
-                        "email": "spencer@example.com",
+                        "full_name": "Example User",
+                        "email": "example.user@example.test",
                         "time_zone": "UTC",
                         "avatar_url": "https://example.com/avatar.png",
                     },
@@ -803,8 +803,8 @@ class TestTransportModule:
         assert sorted(result["data"][0]["relationships"]) == ["shift_override", "user"]
         included_user = result["included"][0]
         assert included_user["attributes"] == {
-            "full_name": "Spencer Cheng",
-            "email": "spencer@example.com",
+            "full_name": "Example User",
+            "email": "example.user@example.test",
             "time_zone": "UTC",
         }
 
@@ -895,7 +895,7 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
             patch.object(
                 middleware,
                 "_validate_token_upstream",
-                return_value={"id": "user_123", "email": "spencer@example.com"},
+                return_value={"id": "user_123", "email": "example.user@example.test"},
             ),
         ):
             await middleware(scope, receive, send)


### PR DESCRIPTION
## Summary
- prefer Rootly's `full_name_with_team` for MCPcat display names
- keep `name` and `email` as fallbacks when team-qualified names are unavailable
- extend the hosted auth identity cache and tests to cover the richer display field

## Testing
- uv run ruff check src/rootly_mcp_server/__main__.py src/rootly_mcp_server/transport.py tests/unit/test_main_transport.py tests/unit/test_transport_module.py
- uv run pyright src/rootly_mcp_server/__main__.py src/rootly_mcp_server/transport.py tests/unit/test_main_transport.py tests/unit/test_transport_module.py
- uv run pytest -q tests/unit/test_main_transport.py tests/unit/test_transport_module.py