### PR TITLE
docs: recommend Code Mode as the default hosted endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Use the hosted MCP server. No local installation required.
 
 ### Hosted Transport Options
 
-- **Streamable HTTP (recommended):** `https://mcp.rootly.com/mcp`
+- **Code Mode (recommended):** `https://mcp.rootly.com/mcp-codemode`
+- **Streamable HTTP:** `https://mcp.rootly.com/mcp`
 - **SSE (stable alternative):** `https://mcp.rootly.com/sse`
-- **Code Mode:** `https://mcp.rootly.com/mcp-codemode`
 
-Hosted tool profiles:
+> **Use Code Mode.** Instead of registering ~200 individual tools (whose schemas are re-sent on every model turn), Code Mode exposes a compact set of meta-tools — `list_tools`, `tool_search`, `get_schema`, `tags`, and `execute`. The model discovers the tools it needs and writes a short async Python block in `execute` that chains multiple `await call_tool(...)` calls **server-side**, returning only the final result. In practice this means **dramatically lower token usage** (a handful of tool schemas instead of hundreds) and **fewer round-trips** for multi-step work (one `execute` call instead of N tool calls). Prefer it for any agent that can write code — which is virtually all modern LLM clients. The plain Streamable HTTP and SSE endpoints remain available for clients that need the classic one-tool-per-operation surface.
+
+Hosted tool profiles (apply to the classic Streamable HTTP / SSE endpoints):
 
 - **Full (default):** use the URLs above as-is
 - **Slim (~70 tools):** add `?tool_profile=slim` to the hosted URL, for example `https://mcp.rootly.com/mcp?tool_profile=slim`
@@ -29,48 +31,7 @@ Hosted tool profiles:
 
 ### General Remote Setup
 
-**With OAuth2 (recommended):**
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "url": "https://mcp.rootly.com/mcp"
-    }
-  }
-}
-```
-
-Your MCP client handles OAuth2 login automatically — a browser window opens for you to authenticate with Rootly. No API token needed.
-
-**With API Token:**
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "url": "https://mcp.rootly.com/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_ROOTLY_API_TOKEN"
-      }
-    }
-  }
-}
-```
-
-SSE (alternative):
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "url": "https://mcp.rootly.com/sse"
-    }
-  }
-}
-```
-
-Code Mode:
+**Code Mode with OAuth2 (recommended):**
 
 ```json
 {
@@ -82,6 +43,40 @@ Code Mode:
 }
 ```
 
+Your MCP client handles OAuth2 login automatically — a browser window opens for you to authenticate with Rootly. No API token needed. Code Mode supports OAuth2 (and bearer tokens) identically to the classic endpoint.
+
+**Code Mode with API Token:**
+
+```json
+{
+  "mcpServers": {
+    "rootly": {
+      "url": "https://mcp.rootly.com/mcp-codemode",
+      "headers": {
+        "Authorization": "Bearer YOUR_ROOTLY_API_TOKEN"
+      }
+    }
+  }
+}
+```
+
+<details>
+<summary>Classic one-tool-per-operation endpoints (Streamable HTTP / SSE)</summary>
+
+Use these if your client can't write code in Code Mode's `execute` tool. Swap the URL for `https://mcp.rootly.com/mcp` (Streamable HTTP) or `https://mcp.rootly.com/sse` (SSE); both accept OAuth2 or a `Authorization: Bearer` token the same way.
+
+```json
+{
+  "mcpServers": {
+    "rootly": {
+      "url": "https://mcp.rootly.com/mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ### Agent Setup
 
 <details>
@@ -89,19 +84,19 @@ Code Mode:
 
 <br>
 
-**With OAuth2 (recommended):**
+**With OAuth2 (recommended) — Code Mode:**
 
 ```bash
-claude mcp add --transport http rootly https://mcp.rootly.com/mcp
+claude mcp add --transport http rootly https://mcp.rootly.com/mcp-codemode
 
-# Code Mode:
-claude mcp add --transport http rootly-codemode https://mcp.rootly.com/mcp-codemode
+# Classic one-tool-per-operation endpoint, if you need it:
+claude mcp add --transport http rootly-classic https://mcp.rootly.com/mcp
 ```
 
 **With API Token:**
 
 ```bash
-claude mcp add --transport http rootly https://mcp.rootly.com/mcp \
+claude mcp add --transport http rootly https://mcp.rootly.com/mcp-codemode \
   --header "Authorization: Bearer YOUR_ROOTLY_API_TOKEN"
 ```
 
@@ -112,7 +107,7 @@ claude mcp add --transport http rootly https://mcp.rootly.com/mcp \
   "mcpServers": {
     "rootly": {
       "type": "http",
-      "url": "https://mcp.rootly.com/mcp"
+      "url": "https://mcp.rootly.com/mcp-codemode"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Use the hosted MCP server. No local installation required.
 - **SSE (stable alternative):** `https://mcp.rootly.com/sse`
 
 > **Use Code Mode.** Instead of registering ~200 individual tools (whose schemas are re-sent on every model turn), Code Mode exposes a compact set of meta-tools — `list_tools`, `tool_search`, `get_schema`, `tags`, and `execute`. The model discovers the tools it needs and writes a short async Python block in `execute` that chains multiple `await call_tool(...)` calls **server-side**, returning only the final result. In practice this means **dramatically lower token usage** (a handful of tool schemas instead of hundreds) and **fewer round-trips** for multi-step work (one `execute` call instead of N tool calls). Prefer it for any agent that can write code — which is virtually all modern LLM clients. The plain Streamable HTTP and SSE endpoints remain available for clients that need the classic one-tool-per-operation surface.
+>
+> ⚠️ **Connect Code Mode *instead of* the classic endpoints, not alongside them.** If both surfaces are available to the same client, the model tends to call the classic tools directly and skips `execute` entirely — so the ~200 tool schemas still load and you lose the token savings. Pick one endpoint per client.
 
 Hosted tool profiles (apply to the classic Streamable HTTP / SSE endpoints):
 


### PR DESCRIPTION
## What

Positions **Code Mode** (`https://mcp.rootly.com/mcp-codemode`) as the recommended/go-to hosted endpoint in the README, with the classic one-tool-per-operation endpoints (Streamable HTTP / SSE) kept as documented alternatives.

## Why

Code Mode exposes a compact set of meta-tools — `list_tools`, `tool_search`, `get_schema`, `tags`, `execute` — instead of ~200 individual tools. The model discovers what it needs and writes a short async Python block in `execute` that chains multiple `await call_tool(...)` calls **server-side**, returning only the final result. That yields:

- **Dramatically lower token usage** — a handful of tool schemas re-sent per model turn instead of hundreds (the classic surface adds ~25K tokens of tool schema per turn).
- **Fewer round-trips** — one `execute` call for multi-step work instead of N separate tool calls.

This directly addresses the "token-hungry" feedback by attacking the dominant fixed cost (tool-surface size) rather than per-call payloads.

## Verified

- Code Mode connects and runs end-to-end against the hosted server (`serverInfo: "Rootly Code Mode" v3.3.1`); `execute` successfully chained `get_current_user` + `list_incidents` in a single call.
- **OAuth2 supported** — `/mcp-codemode` returns the identical `WWW-Authenticate` challenge as the classic endpoint; confirmed working via Claude Desktop's browser OAuth flow.

## Changes (README only)

- Lead the hosted transport options with **Code Mode (recommended)** plus a rationale callout; demote plain Streamable HTTP / SSE to alternatives.
- Lead the general remote setup and the Claude Code quick-add with the `/mcp-codemode` URL; keep the classic endpoints documented (in a collapsible) for clients that can't use the `execute` sandbox.

## Follow-up (not in this PR)

Per-agent quick-start snippets further down (Cursor, Gemini, etc.) still reference the classic `/mcp` URL — can be flipped to `/mcp-codemode` in a follow-up if desired. The separate `rootly-docs` site should get the same treatment.