### PR TITLE
chore: migrate telemetry SDK from mcpcat to agentcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,11 @@ COPY . .
 RUN uv pip install --system --no-cache-dir -e .
 
 # Install AgentCat (formerly MCPcat) for hosted telemetry without changing the
-# repo dependency graph. AgentCat's package metadata pins an older Pydantic
+# repo dependency graph. The [community] extra provides FastMCP support, which
+# this server relies on. AgentCat's package metadata pins an older Pydantic
 # range, but the SDK imports successfully with our runtime pin, so we restore
 # the server's pinned version after installation.
-RUN uv pip install --system --no-cache-dir agentcat==1.0.0 \
+RUN uv pip install --system --no-cache-dir "agentcat[community]==1.0.0" \
     && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ COPY . .
 # Install the package and its dependencies
 RUN uv pip install --system --no-cache-dir -e .
 
-# Install MCPcat for hosted telemetry without changing the repo dependency graph.
-# MCPcat's current package metadata pins an older Pydantic range, but the SDK
-# imports successfully with our runtime pin, so we restore the server's pinned
-# version after installation.
-RUN uv pip install --system --no-cache-dir mcpcat==0.1.14 \
+# Install AgentCat (formerly MCPcat) for hosted telemetry without changing the
+# repo dependency graph. AgentCat's package metadata pins an older Pydantic
+# range, but the SDK imports successfully with our runtime pin, so we restore
+# the server's pinned version after installation.
+RUN uv pip install --system --no-cache-dir agentcat==1.0.0 \
     && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -99,36 +99,37 @@ def resolve_requested_hosted_tool_profile(
 
 
 def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging.Logger) -> None:
-    """Enable MCPcat tracking when configured and available.
+    """Enable AgentCat tracking when configured and available.
 
-    The Python MCPcat package is currently deployed separately from the core
-    server dependency set, so we load it lazily and only when a project ID is
-    configured. This keeps the base server behavior unchanged for self-hosted
-    users and local development environments that do not install MCPcat.
+    The Python AgentCat package (formerly MCPcat) is currently deployed
+    separately from the core server dependency set, so we load it lazily and
+    only when a project ID is configured. This keeps the base server behavior
+    unchanged for self-hosted users and local development environments that do
+    not install AgentCat.
     """
     if not project_id:
         return
 
     try:
-        mcpcat = importlib.import_module("mcpcat")
-        mcpcat_types = importlib.import_module("mcpcat.types")
+        agentcat = importlib.import_module("agentcat")
+        agentcat_types = importlib.import_module("agentcat.types")
     except ImportError:
         logger.warning(
-            "ROOTLY_MCPCAT_PROJECT_ID is set but mcpcat is not installed; skipping MCPcat tracking"
+            "ROOTLY_MCPCAT_PROJECT_ID is set but agentcat is not installed; skipping AgentCat tracking"
         )
         return
 
     try:
-        options = mcpcat_types.MCPCatOptions(
-            identify=build_mcpcat_identify_callback(mcpcat_types.UserIdentity),
+        options = agentcat_types.AgentCatOptions(
+            identify=build_mcpcat_identify_callback(agentcat_types.UserIdentity),
         )
-        mcpcat.track(server, project_id, options)
+        agentcat.track(server, project_id, options)
     except Exception:
-        logger.warning("MCPcat tracking could not be enabled; skipping", exc_info=True)
+        logger.warning("AgentCat tracking could not be enabled; skipping", exc_info=True)
 
 
 def build_mcpcat_identify_callback(user_identity_cls: type[Any]):
-    """Build a lightweight MCPcat identify callback from hosted auth context."""
+    """Build a lightweight AgentCat identify callback from hosted auth context."""
 
     def identify(_request: dict[str, Any], _context: Any) -> Any:
         user = get_hosted_authenticated_user()

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -169,24 +169,24 @@ def test_maybe_enable_mcpcat_tracking_logs_when_package_missing():
     ) as mock_import:
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
-    mock_import.assert_called_once_with("mcpcat")
+    mock_import.assert_called_once_with("agentcat")
     logger.warning.assert_called_once()
 
 
 def test_maybe_enable_mcpcat_tracking_tracks_when_available():
     server = object()
     logger = Mock()
-    mcpcat_module = SimpleNamespace(track=Mock())
-    mcpcat_types_module = SimpleNamespace(
-        MCPCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+    agentcat_module = SimpleNamespace(track=Mock())
+    agentcat_types_module = SimpleNamespace(
+        AgentCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
         UserIdentity=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
     )
 
     def import_side_effect(module_name: str):
-        if module_name == "mcpcat":
-            return mcpcat_module
-        if module_name == "mcpcat.types":
-            return mcpcat_types_module
+        if module_name == "agentcat":
+            return agentcat_module
+        if module_name == "agentcat.types":
+            return agentcat_types_module
         raise ImportError(module_name)
 
     with patch(
@@ -194,8 +194,8 @@ def test_maybe_enable_mcpcat_tracking_tracks_when_available():
     ):
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
-    mcpcat_module.track.assert_called_once()
-    call = mcpcat_module.track.call_args
+    agentcat_module.track.assert_called_once()
+    call = agentcat_module.track.call_args
     assert call.args[:2] == (server, "proj_test_123")
     assert callable(call.args[2].identify)
 
@@ -203,17 +203,17 @@ def test_maybe_enable_mcpcat_tracking_tracks_when_available():
 def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
     server = object()
     logger = Mock()
-    mcpcat_module = SimpleNamespace(track=Mock(side_effect=RuntimeError("boom")))
-    mcpcat_types_module = SimpleNamespace(
-        MCPCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+    agentcat_module = SimpleNamespace(track=Mock(side_effect=RuntimeError("boom")))
+    agentcat_types_module = SimpleNamespace(
+        AgentCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
         UserIdentity=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
     )
 
     def import_side_effect(module_name: str):
-        if module_name == "mcpcat":
-            return mcpcat_module
-        if module_name == "mcpcat.types":
-            return mcpcat_types_module
+        if module_name == "agentcat":
+            return agentcat_module
+        if module_name == "agentcat.types":
+            return agentcat_types_module
         raise ImportError(module_name)
 
     with patch(
@@ -221,9 +221,9 @@ def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
     ):
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
-    assert mcpcat_module.track.call_args.args[:2] == (server, "proj_test_123")
+    assert agentcat_module.track.call_args.args[:2] == (server, "proj_test_123")
     logger.warning.assert_called_once_with(
-        "MCPcat tracking could not be enabled; skipping",
+        "AgentCat tracking could not be enabled; skipping",
         exc_info=True,
     )
 


### PR DESCRIPTION
## What

Migrates the hosted-telemetry SDK from **`mcpcat`** to its renamed successor **`agentcat`** (same API, new package name). Verified against the official [MIGRATION.md](https://github.com/agentcathq/agentcat-python-sdk/blob/HEAD/MIGRATION.md).

`mcpcat` is deprecated — its own PyPI metadata marks it "renamed to 'agentcat'" and links `agentcat` as the migration target — and the guide confirms **both SDKs report to the same unified platform with continuous dashboard history**, so the project ID carries over with no re-registration.

## Changes
- **Dockerfile:** install **`agentcat[community]==1.0.0`** instead of `mcpcat==0.1.14`. The `[community]` extra provides **FastMCP support** (per the guide) — required here since `track()` wraps a FastMCP server; plain `mcpcat` bundled this, `agentcat` splits it into the extra. Kept the "re-pin `pydantic==2.13.4` after install" step (agentcat pulls an older pydantic on install but imports fine under our pin).
- **`__main__.py`:** lazy imports load `agentcat` / `agentcat.types`; `MCPCatOptions` → `AgentCatOptions` (`UserIdentity` unchanged per guide); log/docstring wording updated.
- **Tests:** mocked module names, `AgentCatOptions` type, and warning-text assertions updated.

## Guide checklist
| Guide item | Status |
|---|---|
| `pip install agentcat[community]` (FastMCP) | ✅ Dockerfile |
| import mcpcat → agentcat | ✅ |
| `MCPCatOptions` → `AgentCatOptions` | ✅ |
| `MCPCatData` → `AgentCatData` | n/a (unused here) |
| `UserIdentity` unchanged | ✅ |
| `MCPCAT_API_URL` → `AGENTCAT_API_URL` (old = fallback) | n/a (not set in repo) |
| `~/mcpcat.log` → `~/agentcat.log` | n/a (not referenced) |
| project ID / `track()` unchanged | ✅ |

## Verification
- Introspected real `agentcat` 1.0.0: `track`, `AgentCatOptions`, `UserIdentity` present; `agentcat[community]` imports cleanly under `pydantic==2.13.4`.
- `uv build` succeeds; ruff + pyright clean; **497 unit tests pass**.

## Left unchanged / to check outside this PR
- **`ROOTLY_MCPCAT_PROJECT_ID`** env var — kept (carries the project ID, set in deploy config). Rename only in a coordinated code+deploy change.
- **`AGENTCAT_DEBUG_MODE`** — the guide notes `MCPCAT_DEBUG_MODE` → `AGENTCAT_DEBUG_MODE` has **no fallback**. Not set in this repo, but **check the deploy/hosting config** — if `MCPCAT_DEBUG_MODE` is set there, rename it or debug mode silently stops.
- Internal helper names (`maybe_enable_mcpcat_tracking`, etc.) — cosmetic, kept.
- No TypeScript/JS repo (incl. the Cloudflare MCP) references mcpcat — nothing to migrate there.