### PR TITLE
feat: return alert payload on detail lookups

### DIFF
--- a/src/rootly_mcp_server/tools/alerts.py
+++ b/src/rootly_mcp_server/tools/alerts.py
@@ -82,9 +82,11 @@ def register_alert_tools(
                 "updated_at": attrs.get("updated_at"),
             }
             # Pass through the raw payload / custom-field data when present.
-            # The alert source populates these (e.g. runbook links added as
-            # custom fields), so they're essential when investigating an alert.
-            for key in ("payload", "data", "alert_field_values", "labels"):
+            # `data` is the alert's raw source payload (what the Rootly UI shows
+            # under the "payload" tab); `alert_field_values` and `labels` hold
+            # custom fields. These can carry things like runbook links, so
+            # they're essential when investigating an alert.
+            for key in ("data", "alert_field_values", "labels"):
                 if key in attrs:
                     result[key] = attrs[key]
             return result

--- a/src/rootly_mcp_server/tools/alerts.py
+++ b/src/rootly_mcp_server/tools/alerts.py
@@ -66,7 +66,7 @@ def register_alert_tools(
 
             data = response.json().get("data", {})
             attrs = data.get("attributes", {})
-            return {
+            result = {
                 "id": data.get("id"),
                 "short_id": attrs.get("short_id"),
                 "summary": attrs.get("summary"),
@@ -77,8 +77,17 @@ def register_alert_tools(
                 "ended_at": attrs.get("ended_at"),
                 "noise": attrs.get("noise"),
                 "url": attrs.get("url"),
+                "external_url": attrs.get("external_url"),
                 "created_at": attrs.get("created_at"),
+                "updated_at": attrs.get("updated_at"),
             }
+            # Pass through the raw payload / custom-field data when present.
+            # The alert source populates these (e.g. runbook links added as
+            # custom fields), so they're essential when investigating an alert.
+            for key in ("payload", "data", "alert_field_values", "labels"):
+                if key in attrs:
+                    result[key] = attrs[key]
+            return result
 
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -714,16 +714,24 @@ def strip_heavy_shift_data(data: dict[str, Any]) -> dict[str, Any]:
 def strip_heavy_alert_data(data: dict[str, Any]) -> dict[str, Any]:
     """
     Strip heavy nested data from alert responses to reduce payload size.
-    Uses a whitelist approach: only essential attributes are kept.
-    Handles both list responses (data: [...]) and single-resource responses (data: {...}).
+
+    List responses (data: [...]) use a whitelist approach: only essential
+    attributes are kept, since a list can hold many alerts and the per-alert
+    detail is rarely needed when scanning.
+
+    Single-resource responses (data: {...}) are a point detail lookup
+    (e.g. GET /v1/alerts/{id}), so all attributes are preserved — including
+    the raw ``payload``/source data, which can carry custom fields like
+    runbook links. Relationships are still collapsed to counts and sideloaded
+    ``included`` data is dropped to keep the response bounded.
     """
     if not isinstance(data, dict) or "data" not in data:
         return data
 
-    def _strip_single_alert(alert: Any) -> None:
+    def _strip_single_alert(alert: Any, *, keep_all_attributes: bool = False) -> None:
         if not isinstance(alert, dict):
             return
-        if "attributes" in alert:
+        if not keep_all_attributes and "attributes" in alert:
             attrs = alert["attributes"]
             keys_to_remove = [k for k in attrs if k not in ALERT_ESSENTIAL_ATTRIBUTES]
             for k in keys_to_remove:
@@ -743,7 +751,8 @@ def strip_heavy_alert_data(data: dict[str, Any]) -> dict[str, Any]:
         for alert in data["data"]:
             _strip_single_alert(alert)
     elif isinstance(data["data"], dict):
-        _strip_single_alert(data["data"])
+        # Detail lookup: keep the full attribute set, including the payload.
+        _strip_single_alert(data["data"], keep_all_attributes=True)
 
     # Remove sideloaded relationship data
     data.pop("included", None)

--- a/tests/unit/test_alert_stripping.py
+++ b/tests/unit/test_alert_stripping.py
@@ -95,14 +95,32 @@ class TestStripHeavyAlertData:
             assert "labels" not in alert["attributes"]
             assert "notified_users" not in alert["attributes"]
 
-    def test_strips_heavy_fields_from_single_resource_response(self):
+    def test_preserves_full_attributes_on_single_resource_response(self):
+        """A single-resource (detail) response keeps all attributes, including
+        the raw payload/custom fields, since it's a point lookup."""
         data = {"data": _make_alert("a1")}
         result = strip_heavy_alert_data(data)
 
-        attr_keys = set(result["data"]["attributes"].keys())
-        assert attr_keys <= ALERT_ESSENTIAL_ATTRIBUTES
-        assert result["data"]["attributes"]["summary"] == "CPU usage above 90%"
-        assert "services" not in result["data"]["attributes"]
+        attrs = result["data"]["attributes"]
+        # Essential fields are still present
+        assert attrs["summary"] == "CPU usage above 90%"
+        # Heavy / payload-bearing fields are preserved on detail lookups
+        assert "services" in attrs
+        assert "data" in attrs
+        assert "alert_field_values" in attrs
+        assert "labels" in attrs
+
+    def test_single_resource_still_collapses_relationships_and_drops_included(self):
+        """Even on detail lookups, relationships collapse and sideloads drop
+        to keep the response bounded."""
+        data = {
+            "data": _make_alert("a1"),
+            "included": [{"id": "svc-1", "type": "services"}],
+        }
+        result = strip_heavy_alert_data(data)
+
+        assert result["data"]["relationships"]["events"] == {"count": 2}
+        assert "included" not in result
 
     def test_collapses_relationships_to_counts(self):
         data = {"data": [_make_alert()]}

--- a/tests/unit/test_alert_tools.py
+++ b/tests/unit/test_alert_tools.py
@@ -87,6 +87,35 @@ class TestGetAlertByShortId:
         assert result["summary"] == "Disk full on web-01"
 
     @pytest.mark.asyncio
+    async def test_returns_payload_and_custom_fields(self):
+        """The raw payload (`data`) and custom fields must come through, since
+        they can carry data like runbook links needed to investigate an alert."""
+        tools, request = _register()
+        alert = _alert_payload(short_id="PhIQtP")
+        alert["attributes"]["data"] = {"runbook_url": "https://wiki/runbooks/disk"}
+        alert["attributes"]["alert_field_values"] = [{"field": "region", "value": "us-east-1"}]
+        alert["attributes"]["labels"] = [{"key": "env", "value": "prod"}]
+        request.return_value = _ok_response(alert)
+
+        result = await tools["get_alert_by_short_id"]("PhIQtP")
+
+        assert result["data"] == {"runbook_url": "https://wiki/runbooks/disk"}
+        assert result["alert_field_values"] == [{"field": "region", "value": "us-east-1"}]
+        assert result["labels"] == [{"key": "env", "value": "prod"}]
+
+    @pytest.mark.asyncio
+    async def test_omits_payload_keys_when_absent(self):
+        """Payload keys are only included when present — no null noise."""
+        tools, request = _register()
+        request.return_value = _ok_response(_alert_payload(short_id="PhIQtP"))
+
+        result = await tools["get_alert_by_short_id"]("PhIQtP")
+
+        assert "data" not in result
+        assert "alert_field_values" not in result
+        assert "labels" not in result
+
+    @pytest.mark.asyncio
     async def test_extracts_short_id_from_url(self):
         tools, request = _register()
         request.return_value = _ok_response(_alert_payload(short_id="PhIQtP"))


### PR DESCRIPTION
## Problem

A customer (Sailpoint, via Pylon #28116) reported that the alert lookup tool in the Rootly MCP server doesn't return all alert data — specifically, custom fields in the alert payload (e.g. runbook links) are missing. This blocks using the MCP server in a Cursor skill to investigate alerts.

### Root cause

Alert responses are stripped to a whitelist of "essential" attributes (`ALERT_ESSENTIAL_ATTRIBUTES`) to keep payloads small. This is applied to **all** alert GET responses — including single-alert detail lookups. The raw payload and custom fields are dropped along with everything else not on the whitelist. Two paths were responsible:

1. `strip_heavy_alert_data()` in `transport.py` (auto-generated `listAlerts` / `getAlert` / single GETs)
2. The curated `get_alert_by_short_id` tool in `tools/alerts.py`, which hand-picks fields

## Fix

Apply the aggressive strip only to **list/search** responses. **Single-resource detail lookups** (`GET /v1/alerts/{id}`, where `data` is an object) are a point lookup — exactly when the full payload is wanted — so they now keep their full attribute set. Relationships are still collapsed to counts and `included` sideloads are still dropped, so the response stays bounded.

- **`transport.py`**: `strip_heavy_alert_data` preserves all attributes on single-resource responses; list responses are unchanged.
- **`tools/alerts.py`**: `get_alert_by_short_id` passes through the payload-bearing fields (plus `external_url`, `updated_at`).
- **tests**: cover detail-lookup payload preservation and the curated tool's pass-through; existing list-stripping behavior unchanged.

## Schema verification

Verified the field names against `rootly_openapi.json` (the spec the tools are generated from) rather than guessing:

- There is **no `payload` attribute** on the alert schema. The raw source payload — what the Rootly UI shows under the **`?tab=payload`** view — is the **`data`** object (`"Additional data"`, nullable).
- Custom fields live in **`alert_field_values`** and **`labels`**.
- So the curated tool passes through `data`, `alert_field_values`, and `labels`.

The `dict`-vs-`list` heuristic was also confirmed safe: the spec defines exactly three alert GET endpoints — `getAlert` (`/v1/alerts/{id}`) returns a single object; `listAlerts` and `listIncidentAlerts` return arrays. The only single-object alert GET is the detail lookup, so the heuristic can't misfire.

## Why this approach

Follows the standard REST convention — **list = summary, detail = full** — so list/search calls stay token-efficient while investigating a specific alert returns everything, including the raw payload / custom fields. No new flags or config required. On a detail lookup the dominant size term is the `data` blob itself (which we *want* to return), so a more surgical whitelist wouldn't meaningfully reduce size — keep-all is simpler and avoids the risk of dropping the very field the customer needs.

## Testing

- `tests/unit/test_alert_stripping.py` and `tests/unit/test_alert_tools.py` updated; full unit suite (497 tests) passes.
- ruff + pyright clean via pre-commit.

## Follow-up

Worth confirming against the customer's test alert (`lsK4hO`) that their runbook links land in `data` (raw payload) vs `alert_field_values` (Rootly custom fields) — both are covered, so this works either way, but good to know which.