### PR TITLE
Drop empty query parameters before upstream requests

### DIFF
--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -812,11 +812,11 @@ class AuthenticatedHTTPXClient:
             return normalized or None
         if isinstance(value, list | tuple):
             normalized_items = [
-                item
-                for item in (
+                normalized
+                for normalized in (
                     AuthenticatedHTTPXClient._normalize_query_param_value(item) for item in value
                 )
-                if item is not None
+                if normalized is not None
             ]
             return normalized_items or None
         return value

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -797,6 +797,30 @@ class AuthenticatedHTTPXClient:
             return None
         return api_token
 
+    @staticmethod
+    def _normalize_query_param_value(value: Any) -> Any:
+        """Drop blank query values while preserving meaningful falsey values.
+
+        Rootly endpoints may return 500s when passed empty-string filters such as
+        ``filter[status]=``. We treat blank strings and empty collections as
+        omitted query parameters, while keeping values like ``0`` and ``False``.
+        """
+        if value is None:
+            return None
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+        if isinstance(value, list | tuple):
+            normalized_items = [
+                item
+                for item in (
+                    AuthenticatedHTTPXClient._normalize_query_param_value(item) for item in value
+                )
+                if item is not None
+            ]
+            return normalized_items or None
+        return value
+
     def _transform_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
         """Transform sanitized parameter names back to original names."""
         if not params or not self.parameter_mapping:
@@ -804,9 +828,13 @@ class AuthenticatedHTTPXClient:
 
         transformed = {}
         for key, value in params.items():
+            normalized_value = self._normalize_query_param_value(value)
+            if normalized_value is None:
+                logger.debug(f"Dropping empty query parameter: '{key}'")
+                continue
             # Use the original name if we have a mapping, otherwise keep the sanitized name
             original_key = self.parameter_mapping.get(key, key)
-            transformed[original_key] = value
+            transformed[original_key] = normalized_value
             if original_key != key:
                 logger.debug(f"Transformed parameter: '{key}' -> '{original_key}'")
         return transformed
@@ -1166,8 +1194,12 @@ class AuthenticatedHTTPXClient:
         if request.url.params:
             original_params = {}
             for key, value in request.url.params.items():
+                normalized_value = self._normalize_query_param_value(value)
+                if normalized_value is None:
+                    logger.debug(f"Dropping empty URL query parameter: '{key}'")
+                    continue
                 original_key = self.parameter_mapping.get(key, key)
-                original_params[original_key] = value
+                original_params[original_key] = normalized_value
             # Rebuild URL with transformed parameters
             new_url = str(request.url).split("?")[0]
             if original_params:

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -507,7 +507,17 @@ class TestTransportModule:
         with patch.object(
             transport.AuthenticatedHTTPXClient, "_get_api_token", return_value="token"
         ):
-            client = transport.AuthenticatedHTTPXClient(hosted=False, transport="stdio")
+            client = transport.AuthenticatedHTTPXClient(
+                hosted=False,
+                transport="stdio",
+                parameter_mapping={
+                    "filter_status": "filter[status]",
+                    "filter_source": "filter[source]",
+                    "filter_services": "filter[services]",
+                    "page_number": "page[number]",
+                    "page_size": "page[size]",
+                },
+            )
             client.client.request = AsyncMock(return_value=response)
 
             returned = await client.request("GET", "/v1/incidents")
@@ -615,6 +625,82 @@ class TestTransportModule:
             assert kwargs["json"] == {
                 "data": {"type": "workflows", "attributes": {"name": "Updated"}}
             }
+
+    def test_authenticated_client_drops_empty_query_parameters(self):
+        with patch.object(
+            transport.AuthenticatedHTTPXClient, "_get_api_token", return_value="token"
+        ):
+            client = transport.AuthenticatedHTTPXClient(
+                hosted=False,
+                transport="stdio",
+                parameter_mapping={
+                    "filter_status": "filter[status]",
+                    "filter_source": "filter[source]",
+                    "filter_services": "filter[services]",
+                    "page_number": "page[number]",
+                    "page_size": "page[size]",
+                },
+            )
+        assert client._transform_params(
+            {
+                "filter_status": "",
+                "filter_source": "   ",
+                "filter_services": [
+                    "svc-1",
+                    "",
+                    "svc-2",
+                ],
+                "page_number": 1,
+                "page_size": 20,
+                "include": "alert_urgency",
+            }
+        ) == {
+            "filter[services]": ["svc-1", "svc-2"],
+            "page[number]": 1,
+            "page[size]": 20,
+            "include": "alert_urgency",
+        }
+
+    @pytest.mark.asyncio
+    async def test_authenticated_client_send_drops_empty_query_parameters(self):
+        response = httpx.Response(
+            200,
+            request=httpx.Request(
+                "GET",
+                "https://api.rootly.com/v1/alerts?include=alert_urgency&page%5Bnumber%5D=1",
+            ),
+            content=b'{"data":[]}',
+        )
+
+        with patch.object(
+            transport.AuthenticatedHTTPXClient, "_get_api_token", return_value="token"
+        ):
+            client = transport.AuthenticatedHTTPXClient(
+                hosted=False,
+                transport="stdio",
+                parameter_mapping={
+                    "filter_status": "filter[status]",
+                    "filter_source": "filter[source]",
+                    "page_number": "page[number]",
+                },
+            )
+            client.client.send = AsyncMock(return_value=response)
+
+            request = httpx.Request(
+                "GET",
+                "https://api.rootly.com/v1/alerts"
+                "?filter_status=&filter_source=%20%20%20&include=alert_urgency&page_number=1",
+            )
+
+            await client.send(request)
+
+            sent_request = client.client.send.call_args.args[0]
+            sent_params = dict(sent_request.url.params)
+            assert "filter[status]" not in sent_params
+            assert "filter[status]" not in str(sent_request.url)
+            assert "filter[source]" not in sent_params
+            assert sent_params["include"] == "alert_urgency"
+            assert sent_params["page[number]"] == "1"
 
     def test_sanitize_log_excerpt_redacts_tokens_and_paths(self):
         excerpt = transport._sanitize_log_excerpt(


### PR DESCRIPTION
## Summary
- drop blank query and filter parameters before forwarding requests upstream
- preserve meaningful falsey values like 0 and false while omitting empty strings and empty collections
- add transport tests covering both direct param transforms and URL param rewriting

## Why
Some MCP clients send optional filters as empty strings, for example filter_status= or page_after=. The current transport forwards those values unchanged, and Rootly upstream can respond with a 500 instead of treating them as omitted.

## Testing
- uv run pytest tests/unit/test_transport_module.py -q
- pre-commit hook during commit: 445 passed
