### PR TITLE
chore: bump agentcat to 1.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN uv pip install --system --no-cache-dir -e .
 # this server relies on. AgentCat's package metadata pins an older Pydantic
 # range, but the SDK imports successfully with our runtime pin, so we restore
 # the server's pinned version after installation.
-RUN uv pip install --system --no-cache-dir "agentcat[community]==1.0.0" \
+RUN uv pip install --system --no-cache-dir "agentcat[community]==1.0.1" \
     && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user


### PR DESCRIPTION
One-line follow-up to #154.

#154 merged the mcpcat→agentcat migration at `agentcat[community]==1.0.0`. AgentCat then published **1.0.1**, which adds additional agent context to analytics. The 1.0.1 bump was pushed to the #154 branch after it had already merged, so it never reached `main` — this PR carries it in.

- **Dockerfile:** `agentcat[community]==1.0.0` → `1.0.1`.

Telemetry-only; no runtime or customer impact. Verified: 1.0.1 installs and imports cleanly under `pydantic==2.13.4` (`track` + `AgentCatOptions` present).