### PR TITLE
chore: release v2.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Rootly MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.14] - Released 2026-06-05
 
 ### Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rootly-mcp-server"
-version = "2.3.13"
+version = "2.3.14"
 description = "Secure Model Context Protocol server for Rootly APIs with AI SRE capabilities, comprehensive error handling, and input validation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1762,7 +1762,7 @@ wheels = [
 
 [[package]]
 name = "rootly-mcp-server"
-version = "2.3.13"
+version = "2.3.14"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

Patch release rolling up the two changes currently sitting under `[Unreleased]` on main:

| PR | Type | Description |
|---|---|---|
| #137 | Fixed | Misnamed Tool Argument Normalization — recovers from common LLM parameter mistakes (`from`/`to` → `from_date`/`to_date`, `max_tokens` → `max_results`, list-shaped IDs → CSV) before Pydantic validation runs |
| #140 | Features | `list_incident_roles(incident_id)` tool — exposes incident role assignments (Commander, Postmortem Owner, Scribe, etc.) as a flat, LLM-friendly table |

## Changes

- `CHANGELOG.md`: flip `[Unreleased]` → `[2.3.14] - Released 2026-06-05` (content unchanged)
- `pyproject.toml`: `2.3.13` → `2.3.14`
- `uv.lock`: synced

## Test plan

- [x] `uv run pytest tests/unit/` — 494 passed
- [ ] Confirm `mcp.rootly.com` picks up the new `list_incident_roles` tool after deploy