### PR TITLE
fix: suppress orphaned ASGI body frames from duplicate responses

### DIFF
--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -475,18 +475,21 @@ class AuthCaptureMiddleware:
             _session_authenticated_user.set(authenticated_user)
 
             response_started = False
+            response_dropped = False
 
             async def _send_with_www_authenticate(message):
-                nonlocal response_started
+                nonlocal response_started, response_dropped
                 if message.get("type") == "http.response.start":
                     if response_started:
+                        response_dropped = True
                         return
+                    response_dropped = False
                     response_started = True
                     if message.get("status") == 401:
                         response_headers = list(message.get("headers", []))
                         response_headers.append((b"www-authenticate", www_auth_value))
                         message = {**message, "headers": response_headers}
-                elif message.get("type") == "http.response.body" and not response_started:
+                elif message.get("type") == "http.response.body" and response_dropped:
                     return
                 await send(message)
 


### PR DESCRIPTION
## Summary

Follow-up to #132. The body-drop guard used `not response_started`, which is always `False` after the first response starts — orphaned `http.response.body` frames from duplicate responses still reached uvicorn, triggering a different `RuntimeError`.

Adds a `response_dropped` flag set when a duplicate `http.response.start` is suppressed, so the subsequent body frame is also dropped.

## Test plan

- [x] All 504 existing tests pass
- [ ] Deploy and verify both `http.response.start` and `http.response.body` RuntimeErrors are gone from Datadog