### PR TITLE
fix: prevent duplicate ASGI response in auth middleware

### DIFF
--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -474,11 +474,20 @@ class AuthCaptureMiddleware:
                 return
             _session_authenticated_user.set(authenticated_user)
 
+            response_started = False
+
             async def _send_with_www_authenticate(message):
-                if message.get("type") == "http.response.start" and message.get("status") == 401:
-                    response_headers = list(message.get("headers", []))
-                    response_headers.append((b"www-authenticate", www_auth_value))
-                    message = {**message, "headers": response_headers}
+                nonlocal response_started
+                if message.get("type") == "http.response.start":
+                    if response_started:
+                        return
+                    response_started = True
+                    if message.get("status") == 401:
+                        response_headers = list(message.get("headers", []))
+                        response_headers.append((b"www-authenticate", www_auth_value))
+                        message = {**message, "headers": response_headers}
+                elif message.get("type") == "http.response.body" and not response_started:
+                    return
                 await send(message)
 
             await self.app(scope, receive, _send_with_www_authenticate)


### PR DESCRIPTION
## Summary

- Guards `_send_with_www_authenticate` in `AuthCaptureMiddleware` to track whether an HTTP response has already started, silently dropping duplicate `http.response.start` and orphaned `http.response.body` messages
- Fixes ~66K `RuntimeError: Unexpected ASGI message 'http.response.start' sent, after response already completed` log lines per 4h window in production
- Root cause: Starlette exception handlers attempt to send a second response on connections where the middleware (or downstream FastMCP) already completed one, causing uvicorn to raise

## Context

Production Datadog logs show 66,636 of these RuntimeErrors in a 4h window, all from stderr. The high error volume contributes to memory pressure — the single ECS task (1 vCPU / 4GB, no auto-scaling) OOM-killed twice today.

## Test plan

- [x] All 504 existing tests pass
- [ ] Deploy and verify ASGI RuntimeError count drops to near-zero in Datadog
- [ ] Monitor ECS task memory stability post-deploy