### PR TITLE
feat: add list_incident_roles tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- **`list_incident_roles` Tool**: Added a curated `list_incident_roles(incident_id)` tool that returns role assignments for an incident (Commander, Postmortem Owner, Scribe, etc.) as a flat table with role metadata and the assigned user. Wraps `GET /v1/incidents/{id}?include=roles` and flattens the JSON:API `included` array so callers don't have to walk the relationships graph. Included in the default hosted tool surface
+
 ### Fixed
 
 - **Misnamed Tool Argument Normalization**: Added argument normalization middleware to recover from common LLM/client parameter mistakes before Pydantic validation runs. This now remaps `from`/`to` to `from_date`/`to_date` for `list_shifts`, remaps `max_tokens` to `max_results` for `search_incidents`, and coerces list-shaped schedule/shift identifiers into the CSV form expected by the current tool schemas
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Testing
 
 - Expanded snake_case and argument-normalization coverage for alias handling, CSV coercion, and misnamed-argument recovery paths
+- Added coverage for `list_incident_roles` happy path, unassigned roles, sequential reference resolution, and validation errors
 
 ## [2.3.13] - Released 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to the Rootly MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Misnamed Tool Argument Normalization**: Added argument normalization middleware to recover from common LLM/client parameter mistakes before Pydantic validation runs. This now remaps `from`/`to` to `from_date`/`to_date` for `list_shifts`, remaps `max_tokens` to `max_results` for `search_incidents`, and coerces list-shaped schedule/shift identifiers into the CSV form expected by the current tool schemas
+
+### Testing
+
+- Expanded snake_case and argument-normalization coverage for alias handling, CSV coercion, and misnamed-argument recovery paths
+
 ## [2.3.13] - Released 2026-06-01
 
 ### Features
 
 - **OAuth Authorization Server Metadata**: Hosted MCP deployments now serve RFC 8414 authorization server metadata so OAuth-capable clients can discover Rootly's authorization endpoints directly from the MCP server
-- **Remote Safe Write Surface Expanded**: The hosted/full tool surface now exposes a broader set of non-destructive write tools for alerts, alert events, alert routes, alert sources, custom forms, form fields, workflow runs, status page templates, and related resources
+- **Safe Write Surface Expanded**: The default write-allowed surface now exposes a broader set of non-destructive tools for alerts, alert events, alert routes, alert sources, custom forms, form fields, workflow runs, status page templates, and related resources when write tools are enabled
 
 ### Fixed
 

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -93,6 +93,7 @@ DEFAULT_HOSTED_ENABLED_TOOLS: frozenset[str] = frozenset(
         "list_incident_alerts",
         "list_incident_events",
         "list_incident_form_field_selections",
+        "list_incident_roles",
         "list_incident_types",
         "list_incidents",
         "list_override_shifts",

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -797,6 +797,124 @@ def register_incident_tools(
                 ),
             )
 
+    @mcp.tool(name="list_incident_roles")
+    async def list_incident_roles(
+        incident_id: Annotated[
+            str,
+            Field(
+                description=(
+                    "Incident reference whose role assignments to list. "
+                    "ARGUMENT NAME IS `incident_id` (not `id`). "
+                    "Accepts: UUID, bare sequential number (`4460`), "
+                    "`#4460`, or `INC-4460`."
+                )
+            ),
+        ],
+    ) -> JsonDict:
+        """List role assignments for an incident (who is Commander, Scribe, etc.).
+
+        Returns one entry per defined role with role metadata and the assigned
+        user (or `user_id: null` for roles that are defined on the incident but
+        not yet assigned). Use this to answer questions like "who is the
+        incident commander?", "is there a postmortem owner?", or "list all
+        roles for INC-4460".
+
+        Implementation note: this wraps `GET /v1/incidents/{id}?include=roles`
+        and flattens the JSON:API `included` array of `incident_role_assignments`
+        into a flat table so callers don't need to walk the relationships graph.
+        """
+        try:
+            resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                incident_id, make_authenticated_request
+            )
+            response = await make_authenticated_request(
+                "GET",
+                f"/v1/incidents/{resolved_incident_id}",
+                params={"include": "roles"},
+            )
+            response.raise_for_status()
+
+            payload = response.json()
+            included = payload.get("included") if isinstance(payload, dict) else None
+            assignments: list[dict[str, Any]] = []
+            if isinstance(included, list):
+                for item in included:
+                    if (
+                        not isinstance(item, dict)
+                        or item.get("type") != "incident_role_assignments"
+                    ):
+                        continue
+                    attrs = item.get("attributes") or {}
+                    role_envelope = attrs.get("incident_role") or {}
+                    role_data = (
+                        role_envelope.get("data") if isinstance(role_envelope, dict) else None
+                    ) or {}
+                    role_attrs = role_data.get("attributes") or {}
+                    user_envelope = attrs.get("user") or {}
+                    user_data = (
+                        user_envelope.get("data") if isinstance(user_envelope, dict) else None
+                    )
+                    user_attrs = (
+                        user_data.get("attributes") or {} if isinstance(user_data, dict) else {}
+                    )
+                    role_name = role_attrs.get("name")
+                    if isinstance(role_name, str):
+                        role_name = role_name.strip() or None
+                    assignments.append(
+                        {
+                            "assignment_id": item.get("id"),
+                            "role_id": role_data.get("id"),
+                            "role_name": role_name,
+                            "role_slug": role_attrs.get("slug"),
+                            "role_summary": role_attrs.get("summary"),
+                            "user_id": (
+                                user_data.get("id") if isinstance(user_data, dict) else None
+                            ),
+                            "user_email": user_attrs.get("email"),
+                            "user_name": user_attrs.get("full_name") or user_attrs.get("name"),
+                            "assigned_at": attrs.get("created_at"),
+                            "updated_at": attrs.get("updated_at"),
+                        }
+                    )
+
+            return cast(
+                JsonDict,
+                {
+                    "data": assignments,
+                    "meta": {
+                        "incident_id": resolved_incident_id,
+                        "total_count": len(assignments),
+                        "assigned_count": sum(1 for a in assignments if a.get("user_id")),
+                        "unassigned_count": sum(1 for a in assignments if not a.get("user_id")),
+                    },
+                },
+            )
+        except ValueError as e:
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to list incident roles: {e}",
+                    "validation_error",
+                ),
+            )
+        except LookupError as e:
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to list incident roles: {e}",
+                    "not_found",
+                ),
+            )
+        except Exception as e:
+            error_type, error_message = mcp_error.categorize_error(e)
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to list incident roles: {error_message}",
+                    error_type,
+                ),
+            )
+
     if enable_write_tools:
 
         @mcp.tool(name="create_incident")

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -615,11 +615,18 @@ class TestScopedIncidentUpdateTool:
 
     @pytest.mark.asyncio
     async def test_list_incident_roles_returns_validation_error_for_blank_reference(self):
-        tools, _ = self._register_tools()
+        tools, request = self._register_tools()
 
         result = await tools["list_incident_roles"](incident_id="   ")
 
-        assert result.get("error_type") == "validation_error" or "error" in result
+        # Specifically the ValueError → validation_error branch must be hit.
+        # A loose `"error" in result` check would also pass for unrelated error
+        # branches (e.g. a network failure) and silently mask the wrong code path.
+        assert result["error"] is True
+        assert result["error_type"] == "validation_error"
+        assert "Incident reference is required" in result["message"]
+        # No upstream HTTP call should have been attempted with a blank reference.
+        request.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_update_incident_sends_only_allowed_fields(self):

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -445,6 +445,183 @@ class TestScopedIncidentUpdateTool:
         ]
 
     @pytest.mark.asyncio
+    async def test_list_incident_roles_tool_is_registered(self):
+        tools, _ = self._register_tools()
+        assert "list_incident_roles" in tools
+
+    @pytest.mark.asyncio
+    async def test_list_incident_roles_returns_flattened_assignments(self):
+        """Happy path: incident_role_assignments in `included` get flattened to a table."""
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {
+                "id": "inc-uuid",
+                "type": "incidents",
+                "relationships": {
+                    "roles": {
+                        "data": [
+                            {"id": "assign-1", "type": "incident_role_assignments"},
+                            {"id": "assign-2", "type": "incident_role_assignments"},
+                        ]
+                    }
+                },
+            },
+            "included": [
+                {
+                    "id": "assign-1",
+                    "type": "incident_role_assignments",
+                    "attributes": {
+                        "incident_role": {
+                            "data": {
+                                "id": "role-commander",
+                                "type": "incident_roles",
+                                "attributes": {
+                                    "slug": "commander",
+                                    "name": "Commander",
+                                    "summary": "Incident Commander",
+                                },
+                            }
+                        },
+                        "user": {
+                            "data": {
+                                "id": "109673",
+                                "type": "users",
+                                "attributes": {
+                                    "email": "spencer.cheng@rootly.com",
+                                    "full_name": "Spencer Cheng",
+                                },
+                            }
+                        },
+                        "created_at": "2026-06-05T09:57:17.213-07:00",
+                        "updated_at": "2026-06-05T09:57:17.819-07:00",
+                    },
+                },
+                {
+                    "id": "assign-2",
+                    "type": "incident_role_assignments",
+                    "attributes": {
+                        "incident_role": {
+                            "data": {
+                                "id": "role-postmortem",
+                                "type": "incident_roles",
+                                "attributes": {
+                                    "slug": "postmortem-owner",
+                                    # Trailing space mirrors real API payloads — must be stripped.
+                                    "name": "Postmortem Owner ",
+                                    "summary": "Postmortem Owner",
+                                },
+                            }
+                        },
+                        # Unassigned role: API returns user: None
+                        "user": None,
+                        "created_at": "2026-06-05T09:57:17.244-07:00",
+                        "updated_at": "2026-06-05T09:57:17.244-07:00",
+                    },
+                },
+            ],
+        }
+        request.return_value = response
+
+        result = await tools["list_incident_roles"](incident_id="inc-uuid")
+
+        request.assert_awaited_once_with(
+            "GET", "/v1/incidents/inc-uuid", params={"include": "roles"}
+        )
+        assert result["meta"] == {
+            "incident_id": "inc-uuid",
+            "total_count": 2,
+            "assigned_count": 1,
+            "unassigned_count": 1,
+        }
+        assignments = result["data"]
+        assert len(assignments) == 2
+
+        commander = assignments[0]
+        assert commander["role_slug"] == "commander"
+        # Trailing space stripped.
+        assert commander["role_name"] == "Commander"
+        assert commander["user_id"] == "109673"
+        assert commander["user_email"] == "spencer.cheng@rootly.com"
+        assert commander["user_name"] == "Spencer Cheng"
+        assert commander["assigned_at"] == "2026-06-05T09:57:17.213-07:00"
+
+        postmortem = assignments[1]
+        assert postmortem["role_slug"] == "postmortem-owner"
+        assert postmortem["role_name"] == "Postmortem Owner"
+        assert postmortem["user_id"] is None
+        assert postmortem["user_email"] is None
+        assert postmortem["user_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_incident_roles_returns_empty_when_no_included(self):
+        """Incident with no roles at all → empty data + zero counts, not an error."""
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {"id": "inc-empty", "type": "incidents", "attributes": {}},
+        }
+        request.return_value = response
+
+        result = await tools["list_incident_roles"](incident_id="inc-empty")
+
+        assert result["data"] == []
+        assert result["meta"]["total_count"] == 0
+        assert result["meta"]["assigned_count"] == 0
+        assert result["meta"]["unassigned_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_incident_roles_resolves_sequential_reference(self):
+        """`INC-4460` should be resolved to a UUID first, then include=roles fetched."""
+        tools, request = self._register_tools()
+
+        list_response = Mock()
+        list_response.raise_for_status.return_value = None
+        list_response.json.return_value = {
+            "data": [
+                {
+                    "id": "22222222-2222-4222-8222-222222222222",
+                    "type": "incidents",
+                    "attributes": {"sequential_id": 4460},
+                }
+            ],
+            "meta": {
+                "current_page": 1,
+                "next_page": None,
+                "prev_page": None,
+                "total_pages": 1,
+                "total_count": 1,
+            },
+        }
+        roles_response = Mock()
+        roles_response.raise_for_status.return_value = None
+        roles_response.json.return_value = {
+            "data": {"id": "22222222-2222-4222-8222-222222222222", "type": "incidents"},
+            "included": [],
+        }
+        request.side_effect = [list_response, roles_response]
+
+        result = await tools["list_incident_roles"](incident_id="INC-4460")
+
+        # Second call must be the include=roles fetch against the resolved UUID.
+        assert request.await_args_list[-1] == call(
+            "GET",
+            "/v1/incidents/22222222-2222-4222-8222-222222222222",
+            params={"include": "roles"},
+        )
+        assert result["meta"]["incident_id"] == "22222222-2222-4222-8222-222222222222"
+
+    @pytest.mark.asyncio
+    async def test_list_incident_roles_returns_validation_error_for_blank_reference(self):
+        tools, _ = self._register_tools()
+
+        result = await tools["list_incident_roles"](incident_id="   ")
+
+        assert result.get("error_type") == "validation_error" or "error" in result
+
+    @pytest.mark.asyncio
     async def test_update_incident_sends_only_allowed_fields(self):
         tools, request = self._register_tools()
         response = Mock()


### PR DESCRIPTION
## Summary

Adds a curated `list_incident_roles(incident_id)` MCP tool that returns role assignments for an incident — who's Incident Commander, Postmortem Owner, Scribe, SME, etc. — as a flat, LLM-friendly table.

Closes a gap surfaced by a customer through Slack: programmatic access to incident role assignments. Previously, the existing `get_incident` tool only exposed `relationships.roles.count` (a number), not the actual assignment array. The data has always been retrievable via `GET /v1/incidents/{id}?include=roles`, but the MCP didn't pass the `include` parameter through.

## What it returns

```json
{
  "data": [
    {
      "assignment_id": "4cf9a12a-...",
      "role_id": "8659d989-...",
      "role_name": "Commander",
      "role_slug": "commander",
      "role_summary": "The incident commander holds the high-level state...",
      "user_id": "109673",
      "user_email": "spencer.cheng@rootly.com",
      "user_name": "Spencer Cheng",
      "assigned_at": "2026-06-05T09:57:17.213-07:00",
      "updated_at": "2026-06-05T09:57:17.819-07:00"
    },
    {
      "assignment_id": "3235b939-...",
      "role_slug": "postmortem-owner",
      "role_name": "Postmortem Owner",
      "user_id": null,
      "user_email": null,
      "user_name": null,
      "assigned_at": "...",
      "updated_at": "..."
    }
  ],
  "meta": {
    "incident_id": "<resolved uuid>",
    "total_count": 2,
    "assigned_count": 1,
    "unassigned_count": 1
  }
}
```

Unassigned roles are included with `user_id: null` so callers see complete state.

## Why a dedicated tool (not just `include=roles` on `get_incident`)

| Factor | Generic `include` param | Dedicated tool (this PR) |
|---|---|---|
| LLM ergonomics | Has to parse JSON:API `included` + cross-reference by id | Flat shape — zero ceremony |
| Discoverability | Hidden as a parameter | "list_incident_roles" is self-documenting |
| Payload risk | LLMs aggressively add every available param → big responses | Bounded, predictable |
| Blast radius | Changes a heavily-used tool's surface | New tool, additive only |

The hidden cost of generic `include` is response size — LLMs tend to set `include=alerts,events,services,functionalities,groups,roles` which on a busy incident can balloon to 100KB+. Bounded tool, bounded surface.

## Changes

- `src/rootly_mcp_server/tools/incidents.py` — new `list_incident_roles` curated tool. Same incident-reference resolution semantics as `get_incident` (accepts UUID, `4460`, `#4460`, `INC-4460`).
- `src/rootly_mcp_server/server_defaults.py` — adds `list_incident_roles` to `DEFAULT_HOSTED_ENABLED_TOOLS` so it ships on `mcp.rootly.com` by default.
- `tests/unit/test_tools.py` — 5 new tests: registered, happy path (assigned + unassigned), empty included, sequential reference resolution, blank-reference validation error.
- `CHANGELOG.md` — Unreleased Features + Testing entries.

## Test plan

- [x] `uv run pytest tests/unit/` — 494 passed
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [ ] Smoke test after merge: call `list_incident_roles` from Claude Desktop / Cursor against a real incident and confirm the output shape matches the test fixtures
- [ ] Verify the tool shows up in the hosted slim profile tools/list

## Out of scope

- Adding generic `include` parameter support to `get_incident` — see "Why a dedicated tool" above. Can be revisited if multiple customer asks accumulate for other relationships.
- Exposing `listIncidentRoles` (the role *definitions* catalog at `/v1/incident_roles`) — different concept; not in this PR.