### PR TITLE
Expand remote safe write tool surface

### DIFF
--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -564,6 +564,7 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/escalation_policies",
     "/escalation_policies/{escalation_policy_id}",
     "/escalation_policies/{escalation_policy_id}/escalation_paths",
+    "/escalation_policies/{escalation_policy_id}/escalation_levels",
     "/escalation_paths/{escalation_policy_path_id}",
     "/escalation_paths/{escalation_policy_path_id}/escalation_levels",
     "/escalation_levels/{escalation_level_id}",
@@ -576,6 +577,7 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/workflows/{workflow_id}/workflow_tasks",
     "/workflow_tasks/{id}",
     "/workflows/{workflow_id}/form_field_conditions",
+    "/workflow_form_field_conditions/{id}",
     # Dashboards - create + update
     "/dashboards",
     "/dashboards/{id}",

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -512,6 +512,9 @@ SECURITY_EXCLUDED_PATHS = [
 # read-only workflows and avoids exposing broader admin/config writes.
 DEFAULT_WRITE_ALLOWED_PATHS = [
     # Core incident and infrastructure - create + update
+    "/alerts",
+    "/alerts/{id}",
+    "/incidents/{incident_id}/alerts",
     "/environments",
     "/environments/{environment_id}",
     "/functionalities",
@@ -524,9 +527,23 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/severities/{severity_id}",
     "/teams",
     "/teams/{team_id}",
+    # Alert management - create + update
+    "/alerts/{alert_id}/events",
+    "/alert_groups",
+    "/alert_groups/{id}",
+    "/alert_routes",
+    "/alert_routes/{id}",
+    "/alert_routing_rules",
+    "/alert_routing_rules/{id}",
+    "/alert_urgencies",
+    "/alert_urgencies/{id}",
+    "/alert_sources",
+    "/alert_sources/{id}",
     # Incident mutations
     "/alert_events/{id}",
+    "/action_items/{id}",
     "/incidents/{incident_id}/action_items",
+    "/incidents/{incident_id}/custom_field_selections",
     "/incidents/{incident_id}/events",
     "/incidents/{incident_id}/form_field_selections",
     "/incident_form_field_selections/{id}",
@@ -535,6 +552,8 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/schedules/{schedule_id}",
     "/schedules/{schedule_id}/schedule_rotations",
     "/schedule_rotations/{schedule_rotation_id}",
+    "/schedule_rotations/{schedule_rotation_id}/schedule_rotation_users",
+    "/schedule_rotations/{schedule_rotation_id}/schedule_rotation_active_days",
     "/schedules/{schedule_id}/override_shifts",
     "/override_shifts/{override_shift_id}",
     "/schedules/{schedule_id}/on_call_shadows",
@@ -551,6 +570,7 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     # Workflows - create + update
     "/workflows",
     "/workflows/{workflow_id}",
+    "/workflows/{workflow_id}/workflow_runs",
     "/workflow_groups",
     "/workflow_groups/{id}",
     "/workflows/{workflow_id}/workflow_tasks",
@@ -561,6 +581,13 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/dashboards/{id}",
     "/dashboards/{dashboard_id}/panels",
     "/dashboard_panels/{id}",
+    # Forms - create + update
+    "/custom_forms",
+    "/custom_forms/{id}",
+    "/form_fields",
+    "/form_fields/{id}",
+    "/form_fields/{form_field_id}/options",
+    "/form_field_options/{id}",
     # Playbooks - create + update
     "/playbooks",
     "/playbooks/{id}",
@@ -584,6 +611,9 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/retrospective_steps/{id}",
     "/postmortem_templates",
     "/postmortem_templates/{id}",
+    # Status page templates
+    "/status-pages/{status_page_id}/templates",
+    "/templates/{id}",
     # Communications - create + update
     "/communications_groups",
     "/communications_groups/{id}",

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -374,22 +374,21 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "listCauses" in tool_names
         assert "getCause" in tool_names
 
-        # Workflow creates now enabled, but workflow runs remain excluded
-        assert "createWorkflowRun" not in tool_names
-        # Alert configuration writes remain excluded (connects to external systems)
-        assert "createAlertGroup" not in tool_names
-        assert "updateAlertGroup" not in tool_names
-        assert "createAlertRoutingRule" not in tool_names
-        assert "updateAlertRoutingRule" not in tool_names
-        assert "createAlertSource" not in tool_names
-        assert "updateAlertSource" not in tool_names
-        assert "createAlertUrgency" not in tool_names
-        assert "updateAlertUrgency" not in tool_names
-        # Custom form/field creation excluded (schema-level configuration)
-        assert "createCustomForm" not in tool_names
-        assert "updateCustomForm" not in tool_names
-        assert "createFormField" not in tool_names
-        assert "updateFormField" not in tool_names
+        # The full write-enabled surface should include non-destructive alert,
+        # form, and workflow writes, while destructive deletes remain excluded.
+        assert "createWorkflowRun" in tool_names
+        assert "createAlertEvent" in tool_names
+        assert "createAlertGroup" in tool_names
+        assert "updateAlertGroup" in tool_names
+        assert "createAlertRoutingRule" in tool_names
+        assert "updateAlertRoutingRule" in tool_names
+        assert "createAlertUrgency" in tool_names
+        assert "updateAlertUrgency" in tool_names
+        assert "createCustomForm" in tool_names
+        assert "updateCustomForm" in tool_names
+        assert "createFormField" in tool_names
+        assert "updateFormField" in tool_names
+        assert "deleteAlertEvent" not in tool_names
 
     async def test_enable_write_tools_exposes_curated_generated_write_tools(
         self, mock_environment_token
@@ -419,7 +418,10 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "updateWorkflow" in tool_names
         assert "createWorkflowTask" in tool_names
         assert "updateWorkflowTask" in tool_names
-        assert "updateAlert" not in tool_names
+        assert "createAlertEvent" in tool_names
+        assert "createAlertGroup" in tool_names
+        assert "updateAlert" in tool_names
+        assert "updateAlertGroup" in tool_names
         assert "updateUser" not in tool_names
         assert "deleteSchedule" not in tool_names
         assert "deleteScheduleRotation" not in tool_names
@@ -436,6 +438,9 @@ class TestBundledIncidentFormFieldSelectionTools:
 
         assert len(tool_names) > len(DEFAULT_HOSTED_ENABLED_TOOLS)
         assert "createIncidentActionItem" in tool_names
+        assert "createAlertEvent" in tool_names
+        assert "createAlertGroup" in tool_names
+        assert "updateAlert" in tool_names
         assert "updateIncident" in tool_names
         assert "search_incidents" in tool_names
         assert "createWorkflowTask" in tool_names

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -326,7 +326,9 @@ class TestBundledIncidentFormFieldSelectionTools:
         # Delete operations are still restricted
         assert "deleteWorkflowTask" not in tool_names
 
-    async def test_default_server_shows_additional_read_tools(self, mock_environment_token):
+    async def test_default_server_shows_additional_read_and_write_tools(
+        self, mock_environment_token
+    ):
         server = create_rootly_mcp_server(hosted=False)
 
         tools = await server.list_tools()
@@ -380,14 +382,21 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "createAlertEvent" in tool_names
         assert "createAlertGroup" in tool_names
         assert "updateAlertGroup" in tool_names
+        assert "createAlertRoute" in tool_names
+        assert "updateAlertRoute" in tool_names
+        assert "patchAlertRoute" in tool_names
         assert "createAlertRoutingRule" in tool_names
         assert "updateAlertRoutingRule" in tool_names
+        assert "createAlertsSource" in tool_names
+        assert "updateAlertsSource" in tool_names
         assert "createAlertUrgency" in tool_names
         assert "updateAlertUrgency" in tool_names
         assert "createCustomForm" in tool_names
         assert "updateCustomForm" in tool_names
+        assert "createEscalationLevel" in tool_names
         assert "createFormField" in tool_names
         assert "updateFormField" in tool_names
+        assert "updateWorkflowFormFieldCondition" in tool_names
         assert "deleteAlertEvent" not in tool_names
 
     async def test_enable_write_tools_exposes_curated_generated_write_tools(
@@ -420,8 +429,11 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "updateWorkflowTask" in tool_names
         assert "createAlertEvent" in tool_names
         assert "createAlertGroup" in tool_names
+        assert "createAlertRoute" in tool_names
+        assert "createAlertsSource" in tool_names
         assert "updateAlert" in tool_names
         assert "updateAlertGroup" in tool_names
+        assert "updateWorkflowFormFieldCondition" in tool_names
         assert "updateUser" not in tool_names
         assert "deleteSchedule" not in tool_names
         assert "deleteScheduleRotation" not in tool_names
@@ -440,6 +452,8 @@ class TestBundledIncidentFormFieldSelectionTools:
         assert "createIncidentActionItem" in tool_names
         assert "createAlertEvent" in tool_names
         assert "createAlertGroup" in tool_names
+        assert "createAlertRoute" in tool_names
+        assert "createAlertsSource" in tool_names
         assert "updateAlert" in tool_names
         assert "updateIncident" in tool_names
         assert "search_incidents" in tool_names


### PR DESCRIPTION
## Summary
- expand the write allowlist for non-destructive operations that were already in the allowed API surface
- expose missing remote/full tools like createAlertEvent and adjacent alert/form/workflow writes
- update server tests to lock in the broader hosted/full behavior while keeping destructive deletes excluded

## Why
Remote is intended to be a broad surface, but several safe write operations were still filtered out because their paths were missing from DEFAULT_WRITE_ALLOWED_PATHS. That left documented API operations like createAlertEvent unavailable through MCP even though their read paths were already allowed.

## Testing
- uv run pytest tests/unit/test_server.py -q
- full pre-commit suite during commit: 474 passed
