### PR TITLE
fix: respect ROOTLY_MCP_ENABLE_WRITE_TOOLS=false on the CLI path

### DIFF
--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -27,7 +27,10 @@ from .code_mode import (
 from .exceptions import RootlyConfigurationError, RootlyMCPError
 from .security import validate_api_token
 from .server import create_rootly_mcp_server, get_hosted_auth_middleware
-from .server_defaults import enabled_tools_from_env, write_tools_enabled_from_env
+from .server_defaults import (
+    enabled_tools_from_env,
+    resolve_write_tools_enabled,
+)
 from .transport import get_hosted_authenticated_user
 
 TransportName = Literal["stdio", "sse", "streamable-http", "both"]
@@ -334,7 +337,8 @@ def get_server():
     base_url = os.getenv("ROOTLY_BASE_URL")
     transport = normalize_transport_or_default(os.getenv("ROOTLY_TRANSPORT", "stdio"))
     hosted_tool_profile = server_defaults.hosted_tool_profile_from_env()
-    enable_write_tools = write_tools_enabled_from_env(default=True)
+    # No CLI flag on this path, so pass None and let the env var decide.
+    enable_write_tools = resolve_write_tools_enabled(None)
     enabled_tools = enabled_tools_from_env(
         hosted=hosted,
         hosted_tool_profile=hosted_tool_profile,
@@ -717,15 +721,7 @@ def main():
         # argparse already normalizes/validates --transport via type=normalize_transport
         normalized_transport = args.transport
         code_mode_enabled = args.enable_code_mode or code_mode_enabled_from_env(default=True)
-        # An explicit --no-enable-write-tools flag wins; otherwise fall back to
-        # the ROOTLY_MCP_ENABLE_WRITE_TOOLS env var, defaulting to write-enabled
-        # (full access by default, matching get_server()). Using `or` here would
-        # ignore ROOTLY_MCP_ENABLE_WRITE_TOOLS=false whenever the flag is absent.
-        enable_write_tools = (
-            args.enable_write_tools
-            if args.enable_write_tools is not None
-            else write_tools_enabled_from_env(default=True)
-        )
+        enable_write_tools = resolve_write_tools_enabled(args.enable_write_tools)
         code_mode_path = (
             normalize_code_mode_path(args.code_mode_path)
             if args.code_mode_path

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -245,10 +245,11 @@ def parse_args():
         "--no-enable-write-tools",
         dest="enable_write_tools",
         action="store_false",
-        # Default None (not True) so "flag absent" is distinguishable from
-        # "flag passed -> False". Otherwise `args.enable_write_tools or <env>`
-        # short-circuits to True and ROOTLY_MCP_ENABLE_WRITE_TOOLS=false is
-        # silently ignored on the CLI / `python -m` path.
+        # Default None (not True) so we can distinguish "flag not passed" from
+        # "flag passed". When the flag is absent we fall back to the
+        # ROOTLY_MCP_ENABLE_WRITE_TOOLS env var; a True default here would make
+        # `args.enable_write_tools or <env>` short-circuit and silently ignore
+        # the env var.
         default=None,
         help="Disable write tools to expose read-only operations",
     )
@@ -716,8 +717,10 @@ def main():
         # argparse already normalizes/validates --transport via type=normalize_transport
         normalized_transport = args.transport
         code_mode_enabled = args.enable_code_mode or code_mode_enabled_from_env(default=True)
-        # Explicit --no-enable-write-tools wins; otherwise fall back to the env
-        # var (default True to preserve full access and match get_server()).
+        # An explicit --no-enable-write-tools flag wins; otherwise fall back to
+        # the ROOTLY_MCP_ENABLE_WRITE_TOOLS env var, defaulting to write-enabled
+        # (full access by default, matching get_server()). Using `or` here would
+        # ignore ROOTLY_MCP_ENABLE_WRITE_TOOLS=false whenever the flag is absent.
         enable_write_tools = (
             args.enable_write_tools
             if args.enable_write_tools is not None

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -191,6 +191,20 @@ def write_tools_enabled_from_env(default: bool = False) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
+def resolve_write_tools_enabled(flag: bool | None) -> bool:
+    """Resolve whether write tools should be exposed.
+
+    Precedence: an explicit --[no-]enable-write-tools flag wins; otherwise fall
+    back to the ROOTLY_MCP_ENABLE_WRITE_TOOLS env var, defaulting to
+    write-enabled (full access by default). `flag` is None when the CLI flag was
+    not passed. Keep get_server() and main() using this single resolver so their
+    precedence rules can't drift apart.
+    """
+    if flag is not None:
+        return flag
+    return write_tools_enabled_from_env(default=True)
+
+
 def normalize_hosted_tool_profile(
     raw: str | None, *, default: str = HOSTED_TOOL_PROFILE_FULL
 ) -> str:

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -187,6 +187,61 @@ def test_get_server_keeps_hosted_default_write_surface():
     assert mock_create.call_args.kwargs["enabled_tools"] is None
 
 
+def _run_main_capture_write_flag(extra_argv, env):
+    """Invoke main() through the --list-tools early-return and return the
+    enable_write_tools kwarg passed to create_rootly_mcp_server."""
+    env = {"ROOTLY_API_TOKEN": "test-token-0123456789abcdef", **env}
+    argv = ["rootly-mcp-server", "--list-tools", *extra_argv]
+    with patch.dict("os.environ", env, clear=True):
+        # Mock setup_logging so invoking main() doesn't mutate global logging
+        # config and leak into other tests.
+        with patch("rootly_mcp_server.__main__.setup_logging"):
+            with patch(
+                "rootly_mcp_server.__main__.create_rootly_mcp_server"
+            ) as mock_create:
+                with patch(
+                    "rootly_mcp_server.__main__._get_sorted_tool_names",
+                    new=AsyncMock(return_value=[]),
+                ):
+                    with patch("sys.argv", argv):
+                        main()
+    assert mock_create.call_args is not None
+    return mock_create.call_args.kwargs["enable_write_tools"]
+
+
+def test_main_env_false_enables_read_only_without_flag():
+    # Regression: ROOTLY_MCP_ENABLE_WRITE_TOOLS=false must restrict to read-only
+    # even when --no-enable-write-tools is absent. Previously the env var was
+    # ignored because `args.enable_write_tools or <env>` short-circuited on the
+    # flag's True default.
+    assert (
+        _run_main_capture_write_flag([], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "false"})
+        is False
+    )
+
+
+def test_main_flag_forces_read_only_over_env_true():
+    # An explicit --no-enable-write-tools wins over ROOTLY_MCP_ENABLE_WRITE_TOOLS=true.
+    assert (
+        _run_main_capture_write_flag(
+            ["--no-enable-write-tools"], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"}
+        )
+        is False
+    )
+
+
+def test_main_defaults_to_write_enabled():
+    # Full access by default when neither the flag nor the env var is set.
+    assert _run_main_capture_write_flag([], {}) is True
+
+
+def test_main_env_true_enables_write_tools():
+    assert (
+        _run_main_capture_write_flag([], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"})
+        is True
+    )
+
+
 def test_get_server_applies_slim_hosted_profile_from_env():
     with patch.dict(
         "os.environ",

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -192,19 +192,19 @@ def _run_main_capture_write_flag(extra_argv, env):
     enable_write_tools kwarg passed to create_rootly_mcp_server."""
     env = {"ROOTLY_API_TOKEN": "test-token-0123456789abcdef", **env}
     argv = ["rootly-mcp-server", "--list-tools", *extra_argv]
-    with patch.dict("os.environ", env, clear=True):
+    with (
+        patch.dict("os.environ", env, clear=True),
         # Mock setup_logging so invoking main() doesn't mutate global logging
         # config and leak into other tests.
-        with patch("rootly_mcp_server.__main__.setup_logging"):
-            with patch(
-                "rootly_mcp_server.__main__.create_rootly_mcp_server"
-            ) as mock_create:
-                with patch(
-                    "rootly_mcp_server.__main__._get_sorted_tool_names",
-                    new=AsyncMock(return_value=[]),
-                ):
-                    with patch("sys.argv", argv):
-                        main()
+        patch("rootly_mcp_server.__main__.setup_logging"),
+        patch("rootly_mcp_server.__main__.create_rootly_mcp_server") as mock_create,
+        patch(
+            "rootly_mcp_server.__main__._get_sorted_tool_names",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch("sys.argv", argv),
+    ):
+        main()
     assert mock_create.call_args is not None
     return mock_create.call_args.kwargs["enable_write_tools"]
 
@@ -214,10 +214,7 @@ def test_main_env_false_enables_read_only_without_flag():
     # even when --no-enable-write-tools is absent. Previously the env var was
     # ignored because `args.enable_write_tools or <env>` short-circuited on the
     # flag's True default.
-    assert (
-        _run_main_capture_write_flag([], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "false"})
-        is False
-    )
+    assert _run_main_capture_write_flag([], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "false"}) is False
 
 
 def test_main_flag_forces_read_only_over_env_true():
@@ -236,9 +233,22 @@ def test_main_defaults_to_write_enabled():
 
 
 def test_main_env_true_enables_write_tools():
+    assert _run_main_capture_write_flag([], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"}) is True
+
+
+def test_main_flag_forces_read_only_without_env():
+    # An explicit --no-enable-write-tools wins even when the env var is unset,
+    # independent of any env-derived default.
+    assert _run_main_capture_write_flag(["--no-enable-write-tools"], {}) is False
+
+
+def test_main_hosted_env_false_enables_read_only():
+    # In hosted mode the env var is still honored: read-only when it is false.
+    # Locks in the env fallback default (write-enabled) not being tied to
+    # hosted_mode.
     assert (
-        _run_main_capture_write_flag([], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"})
-        is True
+        _run_main_capture_write_flag(["--hosted"], {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "false"})
+        is False
     )
 
 

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -11,6 +11,7 @@ from rootly_mcp_server.server_defaults import (
     enabled_tools_from_env,
     hosted_tool_profile_from_env,
     normalize_hosted_tool_profile,
+    resolve_write_tools_enabled,
 )
 
 
@@ -134,3 +135,21 @@ class TestServerDefaultsModule:
         for name in DEFAULT_HOSTED_ENABLED_TOOLS:
             assert name == name.lower(), f"{name!r} is not snake_case"
             assert "-" not in name
+
+    def test_resolve_write_tools_explicit_flag_wins(self):
+        # An explicit flag value always wins over the env var.
+        with patch.dict("os.environ", {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"}, clear=True):
+            assert resolve_write_tools_enabled(False) is False
+        with patch.dict("os.environ", {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "false"}, clear=True):
+            assert resolve_write_tools_enabled(True) is True
+
+    def test_resolve_write_tools_falls_back_to_env_when_flag_absent(self):
+        with patch.dict("os.environ", {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "false"}, clear=True):
+            assert resolve_write_tools_enabled(None) is False
+        with patch.dict("os.environ", {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": "true"}, clear=True):
+            assert resolve_write_tools_enabled(None) is True
+
+    def test_resolve_write_tools_defaults_to_write_enabled(self):
+        # No flag and no env var: full access by default.
+        with patch.dict("os.environ", {}, clear=True):
+            assert resolve_write_tools_enabled(None) is True


### PR DESCRIPTION
> Prepared with the help of Claude Code.

Fixes #149.

## Problem

On the console-script / `python -m rootly_mcp_server` path, setting `ROOTLY_MCP_ENABLE_WRITE_TOOLS=false` does **not** restrict the server to read-only — all write tools (`createIncident`, `updateSchedule`, `createTeam`, …) stay exposed. The README documents the env var as equivalent to the `--no-enable-write-tools` flag, so a user following it believes they're read-only while ~82 write tools remain callable with a full-privilege token.

## Cause

In `main()`:

```python
enable_write_tools = args.enable_write_tools or write_tools_enabled_from_env(default=hosted_mode)
```

`--no-enable-write-tools` is `action="store_false", default=True`, so when the flag is absent `args.enable_write_tools` is `True` and `True or <env>` short-circuits — the env var on the right is never consulted.

## Fix

- Change the flag's `default` to `None` so "flag absent" is distinguishable from "flag passed → `False`".
- Resolve as: explicit flag wins; otherwise fall back to `write_tools_enabled_from_env(default=True)` (preserves full-access-by-default and matches `get_server()`).

Behavior after the fix:

| Flag | `ROOTLY_MCP_ENABLE_WRITE_TOOLS` | Result |
|---|---|---|
| absent | unset | write-enabled (unchanged default) |
| absent | `false` | **read-only (now respected)** |
| absent | `true` | write-enabled |
| `--no-enable-write-tools` | any / unset | read-only (explicit flag wins) |

## Tests

Added 4 regression tests in `tests/unit/test_main_transport.py` driving `main()` through its `--list-tools` early-return and asserting the `enable_write_tools` kwarg: env=`false` without flag, flag-over-env=`true`, default, and env=`true`.

```
ruff check    -> All checks passed!
pyright       -> 0 errors, 0 warnings
pytest tests/unit -> 501 passed
```

No README change is needed — the fix makes the existing documented behavior correct.
