### PR TITLE
fix: strip empty params in _transform_params regardless of name mapping

### DIFF
--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -822,8 +822,13 @@ class AuthenticatedHTTPXClient:
         return value
 
     def _transform_params(self, params: dict[str, Any] | None) -> dict[str, Any] | None:
-        """Transform sanitized parameter names back to original names."""
-        if not params or not self.parameter_mapping:
+        """Transform sanitized parameter names back to original names.
+
+        Empty-string and null values are dropped regardless of whether a name
+        mapping exists, so that only meaningful values are forwarded upstream
+        (Rootly returns 500s for blank filters like ``filter[status]=``).
+        """
+        if not params:
             return params
 
         transformed = {}

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, mock_open, patch
 
+import httpx
 import mcp.types as mt
 import pytest
 
@@ -501,6 +502,63 @@ class TestBundledIncidentFormFieldSelectionTools:
             f"Unexpected incident-list tool surface: {list_variants}. "
             "Should be exactly ['listIncidents', 'list_incidents'] under posture A."
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestListAlertsParamSerialization:
+    """Regression for empty optional params corrupting the upstream request.
+
+    Calling listAlerts with empty-string optional filters alongside a valid
+    page_size must drop the blanks and forward the real page[size] value. A
+    forwarded blank like ``filter[status]=`` makes the Rootly API 500 (and echo
+    a bogus ``page[size]=0`` self-link), so the request must omit it entirely.
+    """
+
+    @staticmethod
+    def _find_openapi_tool(server, name):
+        for provider in server.providers:
+            tools = getattr(provider, "_tools", None)
+            if isinstance(tools, dict) and name in tools:
+                return tools[name]
+        return None
+
+    async def test_empty_optional_params_preserve_page_size(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+        tool = self._find_openapi_tool(server, "listAlerts")
+        assert tool is not None, "listAlerts tool should be generated from the spec"
+
+        captured: dict[str, Any] = {}
+
+        async def fake_send(request, **kwargs):
+            captured["url"] = str(request.url)
+            captured["params"] = dict(request.url.params)
+            return httpx.Response(200, request=request, content=b'{"data":[]}')
+
+        # Patch the inner httpx client so we capture the final, fully-serialized
+        # request after the wrapper's parameter transformation runs.
+        tool._client.client.send = fake_send
+
+        await tool.run(
+            {
+                "page_number": 1,
+                "page_size": 20,
+                "filter_status": "",
+                "filter_source": "",
+                "page_after": "",
+            }
+        )
+
+        params = captured["params"]
+        # The valid page size must survive untouched.
+        assert params.get("page[size]") == "20"
+        assert params.get("page[number]") == "1"
+        # Blank optional filters must not be forwarded at all.
+        assert "filter[status]" not in params
+        assert "filter[source]" not in params
+        assert "page[after]" not in params
+        assert "filter[status]" not in captured["url"]
+        assert "page[size]=0" not in captured["url"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -682,6 +682,7 @@ class TestTransportModule:
                     "filter_status": "filter[status]",
                     "filter_source": "filter[source]",
                     "page_number": "page[number]",
+                    "page_size": "page[size]",
                 },
             )
             client.client.send = AsyncMock(return_value=response)
@@ -689,7 +690,8 @@ class TestTransportModule:
             request = httpx.Request(
                 "GET",
                 "https://api.rootly.com/v1/alerts"
-                "?filter_status=&filter_source=%20%20%20&include=alert_urgency&page_number=1",
+                "?filter_status=&filter_source=%20%20%20&include=alert_urgency"
+                "&page_number=1&page_size=20",
             )
 
             await client.send(request)
@@ -701,6 +703,8 @@ class TestTransportModule:
             assert "filter[source]" not in sent_params
             assert sent_params["include"] == "alert_urgency"
             assert sent_params["page[number]"] == "1"
+            # A valid page size must be forwarded untouched (not corrupted to 0).
+            assert sent_params["page[size]"] == "20"
 
     def test_sanitize_log_excerpt_redacts_tokens_and_paths(self):
         excerpt = transport._sanitize_log_excerpt(


### PR DESCRIPTION
## Summary

- Removes the `not self.parameter_mapping` early-return from `_transform_params` so blank/null values are dropped on the `request()` path even when the name mapping is empty — making the invariant hold universally across both serialization paths
- Strengthens `test_authenticated_client_send_drops_empty_query_parameters` to assert `page[size]=20` is preserved (it previously only checked that empties were dropped, not that the valid value survived)
- Adds `TestListAlertsParamSerialization.test_empty_optional_params_preserve_page_size`: an end-to-end regression test that drives the real `listAlerts` tool through the full director→send chain with empty optional params and `page_size=20`, asserting the correct `page[size]=20` reaches the API and no blank filters leak through (including the `page[size]=0` case in the response self-link that occurs when empty `page[after]` triggers cursor-pagination mode)

## Test plan

- [ ] New end-to-end test fails when `_normalize_query_param_value` empty-stripping is neutralized, passes with it in place
- [ ] All 446 unit tests pass
- [ ] Ruff lint + Pyright type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)