### PR TITLE
feat: expose meeting recordings and transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.3.15] - Unreleased
 
+### Added
+
+- **Meeting Recordings & Transcripts**: Added read-only tools `get_meeting_recording`, `list_meeting_recordings`, and `list_all_meeting_recordings` so agents can read call transcripts (the `meeting_transcript` / `meeting_transcript_formatted` data). Call `get_meeting_recording` with `include=transcript` for the full transcript. Refreshed the bundled `data/swagger.json` from source to pick up these endpoints
+
 ### Fixed
 
 - **Alert Payload Returned on Detail Lookups**: Single-alert lookups now return the full alert payload, including custom fields. Alert responses were stripped to a whitelist of essential attributes to keep payloads small, but this also dropped the raw `data` payload — where custom fields such as runbook links live (the same data shown under the Rootly UI's alert "payload" tab). The strip now applies only to list/search responses; single-resource detail lookups (`GET /v1/alerts/{id}`) preserve their full attribute set, while relationships are still collapsed to counts and sideloaded `included` data is dropped to keep responses bounded. The curated `get_alert_by_short_id` tool also passes through `data`, `alert_field_values`, and `labels` (plus `external_url` and `updated_at`). Verified end-to-end against a live alert

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,19 +39,23 @@ uv pip install <package>
 
 ### 3. Set Up Git Hooks (Recommended)
 
-Install pre-commit hooks to automatically run linting and tests before commits:
+Install pre-commit hooks to automatically run the quality gate before commits:
 
 ```bash
-./scripts/setup-hooks.sh
+make hooks   # or: ./scripts/setup-hooks.sh
 ```
 
-This ensures code quality by running:
-- Ruff linting
-- Pyright type checking
-- Unit tests
+The hook runs `make check` (lint, format check, type checks, unit tests) —
+the same gate CI enforces.
 
 ### 4. Verify Installation
 
 The server should now be ready to use with your MCP-compatible editor.
 
 Additional testing tools are available in the `tests/` directory.
+
+## Common Tasks
+
+The `Makefile` wraps the toolchain; run `make help` to list every target.
+Common ones: `make check` (pre-push gate), `make test`, and `make fetch-spec`
+to refresh the bundled OpenAPI spec from source.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,87 @@
+.DEFAULT_GOAL := help
+
+PYTHON_VERSION := 3.12
+SPEC_URL       := https://rootly-heroku.s3.amazonaws.com/swagger/v1/swagger.json
+SPEC_PATH      := src/rootly_mcp_server/data/swagger.json
+PKG            := src/rootly_mcp_server
+UV             := uv run --python $(PYTHON_VERSION)
+
+IMAGE := rootly-mcp-server
+
+.PHONY: help install build run \
+        test test-unit test-integration \
+        lint format format-check typecheck security \
+        fetch-spec audit-spec \
+        docker-build docker-test \
+        check ci hooks clean
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install dependencies and the pinned Python via uv
+	uv sync --dev --python $(PYTHON_VERSION)
+
+build: ## Build the sdist and wheel
+	uv build
+
+run: ## Run the MCP server locally (needs ROOTLY_API_TOKEN)
+	$(UV) rootly-mcp-server
+
+# --- tests ---
+test: ## Run the full test suite (with coverage)
+	$(UV) pytest
+
+test-unit: ## Run unit tests only
+	$(UV) pytest tests/unit/
+
+test-integration: ## Run local integration tests (needs ROOTLY_API_TOKEN)
+	$(UV) pytest tests/integration/local/ -x
+
+# --- quality ---
+lint: ## Lint with ruff
+	$(UV) ruff check .
+
+format: ## Auto-format with ruff
+	$(UV) ruff format .
+
+format-check: ## Check formatting without modifying files (CI gate)
+	$(UV) ruff format --check .
+
+typecheck: ## Type-check with pyright and mypy
+	$(UV) pyright
+	$(UV) mypy $(PKG)
+
+security: ## Security scan (bandit blocking; pip-audit advisory, mirrors CI)
+	$(UV) bandit -r src/
+	-$(UV) pip-audit
+
+# --- OpenAPI spec ---
+fetch-spec: ## Refresh the bundled OpenAPI spec from source (never hand-edit it)
+	curl -fsS $(SPEC_URL) -o $(SPEC_PATH)
+
+audit-spec: ## Audit the bundled spec for MCP tool-generation issues
+	$(UV) python scripts/audit_openapi.py --filtered-defaults --instantiate-server
+
+# --- docker (mirrors the CI container-tests job) ---
+docker-build: ## Build the Docker image
+	docker build -t $(IMAGE) .
+
+docker-test: docker-build ## Build the image and run the containerized server smoke test (needs ROOTLY_API_TOKEN)
+	docker run -d --name $(IMAGE) -p 8000:8000 -e ROOTLY_API_TOKEN="$(ROOTLY_API_TOKEN)" $(IMAGE)
+	timeout 30s bash -c 'until curl -fsS http://localhost:8000/health || curl -fsS http://localhost:8000/; do sleep 2; done'
+	MCP_SERVER_URL=http://localhost:8000 $(UV) pytest tests/integration/remote/test_essential.py -v --timeout=60; \
+		status=$$?; docker stop $(IMAGE) && docker rm $(IMAGE); exit $$status
+
+# --- aggregates ---
+check: lint format-check typecheck test-unit ## Fast pre-push gate (mirrors CI quality + unit tests)
+
+ci: lint format-check typecheck security test-unit audit-spec ## Everything CI enforces (excl. docker/remote)
+
+# --- misc ---
+hooks: ## Install the git pre-commit hook
+	./scripts/setup-hooks.sh
+
+clean: ## Remove build and test artifacts
+	rm -rf dist build .pytest_cache .mypy_cache .ruff_cache coverage.xml htmlcov
+	find . -type d -name __pycache__ -prune -exec rm -rf {} +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ dev = [
     "pip-audit>=2.7.0",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pyright>=1.1.411",
     "ruff>=0.7.3",
     "pytest>=9.0.3",

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -9,47 +9,20 @@ HOOKS_DIR="$REPO_ROOT/.git/hooks"
 
 echo "🔧 Setting up git hooks..."
 
-# Create pre-commit hook
+# Create pre-commit hook. It delegates to `make check` so the hook and CI
+# share a single definition of the pre-push gate (lint, format-check,
+# typecheck, unit tests).
 cat > "$HOOKS_DIR/pre-commit" << 'EOF'
 #!/bin/bash
-# Pre-commit hook to run linting and type checking
-# This ensures code quality before committing
-
+# Pre-commit hook: run the shared quality gate before committing.
 set -e
 
-echo "🔍 Running pre-commit checks..."
-echo ""
-
-# 1. Ruff linting
-echo "📝 Checking code style with ruff..."
-if ! uv run ruff check .; then
-    echo "❌ Ruff linting failed!"
-    echo "💡 Try running: uv run ruff check . --fix"
+echo "🔍 Running pre-commit checks (make check)..."
+if ! make check; then
+    echo "❌ Pre-commit checks failed!"
+    echo "💡 Fix the issues above, or skip with: git commit --no-verify"
     exit 1
 fi
-echo "✅ Ruff passed!"
-echo ""
-
-# 2. Pyright type checking
-echo "🔍 Running type checks with pyright..."
-if ! uv run pyright; then
-    echo "❌ Type checking failed!"
-    echo "💡 Fix type errors or add type: ignore comments"
-    exit 1
-fi
-echo "✅ Pyright passed!"
-echo ""
-
-# 3. Run unit tests (quick check)
-echo "🧪 Running unit tests..."
-if ! uv run pytest tests/unit/ -q --tb=line; then
-    echo "❌ Tests failed!"
-    echo "💡 Fix failing tests before committing"
-    exit 1
-fi
-echo "✅ Tests passed!"
-echo ""
-
 echo "✅ All pre-commit checks passed! Proceeding with commit..."
 exit 0
 EOF
@@ -58,9 +31,9 @@ chmod +x "$HOOKS_DIR/pre-commit"
 
 echo "✅ Git hooks installed successfully!"
 echo ""
-echo "The following checks will run before every commit:"
-echo "  1. Ruff linting"
-echo "  2. Pyright type checking"
-echo "  3. Unit tests"
+echo "Before every commit, 'make check' runs:"
+echo "  - Ruff lint + format check"
+echo "  - Pyright and mypy type checks"
+echo "  - Unit tests"
 echo ""
 echo "To skip hooks (not recommended): git commit --no-verify"

--- a/src/rootly_mcp_server/data/swagger.json
+++ b/src/rootly_mcp_server/data/swagger.json
@@ -9,6 +9,239 @@
     }
   },
   "paths": {
+    "/v1/ai/chat": {
+      "post": {
+        "summary": "Send AI chat message",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "AI Chat"
+        ],
+        "description": "Send a message to the AI assistant and receive a synchronous reply. Optionally bind the conversation to an incident or alert for context-aware responses. Requires `ai.chat:write` OAuth scope or an API key.",
+        "operationId": "createAiChat",
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Message to send to the AI assistant",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Resume an existing session",
+            "required": false
+          },
+          {
+            "name": "incident_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Bind session to an incident for context (mutually exclusive with alert_id)",
+            "required": false
+          },
+          {
+            "name": "alert_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Bind session to an alert for context (mutually exclusive with incident_id)",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI chat response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ai_chat_response"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "AI chat not enabled or insufficient scope"
+          },
+          "422": {
+            "description": "invalid request"
+          }
+        }
+      }
+    },
+    "/v1/ai/chat/stream": {
+      "post": {
+        "summary": "Stream AI chat response (SSE)",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "AI Chat"
+        ],
+        "description": "Send a message and receive the AI response as a Server-Sent Events stream. Optionally bind to an incident or alert for context. Events: `session_id` (initial), `text` (content chunks), `task_update` (tool progress), `error`, `done` (terminal with status). Requires `ai.chat:write` OAuth scope or an API key.",
+        "operationId": "streamAiChat",
+        "parameters": [
+          {
+            "name": "message",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Message to send",
+            "required": true
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Resume an existing session",
+            "required": false
+          },
+          {
+            "name": "incident_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Bind session to an incident (mutually exclusive with alert_id)",
+            "required": false
+          },
+          {
+            "name": "alert_id",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Bind session to an alert (mutually exclusive with incident_id)",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE event stream"
+          },
+          "403": {
+            "description": "AI chat not enabled"
+          }
+        }
+      }
+    },
+    "/v1/ai/chat/sessions/{session_id}/messages": {
+      "get": {
+        "summary": "List AI chat session messages",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "AI Chat"
+        ],
+        "description": "Returns the user and assistant message history for a session, paginated and chronologically ordered. Internal tool messages are filtered out. Requires `ai.chat:read` OAuth scope or an API key.",
+        "operationId": "listAiChatSessionMessages",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Session UUID",
+            "required": true
+          },
+          {
+            "name": "page[number]",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Page number (default 1)",
+            "required": false
+          },
+          {
+            "name": "page[size]",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Messages per page (max 100, default 50)",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "session messages",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ai_chat_session_message_list"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found"
+          }
+        }
+      }
+    },
+    "/v1/ai/chat/sessions/{id}": {
+      "delete": {
+        "summary": "Delete AI chat session",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "AI Chat"
+        ],
+        "description": "Permanently deletes an AI chat session and all its messages. Requires `ai.chat:write` OAuth scope or an API key.",
+        "operationId": "deleteAiChatSession",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Session UUID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "session deleted"
+          },
+          "404": {
+            "description": "session not found"
+          }
+        }
+      }
+    },
     "/v1/alerts/{alert_id}/events": {
       "parameters": [
         {
@@ -127,6 +360,177 @@
             "application/vnd.api+json": {
               "schema": {
                 "$ref": "#/components/schemas/new_alert_event"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/alert_events": {
+      "get": {
+        "summary": "List alert events across alerts",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "AlertEvents"
+        ],
+        "description": "Returns a flat list of alert events across all alerts the requester can access. Designed for periodic polling: use `page[after]` with the `next_cursor` returned in the previous response to stream forward.",
+        "operationId": "listAlertEventsFeed",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page[size]",
+            "in": "query",
+            "required": false,
+            "description": "Page size (max 50).",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[after]",
+            "in": "query",
+            "required": false,
+            "description": "Cursor token from the previous response's `meta.next_cursor`. Pass the same `sort` value used to obtain the cursor.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort by `created_at`. Defaults to `created_at` (oldest-first). Use `-created_at` for newest-first.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created_at",
+                "-created_at"
+              ]
+            },
+            "required": false
+          },
+          {
+            "name": "filter[kind]",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "informational",
+                "notification",
+                "action",
+                "status_update",
+                "recording",
+                "alert_grouping",
+                "alert_urgency",
+                "alert_routing",
+                "note",
+                "noise",
+                "maintenance",
+                "deferral"
+              ]
+            },
+            "required": false
+          },
+          {
+            "name": "filter[action]",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "created",
+                "escalation_policy_paged",
+                "ignored_alert_request",
+                "call_lifecycle",
+                "level_skipped",
+                "emailed",
+                "slacked",
+                "ms_teams_messaged",
+                "google_chat_messaged",
+                "called",
+                "texted",
+                "notified",
+                "skipped",
+                "opened",
+                "retriggered",
+                "answered",
+                "acknowledged",
+                "escalated",
+                "paged",
+                "resolved",
+                "attached",
+                "snoozed",
+                "triggered",
+                "open",
+                "updated",
+                "added",
+                "removed",
+                "marked",
+                "not_marked",
+                "muted",
+                "deferred"
+              ]
+            },
+            "required": false
+          },
+          {
+            "name": "filter[alert_id]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[created_at][gt]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[created_at][gte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[created_at][lt]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/alert_event_feed_list"
+                }
               }
             }
           }
@@ -404,6 +808,70 @@
             }
           },
           {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -652,6 +1120,70 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -847,6 +1379,70 @@
           },
           {
             "name": "filter[name]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -1340,6 +1936,70 @@
             }
           },
           {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -1644,6 +2304,38 @@
             }
           },
           {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -1921,6 +2613,14 @@
             }
           },
           {
+            "name": "filter[enabled]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -2004,7 +2704,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "alert source updated",
+            "description": "preserves existing alert source field ids",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -2151,8 +2851,10 @@
                 "environments",
                 "services",
                 "groups",
+                "functionalities",
                 "responders",
                 "incidents",
+                "notified_users",
                 "events",
                 "alert_urgency",
                 "heartbeat",
@@ -2163,8 +2865,7 @@
                 "alert_field_values",
                 "alerting_targets",
                 "escalation_policies",
-                "alert_call_recording",
-                "alert_urgency"
+                "alert_call_recording"
               ]
             },
             "required": false
@@ -2264,8 +2965,10 @@
                 "environments",
                 "services",
                 "groups",
+                "functionalities",
                 "responders",
                 "incidents",
+                "notified_users",
                 "events",
                 "alert_urgency",
                 "heartbeat",
@@ -2276,8 +2979,7 @@
                 "alert_field_values",
                 "alerting_targets",
                 "escalation_policies",
-                "alert_call_recording",
-                "alert_urgency"
+                "alert_call_recording"
               ]
             },
             "required": false
@@ -2427,6 +3129,230 @@
             }
           },
           {
+            "name": "filter[updated_at][gt]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[updated_at][gte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[updated_at][lt]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[updated_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[groups][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[groups][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[groups][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[groups][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "page[after]",
             "in": "query",
             "required": false,
@@ -2500,8 +3426,10 @@
                 "environments",
                 "services",
                 "groups",
+                "functionalities",
                 "responders",
                 "incidents",
+                "notified_users",
                 "events",
                 "alert_urgency",
                 "heartbeat",
@@ -2512,8 +3440,7 @@
                 "alert_field_values",
                 "alerting_targets",
                 "escalation_policies",
-                "alert_call_recording",
-                "alert_urgency"
+                "alert_call_recording"
               ]
             },
             "required": false
@@ -2702,6 +3629,161 @@
         }
       }
     },
+    "/v1/alerts/{id}/snooze": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Snoozes an alert",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Alerts"
+        ],
+        "description": "Snoozes a specific alert by id, extending the acknowledgment timeout",
+        "operationId": "snoozeAlert",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "alert snoozed",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/alert_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "resource not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid delay_minutes",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "snooze service failure",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/snooze_alert"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/alerts/{id}/escalate": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Escalates an alert",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Alerts"
+        ],
+        "description": "Escalates a specific alert to the next or specified level in its escalation policy",
+        "operationId": "escalateAlert",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "escalates to different EP defaults to level 1",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/alert_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "escalation_policy_level exceeds max",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "cannot escalate grouped member alert",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "malformed escalation_policy_id",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/escalate_alert"
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/api_keys": {
       "get": {
         "summary": "List API keys",
@@ -2713,7 +3795,7 @@
         "tags": [
           "API Keys"
         ],
-        "description": "List API keys for the current organization. Returns key metadata including name, kind, expiration, and last usage \u2014 the secret token value is never included in the response.\n\n**API key kinds:**\n- `personal` \u2014 tied to a specific user, inherits that user's permissions.\n- `team` \u2014 scoped to one or more teams (groups), creates a service account with permissions derived from group membership.\n- `organization` \u2014 organization-wide, creates a service account with a configurable role and on-call role.\n\n**Automated rotation workflow:** Use `filter[expires_at][lt]` to find keys approaching expiration, then call the rotate endpoint to issue a new token before the old one expires. Combine with `filter[active]=true` to exclude already-expired keys.\n\n**Sorting:** Use the `sort` parameter with a field name (e.g., `sort=expires_at`). Prefix with `-` for descending order (e.g., `sort=-created_at`). Allowed fields: `name`, `kind`, `created_at`, `updated_at`, `expires_at`, `last_used_at`.\n",
+        "description": "List API keys for the current organization. Returns key metadata including name, kind, expiration, and last usage — the secret token value is never included in the response.\n\n**API key kinds:**\n- `personal` — tied to a specific user, inherits that user's permissions.\n- `team` — scoped to one or more teams (groups), creates a service account with permissions derived from group membership.\n- `organization` — organization-wide, creates a service account with a configurable role and on-call role.\n\n**Automated rotation workflow:** Use `filter[expires_at][lt]` to find keys approaching expiration, then call the rotate endpoint to issue a new token before the old one expires. Combine with `filter[active]=true` to exclude already-expired keys.\n\n**Sorting:** Use the `sort` parameter with a field name (e.g., `sort=expires_at`). Prefix with `-` for descending order (e.g., `sort=-created_at`). Allowed fields: `name`, `kind`, `created_at`, `updated_at`, `expires_at`, `last_used_at`.\n",
         "operationId": "listApiKeys",
         "parameters": [
           {
@@ -2964,7 +4046,7 @@
         "tags": [
           "API Keys"
         ],
-        "description": "Creates a new API key and returns it with the plaintext token. **The token is only returned once** \u2014 store it securely, as it cannot be retrieved again.\n\n**Kinds and required fields:**\n- `personal` \u2014 created for the authenticated user. No additional fields required.\n- `team` \u2014 scoped to a team (group). Requires `group_id`. A service account is automatically created with permissions derived from group membership.\n- `organization` \u2014 organization-wide access. Requires owner or admin role. Optionally set `role_id` and `on_call_role_id` to control the service account's permissions.\n\n**Expiration:** All keys require an `expires_at` date set in the future (maximum 5 years). Names must be unique within their kind and scope.\n",
+        "description": "Creates a new API key and returns it with the plaintext token. **The token is only returned once** — store it securely, as it cannot be retrieved again.\n\n**Kinds and required fields:**\n- `personal` — created for the authenticated user. No additional fields required.\n- `team` — scoped to a team (group). Requires `group_id`. A service account is automatically created with permissions derived from group membership.\n- `organization` — organization-wide access. Requires owner or admin role. Optionally set `role_id` and `on_call_role_id` to control the service account's permissions.\n\n**Expiration:** All keys require an `expires_at` date set in the future (maximum 5 years). Names must be unique within their kind and scope.\n",
         "operationId": "createApiKey",
         "parameters": [],
         "responses": {
@@ -3038,7 +4120,7 @@
         "tags": [
           "API Keys"
         ],
-        "description": "Retrieves a specific API key by its UUID. Returns key metadata including name, kind, expiration, last usage timestamp, and the grace period status \u2014 the secret token is never included.",
+        "description": "Retrieves a specific API key by its UUID. Returns key metadata including name, kind, expiration, last usage timestamp, and the grace period status — the secret token is never included.",
         "operationId": "getApiKey",
         "parameters": [
           {
@@ -3177,7 +4259,7 @@
         "tags": [
           "API Keys"
         ],
-        "description": "Rotate an API key's token. Issues a new secret token and returns it \u2014 **the new token is only shown once**, so store it securely.\n\n**Self-only:** You can only rotate the API key that was used to authenticate this request. Attempting to rotate a different key returns `403 Forbidden`.\n\n**Grace period:** When enabled for your organization, the previous token remains valid after rotation, giving you time to deploy the new token without downtime. Pass `grace_period_minutes` (integer, 0\u20131440, default 30) to control how long the old token stays valid. Set to 0 to immediately invalidate the old token. The `grace_period_ends_at` field in the response confirms the exact time the old token will stop working.\n\n**Expiration:** Optionally provide a new `expires_at` date (ISO 8601, up to 5 years). Defaults to 90 days from now if omitted. Dates in the past are rejected.\n\n**Typical rotation workflow:**\n1. Call this endpoint to get a new token (optionally with a custom `grace_period_minutes`).\n2. Deploy the new token to your systems.\n3. The old token continues working for `grace_period_minutes` (if grace period is enabled).\n4. After the grace period, the old token is automatically invalidated.\n",
+        "description": "Rotate an API key's token. Issues a new secret token and returns it — **the new token is only shown once**, so store it securely.\n\n**Self-only:** You can only rotate the API key that was used to authenticate this request. Attempting to rotate a different key returns `403 Forbidden`.\n\n**Grace period:** When enabled for your organization, the previous token remains valid after rotation, giving you time to deploy the new token without downtime. Pass `grace_period_minutes` (integer, 0–1440, default 30) to control how long the old token stays valid. Set to 0 to immediately invalidate the old token. The `grace_period_ends_at` field in the response confirms the exact time the old token will stop working.\n\n**Expiration:** Optionally provide a new `expires_at` date (ISO 8601, up to 5 years). Defaults to 90 days from now if omitted. Dates in the past are rejected.\n\n**Typical rotation workflow:**\n1. Call this endpoint to get a new token (optionally with a custom `grace_period_minutes`).\n2. Deploy the new token to your systems.\n3. The old token continues working for `grace_period_minutes` (if grace period is enabled).\n4. After the grace period, the old token is automatically invalidated.\n",
         "operationId": "rotateApiKey",
         "parameters": [],
         "responses": {
@@ -3309,6 +4391,134 @@
           },
           {
             "name": "filter[item_type]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[api_key_id][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[api_key_id][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[api_key_id][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[api_key_id][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[item_type][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[item_type][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[item_type][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[item_type][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -4173,6 +5383,30 @@
             }
           },
           {
+            "name": "filter[backstage_id]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[external_id]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filter[created_at][gt]",
             "in": "query",
             "required": false,
@@ -4198,6 +5432,102 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -4370,6 +5700,156 @@
               }
             }
           }
+        }
+      }
+    },
+    "/v1/catalogs/{catalog_id}/entities/bulk_upsert": {
+      "parameters": [
+        {
+          "name": "catalog_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Bulk upsert Catalog Entities",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "CatalogEntities"
+        ],
+        "description": "Create or update multiple catalog entities by external_id. Only attributes present in the payload are written (managed-fields semantics). Transactional: all succeed or all fail.",
+        "operationId": "bulkUpsertCatalogEntities",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "entities upserted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_upsert_catalog_entities_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or entity-level error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_upsert_catalog_entities_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_upsert_catalog_entities"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/catalogs/{catalog_id}/entities/bulk_delete": {
+      "parameters": [
+        {
+          "name": "catalog_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Bulk delete Catalog Entities",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "CatalogEntities"
+        ],
+        "description": "Delete catalog entities by external_id list, or prune by managed_by source. Two mutually exclusive modes.",
+        "operationId": "bulkDeleteCatalogEntities",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "entities deleted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_destroy_catalog_entities_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or partial-failure error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_destroy_catalog_entities_response"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_destroy_catalog_entities"
+              }
+            }
+          },
+          "required": true
         }
       }
     },
@@ -5143,6 +6623,22 @@
             }
           },
           {
+            "name": "filter[external_id]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filter[created_at][gt]",
             "in": "query",
             "required": false,
@@ -5168,6 +6664,102 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[managed_by][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -5472,6 +7064,70 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -7416,6 +9072,134 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[label][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[label][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[label][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[label][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8991,6 +10775,41 @@
                               "type": "string"
                             },
                             "description": "Array of event types to subscribe to"
+                          },
+                          "filters": {
+                            "type": "object",
+                            "description": "Event filters. OR within dimension, AND across dimensions.",
+                            "properties": {
+                              "group_ids": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Filter by group UUIDs"
+                              },
+                              "service_ids": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Filter by service UUIDs"
+                              },
+                              "environment_ids": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Filter by environment UUIDs"
+                              },
+                              "functionality_ids": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Filter by functionality UUIDs"
+                              }
+                            },
+                            "additionalProperties": false
                           }
                         },
                         "required": [
@@ -9114,6 +10933,10 @@
                             "items": {
                               "type": "string"
                             }
+                          },
+                          "filters": {
+                            "type": "object",
+                            "description": "Event filters"
                           }
                         }
                       }
@@ -9306,6 +11129,102 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -9660,6 +11579,136 @@
         }
       }
     },
+    "/v1/environments/bulk_upsert": {
+      "post": {
+        "summary": "Bulk upsert Environments",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Environments"
+        ],
+        "description": "Create or update multiple environments by external_id. Only attributes present in the payload are written (managed-fields semantics). Transactional: all succeed or all fail. Requires an API key with both create and update capability across the resource scope (team/org-scoped); record-scoped principals cannot use this endpoint (they receive 404), which also prevents the create-vs-update branch from leaking whether an external_id exists.",
+        "operationId": "bulkUpsertEnvironments",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records upserted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_upsert_environments_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or record-level error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_upsert_environments_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_upsert_environments"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/environments/bulk_delete": {
+      "post": {
+        "summary": "Bulk delete Environments",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Environments"
+        ],
+        "description": "Delete environments by external_id list, or prune by managed_by source. Two mutually exclusive modes.",
+        "operationId": "bulkDeleteEnvironments",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records deleted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_destroy_environments_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or partial-failure error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_destroy_environments_response"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_destroy_environments"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/v1/escalation_policies": {
       "post": {
         "summary": "Creates an escalation policy",
@@ -9762,6 +11811,15 @@
             }
           },
           {
+            "name": "filter[team_ids]",
+            "in": "query",
+            "required": false,
+            "description": "Filter escalation policies by associated team IDs. Comma-separate multiple values.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filter[created_at][gt]",
             "in": "query",
             "required": false,
@@ -9787,6 +11845,70 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -10423,6 +12545,19 @@
               "type": "string",
               "enum": [
                 "escalation_policy_levels"
+              ]
+            },
+            "required": false
+          },
+          {
+            "name": "filter[path_type]",
+            "in": "query",
+            "description": "Filter by path_type. Returns all path types when omitted.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "escalation",
+                "deferral"
               ]
             },
             "required": false
@@ -11154,7 +13289,7 @@
             }
           },
           "422": {
-            "description": "invalid request",
+            "description": "rejects a native field on an action item form",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -11306,11 +13441,21 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "form_field_placement updated with non_editable",
+            "description": "moves a custom field's placement onto an action item form",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/form_field_placement_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "rejects moving a native field's placement onto an action item form",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
                 }
               }
             }
@@ -11458,11 +13603,21 @@
         "parameters": [],
         "responses": {
           "201": {
-            "description": "form_field_position created",
+            "description": "form_field_position created on an action item form",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/form_field_position_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "rejects an action item form when the feature is disabled",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
                 }
               }
             }
@@ -11556,6 +13711,16 @@
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/form_field_position_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "does not error when updating with a nonexistent form_field_id",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
                 }
               }
             }
@@ -11783,6 +13948,134 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -12692,6 +14985,70 @@
             }
           },
           {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -13174,6 +15531,136 @@
         }
       }
     },
+    "/v1/functionalities/bulk_upsert": {
+      "post": {
+        "summary": "Bulk upsert Functionalities",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Functionalities"
+        ],
+        "description": "Create or update multiple functionalities by external_id. Only attributes present in the payload are written (managed-fields semantics). Transactional: all succeed or all fail. Requires an API key with both create and update capability across the resource scope (team/org-scoped); record-scoped principals cannot use this endpoint (they receive 404), which also prevents the create-vs-update branch from leaking whether an external_id exists.",
+        "operationId": "bulkUpsertFunctionalities",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records upserted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_upsert_functionalities_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or record-level error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_upsert_functionalities_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_upsert_functionalities"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/functionalities/bulk_delete": {
+      "post": {
+        "summary": "Bulk delete Functionalities",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Functionalities"
+        ],
+        "description": "Delete functionalities by external_id list, or prune by managed_by source. Two mutually exclusive modes.",
+        "operationId": "bulkDeleteFunctionalities",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records deleted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_destroy_functionalities_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or partial-failure error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_destroy_functionalities_response"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_destroy_functionalities"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/v1/workflows/{workflow_id}/workflow_tasks": {
       "parameters": [
         {
@@ -13286,6 +15773,70 @@
           },
           {
             "name": "filter[slug]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -13418,6 +15969,256 @@
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/workflow_task_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "resource not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflows/{workflow_id}/action_item_form_field_conditions": {
+      "parameters": [
+        {
+          "name": "workflow_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "Creates a workflow action item form field condition",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "WorkflowActionItemFormFieldConditions"
+        ],
+        "description": "Creates a new workflow action item form field condition from provided data",
+        "operationId": "createWorkflowActionItemFormFieldCondition",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "workflow_action_item_form_field_condition created",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/workflow_action_item_form_field_condition_response"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "responds with unauthorized for invalid token",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "responds with forbidden when the feature flag is disabled"
+          },
+          "422": {
+            "description": "rejects conditions on a non-action-item workflow",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/new_workflow_action_item_form_field_condition"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "get": {
+        "summary": "List workflow action item form field conditions",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "WorkflowActionItemFormFieldConditions"
+        ],
+        "description": "List workflow action item form field conditions",
+        "operationId": "listWorkflowActionItemFormFieldConditions",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page[number]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page[size]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "success",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/workflow_action_item_form_field_condition_list"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflow_action_item_form_field_conditions/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Retrieves a workflow action item form field condition",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "WorkflowActionItemFormFieldConditions"
+        ],
+        "description": "Retrieves a specific workflow action item form field condition by id",
+        "operationId": "getWorkflowActionItemFormFieldCondition",
+        "responses": {
+          "200": {
+            "description": "includes native field ids",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/workflow_action_item_form_field_condition_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "resource not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update a workflow action item form field condition",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "WorkflowActionItemFormFieldConditions"
+        ],
+        "description": "Update a specific workflow action item form field condition by id",
+        "operationId": "updateWorkflowActionItemFormFieldCondition",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "ignores non-allowlisted attributes such as workflow_id",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/workflow_action_item_form_field_condition_response"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "resource not found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/update_workflow_action_item_form_field_condition"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "summary": "Delete a workflow action item form field condition",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "WorkflowActionItemFormFieldConditions"
+        ],
+        "description": "Delete a specific workflow action item form field condition by id",
+        "operationId": "deleteWorkflowActionItemFormFieldCondition",
+        "responses": {
+          "200": {
+            "description": "allows deleting an existing condition when the feature flag is disabled",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/workflow_action_item_form_field_condition_response"
                 }
               }
             }
@@ -14527,6 +17328,70 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -14632,7 +17497,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "can set and clear alert workflow status conditions",
+            "description": "preserves repeat_condition_* fields when omitted from PATCH payload",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -15470,6 +18335,134 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[priority][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[priority][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[priority][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[priority][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_status][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_status][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_status][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_status][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -18785,6 +21778,102 @@
             }
           },
           {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[enabled][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -18972,7 +22061,7 @@
         "parameters": [],
         "responses": {
           "201": {
-            "description": "incident_status_page_event created",
+            "description": "incident_status_page_event created with started_at",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -19126,7 +22215,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "incident_status_page_event updated",
+            "description": "incident_status_page_event started_at updated",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -19638,6 +22727,102 @@
             }
           },
           {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -20056,6 +23241,15 @@
         "operationId": "listIncidents",
         "parameters": [
           {
+            "name": "page[after]",
+            "in": "query",
+            "required": false,
+            "description": "The cursor to fetch results using cursor pagination. A cursor is provided in meta.next_cursor in the response.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "page[number]",
             "in": "query",
             "required": false,
@@ -20267,6 +23461,15 @@
             "name": "filter[slack_channel_id]",
             "in": "query",
             "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[sequential_id]",
+            "in": "query",
+            "required": false,
+            "description": "Filter by the human-readable incident number (the 123 in INC-123).",
             "schema": {
               "type": "string"
             }
@@ -20560,6 +23763,774 @@
             }
           },
           {
+            "name": "filter[kind][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[kind][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[status][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[private][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[private][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[private][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[private][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[user_id][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity_id][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity_id][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity_id][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity_id][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[zendesk_ticket_id][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[zendesk_ticket_id][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[zendesk_ticket_id][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[zendesk_ticket_id][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[sequential_id][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[sequential_id][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[sequential_id][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[sequential_id][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[types][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[types][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[types][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[types][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[type_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[type_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[type_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[type_ids][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environment_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environment_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environment_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environment_ids][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_ids][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_names][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_names][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_names][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[service_names][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionalities][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionalities][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionalities][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionalities][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_ids][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_names][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_names][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_names][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[functionality_names][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[causes][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[causes][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[causes][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[causes][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[cause_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[cause_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[cause_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[cause_ids][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[teams][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[teams][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[teams][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[teams][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_ids][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_names][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_names][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_names][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[team_names][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "description": "comma separated if needed. eg: created_at,updated_at",
@@ -20617,6 +24588,16 @@
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/incident_list"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "offset pagination exceeds limit",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
                 }
               }
             }
@@ -21831,6 +25812,7 @@
                 "NL",
                 "NZ",
                 "SE",
+                "CH",
                 "GB",
                 "US"
               ]
@@ -21928,7 +25910,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "live_call_router updated",
+            "description": "live_call_router multichannel notification fields updated",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -22093,10 +26075,200 @@
         ],
         "responses": {
           "201": {
-            "description": "recording session created"
+            "description": "recording session created",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "validation error (e.g. bot already active)"
+          }
+        }
+      }
+    },
+    "/v1/incidents/{incident_id}/meeting_recordings/import": {
+      "post": {
+        "summary": "Import a meeting recording",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Meeting Recordings"
+        ],
+        "description": "Import an externally captured meeting recording and attach it to an incident. Video and transcript are fetched asynchronously. The existing POST /v1/incidents/{incident_id}/meeting_recordings endpoint invites a bot — this endpoint handles recordings that were captured outside of the bot flow.",
+        "operationId": "importMeetingRecording",
+        "parameters": [
+          {
+            "name": "incident_id",
+            "in": "path",
+            "description": "Incident UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "recording imported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation error (e.g. unsupported source, duplicate recording)"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/import_meeting_recording"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/meeting_recordings": {
+      "get": {
+        "summary": "List all meeting recordings",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Meeting Recordings"
+        ],
+        "description": "List meeting recordings across the organization. Returns the current user's standalone recordings plus incident-backed recordings the user can access. Supports filtering by status, platform, and created_by.",
+        "operationId": "listAllMeetingRecordings",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter by status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "description": "Filter by platform",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "created_by",
+            "in": "query",
+            "required": false,
+            "description": "Filter by creator type",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "meeting recordings found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_list"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/meeting_recordings/start_session": {
+      "post": {
+        "summary": "Start a recording session",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Meeting Recordings"
+        ],
+        "description": "Start a new desktop recording session. The server creates a recording record and returns a stream token the desktop client uses to send audio. No provider-specific configuration is needed from the client.",
+        "operationId": "startRecordingSession",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "session created",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/start_session_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "invalid platform"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/start_session_request"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/meeting_recordings/{id}/delete_session": {
+      "delete": {
+        "summary": "Delete a standalone meeting recording",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Meeting Recordings"
+        ],
+        "description": "Delete a standalone meeting recording (not linked to an incident). Only the recording owner can delete it. Active recordings (pending, recording, paused) must be stopped first. Returns 404 for incident-linked recordings or recordings owned by another user.",
+        "operationId": "deleteStandaloneMeetingRecording",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Meeting Recording UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "recording deleted"
+          },
+          "422": {
+            "description": "cannot delete active recording"
+          },
+          "404": {
+            "description": "recording not found or not owned by user"
           }
         }
       }
@@ -22123,11 +26295,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "comma separated if needed. eg: transcript",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "transcript"
+              ]
+            },
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "meeting recording found"
+            "description": "meeting recording found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "404": {
             "description": "meeting recording not found"
@@ -22159,7 +26350,14 @@
         ],
         "responses": {
           "200": {
-            "description": "meeting recording deleted"
+            "description": "meeting recording deleted",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "cannot delete active recording"
@@ -22193,7 +26391,14 @@
         ],
         "responses": {
           "200": {
-            "description": "video deleted"
+            "description": "video deleted",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "cannot delete video (active recording or no video)"
@@ -22227,7 +26432,14 @@
         ],
         "responses": {
           "200": {
-            "description": "recording paused"
+            "description": "recording paused",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "recording is not active"
@@ -22261,7 +26473,14 @@
         ],
         "responses": {
           "200": {
-            "description": "recording resumed"
+            "description": "recording resumed",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "recording is not paused"
@@ -22280,7 +26499,7 @@
         "tags": [
           "Meeting Recordings"
         ],
-        "description": "Stop an active or paused recording. The bot finishes processing, generates a transcript, and the session status transitions to completed. This is irreversible \u2014 to record again, create a new session.",
+        "description": "Stop an active or paused recording. The bot finishes processing, generates a transcript, and the session status transitions to completed. This is irreversible — to record again, create a new session.",
         "operationId": "stopMeetingRecording",
         "parameters": [
           {
@@ -22295,7 +26514,14 @@
         ],
         "responses": {
           "200": {
-            "description": "recording stopped"
+            "description": "recording stopped",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "recording cannot be stopped"
@@ -22329,7 +26555,14 @@
         ],
         "responses": {
           "200": {
-            "description": "bot left the call"
+            "description": "bot left the call",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/meeting_recording_response"
+                }
+              }
+            }
           },
           "422": {
             "description": "bot is not in a call"
@@ -23253,7 +27486,7 @@
           {
             "name": "earliest",
             "in": "query",
-            "description": "When true, returns only the first on-call user per escalation policy level",
+            "description": "When true, returns only the first on-call entry per escalation policy path and level",
             "required": false,
             "schema": {
               "type": "boolean"
@@ -23319,13 +27552,20 @@
             "schema": {
               "type": "string"
             },
-            "description": "Comma-separated notification types to include. One or both of: audible, quiet. When present, oncalls are returned from every non-deferral escalation path whose notification_type is in the filter, sorted audible-first. When absent, only the default path's oncalls are returned (existing behavior).",
+            "description": "Comma-separated notification types to include. One or both of: audible, quiet. When omitted, returns oncalls from all non-deferral escalation paths. When provided, limits results to matching notification types and sorts audible-first.",
             "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/oncall_list"
+                }
+              }
+            }
           },
           "404": {
             "description": "resource not found when alerting is disabled",
@@ -23371,7 +27611,7 @@
         "tags": [
           "OverrideShifts"
         ],
-        "description": "Creates a new override shift from provided data. If any existing override shifts overlap with the specified time range, they will be automatically deleted and replaced by the new override.",
+        "description": "Creates a new override shift from provided data. If any existing override shifts overlap with the specified time range, they will be automatically deleted and replaced by the new override. This endpoint is idempotent: re-sending an identical override (same user and same start/end time) returns the existing override with a 200 status and does not recreate it.",
         "operationId": "createOverrideShift",
         "parameters": [],
         "responses": {
@@ -23391,6 +27631,16 @@
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "returns the existing override without recreating it",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/override_shift_response"
                 }
               }
             }
@@ -24574,6 +28824,166 @@
             }
           },
           {
+            "name": "filter[source][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[source][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[services][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[environments][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[labels][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[refs][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[refs][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[refs][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[refs][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "page[number]",
             "in": "query",
             "required": false,
@@ -24694,6 +29104,47 @@
             }
           },
           "required": true
+        }
+      }
+    },
+    "/v1/alerts/receipts/{id}": {
+      "get": {
+        "summary": "Get a receipt",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Alerts"
+        ],
+        "description": "Retrieve the delivery receipt for a notification by ID, including its state and (when applicable) failure reason and referenced resource.",
+        "operationId": "getReceipt",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Receipt ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "receipt found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/receipt"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "receipt not found"
+          }
         }
       }
     },
@@ -27125,6 +31576,38 @@
             }
           },
           {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "page[number]",
             "in": "query",
             "required": false,
@@ -27782,6 +32265,134 @@
             }
           },
           {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -28264,6 +32875,136 @@
         }
       }
     },
+    "/v1/services/bulk_upsert": {
+      "post": {
+        "summary": "Bulk upsert Services",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Services"
+        ],
+        "description": "Create or update multiple services by external_id. Only attributes present in the payload are written (managed-fields semantics). Transactional: all succeed or all fail. Requires an API key with both create and update capability across the resource scope (team/org-scoped); record-scoped principals cannot use this endpoint (they receive 404), which also prevents the create-vs-update branch from leaking whether an external_id exists.",
+        "operationId": "bulkUpsertServices",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records upserted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_upsert_services_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or record-level error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_upsert_services_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_upsert_services"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/services/bulk_delete": {
+      "post": {
+        "summary": "Bulk delete Services",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Services"
+        ],
+        "description": "Delete services by external_id list, or prune by managed_by source. Two mutually exclusive modes.",
+        "operationId": "bulkDeleteServices",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records deleted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_destroy_services_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or partial-failure error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_destroy_services_response"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_destroy_services"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/v1/severities": {
       "post": {
         "summary": "Creates a severity",
@@ -28431,6 +33172,134 @@
             }
           },
           {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[severity][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -28585,6 +33454,151 @@
               "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/schedules/{schedule_id}/shift_coverage_requests": {
+      "parameters": [
+        {
+          "name": "schedule_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "summary": "creates shift coverage requests",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "ShiftCoverageRequests"
+        ],
+        "description": "Creates coverage requests for the shifts overlapping the requested time range. A range can span multiple consecutive shifts (e.g. across a handoff), so one or more coverage requests may be created; the response is always a list. A coverage request broadcasts to schedule members so someone can volunteer to cover the shift.",
+        "operationId": "createShiftCoverageRequest",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "without override permission, can request coverage for own shift",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shift_coverage_request_list"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "without override permission, cannot request coverage for another user's shift",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/new_shift_coverage_request"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "get": {
+        "summary": "list shift coverage requests",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "ShiftCoverageRequests"
+        ],
+        "description": "List active shift coverage requests for a schedule.",
+        "operationId": "listShiftCoverageRequests",
+        "responses": {
+          "200": {
+            "description": "shift_coverage_requests listed",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shift_coverage_request_list"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/shift_coverage_requests/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "summary": "retrieves a shift coverage request",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "ShiftCoverageRequests"
+        ],
+        "description": "Retrieves a specific shift coverage request.",
+        "operationId": "getShiftCoverageRequest",
+        "responses": {
+          "200": {
+            "description": "shift_coverage_request found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shift_coverage_request_response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "deletes a shift coverage request",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "ShiftCoverageRequests"
+        ],
+        "description": "Deletes a shift coverage request.",
+        "operationId": "deleteShiftCoverageRequest",
+        "responses": {
+          "200": {
+            "description": "shift_coverage_request deleted",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shift_coverage_request_response"
                 }
               }
             }
@@ -28844,6 +33858,70 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -29392,6 +34470,70 @@
           },
           {
             "name": "filter[created_at][lte]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
             "in": "query",
             "required": false,
             "schema": {
@@ -30128,7 +35270,9 @@
             "schema": {
               "type": "string",
               "enum": [
-                "users"
+                "users",
+                "schedules",
+                "escalation_policies"
               ]
             },
             "required": false
@@ -30262,6 +35406,166 @@
             }
           },
           {
+            "name": "filter[slug][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[slug][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[name][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[color][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[alert_broadcast_enabled][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][not_eq]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[incident_broadcast_enabled][not_in]",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "sort",
             "in": "query",
             "required": false,
@@ -30326,7 +35630,9 @@
             "schema": {
               "type": "string",
               "enum": [
-                "users"
+                "users",
+                "schedules",
+                "escalation_policies"
               ]
             },
             "required": false
@@ -30673,6 +35979,136 @@
             "application/vnd.api+json": {
               "schema": {
                 "$ref": "#/components/schemas/new_catalog_property"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/teams/bulk_upsert": {
+      "post": {
+        "summary": "Bulk upsert Teams",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Teams"
+        ],
+        "description": "Create or update multiple teams by external_id. Only attributes present in the payload are written (managed-fields semantics). Transactional: all succeed or all fail. Requires an API key with both create and update capability across the resource scope (team/org-scoped); record-scoped principals cannot use this endpoint (they receive 404), which also prevents the create-vs-update branch from leaking whether an external_id exists.",
+        "operationId": "bulkUpsertGroups",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records upserted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_upsert_teams_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or record-level error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_upsert_teams_error"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_upsert_teams"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/v1/teams/bulk_delete": {
+      "post": {
+        "summary": "Bulk delete Teams",
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": [
+          "Teams"
+        ],
+        "description": "Delete teams by external_id list, or prune by managed_by source. Two mutually exclusive modes.",
+        "operationId": "bulkDeleteGroups",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "records deleted successfully",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bulk_destroy_teams_response"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "validation or partial-failure error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/errors_list"
+                    },
+                    {
+                      "$ref": "#/components/schemas/bulk_destroy_teams_response"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_list"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/bulk_destroy_teams"
               }
             }
           },
@@ -31871,7 +37307,7 @@
         ],
         "responses": {
           "200": {
-            "description": "schedules include only returns schedules from the current team",
+            "description": "teams include only returns teams from the current team",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -31942,7 +37378,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "update name and role simultaneously",
+            "description": "custom role with roles_permissions can update user role (IR-5606)",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -32134,7 +37570,7 @@
         "parameters": [],
         "responses": {
           "201": {
-            "description": "webhooks_endpoint created",
+            "description": "webhooks_endpoint created with custom_headers",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -32304,7 +37740,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "webhooks_endpoint updated",
+            "description": "webhooks_endpoint custom_headers cleared with empty array",
             "content": {
               "application/vnd.api+json": {
                 "schema": {
@@ -32385,6 +37821,117 @@
       }
     },
     "schemas": {
+      "ai_chat_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Session UUID"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ai_chat_responses"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "session_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "AI chat session UUID"
+                  },
+                  "reply": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Assistant reply text"
+                  },
+                  "status": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Response status (present when user input is required)",
+                    "enum": [
+                      "user_input_required"
+                    ]
+                  }
+                },
+                "required": [
+                  "session_id"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "attributes"
+            ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "ai_chat_session_message": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Message UUID"
+          },
+          "role": {
+            "type": "string",
+            "description": "Message author role",
+            "enum": [
+              "user",
+              "assistant"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "description": "Message content"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the message was created"
+          }
+        },
+        "required": [
+          "id",
+          "role",
+          "content",
+          "created_at"
+        ]
+      },
+      "ai_chat_session_message_list": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ai_chat_session_message"
+            }
+          },
+          "meta": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "messages"
+        ]
+      },
       "attach_alert": {
         "type": "object",
         "properties": {
@@ -32451,54 +37998,8 @@
                   },
                   "source": {
                     "type": "string",
-                    "description": "The source of the alert",
-                    "enum": [
-                      "rootly",
-                      "manual",
-                      "api",
-                      "heartbeat",
-                      "web",
-                      "slack",
-                      "email",
-                      "workflow",
-                      "live_call_routing",
-                      "mobile",
-                      "pagerduty",
-                      "opsgenie",
-                      "victorops",
-                      "pagertree",
-                      "datadog",
-                      "dynatrace",
-                      "nobl9",
-                      "zendesk",
-                      "asana",
-                      "clickup",
-                      "sentry",
-                      "rollbar",
-                      "jira",
-                      "honeycomb",
-                      "service_now",
-                      "linear",
-                      "grafana",
-                      "alertmanager",
-                      "google_cloud",
-                      "generic_webhook",
-                      "cloud_watch",
-                      "aws_sns",
-                      "azure",
-                      "splunk",
-                      "chronosphere",
-                      "app_optics",
-                      "bug_snag",
-                      "monte_carlo",
-                      "nagios",
-                      "prtg",
-                      "catchpoint",
-                      "app_dynamics",
-                      "checkly",
-                      "new_relic",
-                      "gitlab"
-                    ]
+                    "description": "Deprecated. Accepted for backwards compatibility; new clients should omit. Defaults to `api`.",
+                    "deprecated": true
                   },
                   "status": {
                     "type": "string",
@@ -32528,6 +38029,14 @@
                   "group_ids": {
                     "type": "array",
                     "description": "The Group IDs to attach to the alert. If your organization has On-Call enabled and your notification target is a Group. This field will be automatically set for you.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true
+                  },
+                  "functionality_ids": {
+                    "type": "array",
+                    "description": "The Functionality IDs to attach to the alert",
                     "items": {
                       "type": "string"
                     },
@@ -32574,15 +38083,47 @@
                       "User",
                       "Group",
                       "EscalationPolicy",
-                      "Service"
+                      "Service",
+                      "Functionality"
                     ],
-                    "description": "Only available for organizations with Rootly On-Call enabled. Can be one of Group, Service, EscalationPolicy, User.",
+                    "description": "Only available for organizations with Rootly On-Call enabled. Can be one of Group, Service, EscalationPolicy, Functionality, User. Please contact support if you encounter issues using `Functionality` as a notification target type.",
                     "nullable": true
                   },
                   "notification_target_id": {
                     "type": "string",
                     "description": "Only available for organizations with Rootly On-Call enabled. The _identifier_ of the notification target object.",
                     "nullable": true
+                  },
+                  "notification_targets": {
+                    "type": "array",
+                    "description": "Only available for organizations with Rootly On-Call enabled. Page multiple destinations (any combination of Group, Service, EscalationPolicy, Functionality, or User) in a single request. `Functionality` targets require the `enable_paging_functionalities` feature; a request that includes one while it is disabled is rejected. Applies to alert creation only. When provided, this takes precedence over the singular `notification_target_type` / `notification_target_id` fields.",
+                    "nullable": true,
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "User",
+                            "Group",
+                            "EscalationPolicy",
+                            "Service",
+                            "Functionality"
+                          ],
+                          "description": "The type of the notification target. Can be one of Group, Service, EscalationPolicy, Functionality, User."
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "The identifier of the notification target object."
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "id"
+                      ]
+                    }
                   },
                   "labels": {
                     "type": "array",
@@ -32650,7 +38191,6 @@
                 },
                 "additionalProperties": false,
                 "required": [
-                  "source",
                   "summary"
                 ]
               }
@@ -32691,54 +38231,8 @@
                   },
                   "source": {
                     "type": "string",
-                    "description": "The source of the alert",
-                    "enum": [
-                      "rootly",
-                      "manual",
-                      "api",
-                      "heartbeat",
-                      "web",
-                      "slack",
-                      "email",
-                      "workflow",
-                      "live_call_routing",
-                      "mobile",
-                      "pagerduty",
-                      "opsgenie",
-                      "victorops",
-                      "pagertree",
-                      "datadog",
-                      "dynatrace",
-                      "nobl9",
-                      "zendesk",
-                      "asana",
-                      "clickup",
-                      "sentry",
-                      "rollbar",
-                      "jira",
-                      "honeycomb",
-                      "service_now",
-                      "linear",
-                      "grafana",
-                      "alertmanager",
-                      "google_cloud",
-                      "generic_webhook",
-                      "cloud_watch",
-                      "aws_sns",
-                      "azure",
-                      "splunk",
-                      "chronosphere",
-                      "app_optics",
-                      "bug_snag",
-                      "monte_carlo",
-                      "nagios",
-                      "prtg",
-                      "catchpoint",
-                      "app_dynamics",
-                      "checkly",
-                      "new_relic",
-                      "gitlab"
-                    ]
+                    "description": "Deprecated. Accepted for backwards compatibility; new clients should omit. Defaults to `api`.",
+                    "deprecated": true
                   },
                   "summary": {
                     "type": "string",
@@ -32760,6 +38254,14 @@
                   "group_ids": {
                     "type": "array",
                     "description": "The Group IDs to attach to the alert",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true
+                  },
+                  "functionality_ids": {
+                    "type": "array",
+                    "description": "The Functionality IDs to attach to the alert",
                     "items": {
                       "type": "string"
                     },
@@ -32868,8 +38370,7 @@
               }
             },
             "required": [
-              "source",
-              "summary",
+              "type",
               "attributes"
             ]
           }
@@ -32896,54 +38397,7 @@
           },
           "source": {
             "type": "string",
-            "description": "The source of the alert",
-            "enum": [
-              "rootly",
-              "manual",
-              "api",
-              "heartbeat",
-              "web",
-              "slack",
-              "email",
-              "workflow",
-              "live_call_routing",
-              "mobile",
-              "pagerduty",
-              "opsgenie",
-              "victorops",
-              "pagertree",
-              "datadog",
-              "dynatrace",
-              "nobl9",
-              "zendesk",
-              "asana",
-              "clickup",
-              "sentry",
-              "rollbar",
-              "jira",
-              "honeycomb",
-              "service_now",
-              "linear",
-              "grafana",
-              "alertmanager",
-              "google_cloud",
-              "generic_webhook",
-              "cloud_watch",
-              "aws_sns",
-              "azure",
-              "splunk",
-              "chronosphere",
-              "app_optics",
-              "bug_snag",
-              "monte_carlo",
-              "nagios",
-              "prtg",
-              "catchpoint",
-              "app_dynamics",
-              "checkly",
-              "new_relic",
-              "gitlab"
-            ]
+            "description": "The source of the alert"
           },
           "status": {
             "type": "string",
@@ -32989,6 +38443,18 @@
               ]
             }
           },
+          "functionalities": {
+            "type": "array",
+            "description": "Functionalities attached to the alert",
+            "items": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/functionality"
+                }
+              ]
+            }
+          },
           "environments": {
             "type": "array",
             "description": "Environments attached to the alert",
@@ -33017,6 +38483,14 @@
             },
             "nullable": true
           },
+          "functionality_ids": {
+            "type": "array",
+            "description": "The Functionality IDs to attach to the alert",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "environment_ids": {
             "type": "array",
             "description": "The Environment IDs to attach to the alert",
@@ -33038,6 +38512,15 @@
           "alert_urgency_id": {
             "type": "string",
             "description": "The ID of the alert urgency",
+            "nullable": true
+          },
+          "alert_urgency": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/alert_urgency"
+              }
+            ],
             "nullable": true
           },
           "group_leader_alert_id": {
@@ -33086,32 +38569,122 @@
             "description": "Additional data",
             "nullable": true
           },
+          "notification_target_type": {
+            "type": "string",
+            "enum": [
+              "User",
+              "Group",
+              "EscalationPolicy",
+              "Service",
+              "Functionality"
+            ],
+            "description": "Only available for organizations with Rootly On-Call enabled. Can be one of Group, Service, EscalationPolicy, Functionality, User.",
+            "nullable": true
+          },
+          "notification_target_id": {
+            "type": "string",
+            "description": "Only available for organizations with Rootly On-Call enabled. The identifier of the notification target object.",
+            "nullable": true
+          },
           "deduplication_key": {
             "type": "string",
             "description": "Alerts sharing the same deduplication key are treated as a single alert.",
             "nullable": true
           },
-          "alert_field_values_attributes": {
+          "alert_field_values": {
             "type": "array",
-            "description": "Custom alert field values to create with the alert",
+            "description": "Custom alert field values associated with the alert. Only present when the enable_alert_fields feature flag is enabled for the team.",
             "items": {
               "type": "object",
               "properties": {
-                "alert_field_id": {
+                "id": {
                   "type": "string",
-                  "description": "ID of the custom alert field"
+                  "description": "Unique ID of the alert field value"
                 },
                 "value": {
                   "type": "string",
                   "description": "Value for the alert field"
+                },
+                "alert_field_id": {
+                  "type": "string",
+                  "description": "ID of the custom alert field"
+                },
+                "alert_id": {
+                  "type": "string",
+                  "description": "ID of the alert"
+                },
+                "created_at": {
+                  "type": "string",
+                  "description": "Date of creation"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "description": "Date of last update"
                 }
               },
               "required": [
+                "id",
+                "value",
                 "alert_field_id",
-                "value"
-              ],
-              "nullable": true
-            }
+                "alert_id",
+                "created_at",
+                "updated_at"
+              ]
+            },
+            "nullable": true
+          },
+          "responders": {
+            "type": "array",
+            "description": "Users who responded to the alert. Included on all non-list responses (show, create, update, resolve, etc.); on list responses only when `include=responders` is requested.",
+            "items": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/user_flat_response"
+                }
+              ]
+            },
+            "nullable": true
+          },
+          "notified_users": {
+            "type": "array",
+            "description": "Users who were notified about the alert. Included on all non-list responses (show, create, update, resolve, etc.); on list responses only when `include=notified_users` is requested.",
+            "items": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/user"
+                }
+              ]
+            },
+            "nullable": true
+          },
+          "alerting_targets": {
+            "type": "array",
+            "description": "Alerting targets associated with the alert. Only present when advanced routing is enabled for the team.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "ID of the alerting target"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Type of the alerting target (e.g. team, user, escalation_policy, service, functionality, slack_channel)"
+                }
+              },
+              "required": [
+                "id",
+                "type"
+              ]
+            },
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "description": "The Rootly dashboard URL for the alert",
+            "format": "uri"
           },
           "started_at": {
             "type": "string",
@@ -33154,54 +38727,7 @@
               },
               "source": {
                 "type": "string",
-                "description": "The source of the alert",
-                "enum": [
-                  "rootly",
-                  "manual",
-                  "api",
-                  "heartbeat",
-                  "web",
-                  "slack",
-                  "email",
-                  "workflow",
-                  "live_call_routing",
-                  "mobile",
-                  "pagerduty",
-                  "opsgenie",
-                  "victorops",
-                  "pagertree",
-                  "datadog",
-                  "dynatrace",
-                  "nobl9",
-                  "zendesk",
-                  "asana",
-                  "clickup",
-                  "sentry",
-                  "rollbar",
-                  "jira",
-                  "honeycomb",
-                  "service_now",
-                  "linear",
-                  "grafana",
-                  "alertmanager",
-                  "google_cloud",
-                  "generic_webhook",
-                  "cloud_watch",
-                  "aws_sns",
-                  "azure",
-                  "splunk",
-                  "chronosphere",
-                  "app_optics",
-                  "bug_snag",
-                  "monte_carlo",
-                  "nagios",
-                  "prtg",
-                  "catchpoint",
-                  "app_dynamics",
-                  "checkly",
-                  "new_relic",
-                  "gitlab"
-                ]
+                "description": "The source of the alert"
               },
               "type": {
                 "type": "string",
@@ -33223,6 +38749,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -33243,54 +38775,7 @@
                 },
                 "source": {
                   "type": "string",
-                  "description": "The source of the alert",
-                  "enum": [
-                    "rootly",
-                    "manual",
-                    "api",
-                    "heartbeat",
-                    "web",
-                    "slack",
-                    "email",
-                    "workflow",
-                    "live_call_routing",
-                    "mobile",
-                    "pagerduty",
-                    "opsgenie",
-                    "victorops",
-                    "pagertree",
-                    "datadog",
-                    "dynatrace",
-                    "nobl9",
-                    "zendesk",
-                    "asana",
-                    "clickup",
-                    "sentry",
-                    "rollbar",
-                    "jira",
-                    "honeycomb",
-                    "service_now",
-                    "linear",
-                    "grafana",
-                    "alertmanager",
-                    "google_cloud",
-                    "generic_webhook",
-                    "cloud_watch",
-                    "aws_sns",
-                    "azure",
-                    "splunk",
-                    "chronosphere",
-                    "app_optics",
-                    "bug_snag",
-                    "monte_carlo",
-                    "nagios",
-                    "prtg",
-                    "catchpoint",
-                    "app_dynamics",
-                    "checkly",
-                    "new_relic",
-                    "gitlab"
-                  ]
+                  "description": "The source of the alert"
                 },
                 "type": {
                   "type": "string",
@@ -33329,6 +38814,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -33368,6 +38859,122 @@
             }
           }
         }
+      },
+      "snooze_alert": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "alerts"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "delay_minutes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10080,
+                    "description": "Number of minutes to snooze the alert for"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "delay_minutes"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "escalate_alert": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "alerts"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "escalation_policy_id": {
+                    "type": "string",
+                    "description": "The ID of the escalation policy to escalate to. If omitted, uses the alert's current escalation policy from metadata. Required for resolved alerts whose metadata may have been cleared."
+                  },
+                  "escalation_policy_level": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "The escalation policy level to escalate to. If omitted, defaults to the next level (same EP) or level 1 (different EP)."
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "alert_event_user": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "preferred_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "time_zone": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email",
+          "created_at",
+          "updated_at"
+        ]
       },
       "new_alert_event": {
         "type": "object",
@@ -33460,6 +39067,10 @@
       "alert_event": {
         "type": "object",
         "properties": {
+          "alert_id": {
+            "type": "string",
+            "description": "ID of the alert this event belongs to."
+          },
           "kind": {
             "type": "string",
             "enum": [
@@ -33483,8 +39094,12 @@
               "created",
               "escalation_policy_paged",
               "ignored_alert_request",
+              "call_lifecycle",
+              "level_skipped",
               "emailed",
               "slacked",
+              "ms_teams_messaged",
+              "google_chat_messaged",
               "called",
               "texted",
               "notified",
@@ -33522,6 +39137,154 @@
             "description": "Note message.",
             "nullable": true
           },
+          "user": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/alert_event_user"
+              }
+            ],
+            "nullable": true
+          },
+          "incident": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "sequential_id": {
+                "type": "integer",
+                "nullable": true
+              },
+              "title": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "private": {
+                "type": "boolean"
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "started_at": {
+                "type": "string",
+                "nullable": true
+              },
+              "duration": {
+                "type": "integer",
+                "description": "Duration in seconds.",
+                "nullable": true
+              },
+              "url": {
+                "type": "string"
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            }
+          },
+          "schedule": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string",
+                "nullable": true
+              },
+              "escalation_policies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "updated_at": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "created_at": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string"
+              }
+            }
+          },
+          "escalation_level": {
+            "type": "integer",
+            "nullable": true
+          },
+          "escalation_target_type": {
+            "type": "string",
+            "description": "e.g. EscalationPolicy, User.",
+            "nullable": true
+          },
+          "escalation_target": {
+            "type": "object",
+            "description": "JSON:API-wrapped escalation target (User or EscalationPolicy).",
+            "nullable": true,
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "e.g. users, escalation_policies."
+                  },
+                  "attributes": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "slack_channel": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/slack_channel"
+              }
+            ],
+            "nullable": true
+          },
+          "incident_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "created_at": {
             "type": "string"
           },
@@ -33530,6 +39293,7 @@
           }
         },
         "required": [
+          "alert_id",
           "source",
           "kind",
           "action",
@@ -33567,6 +39331,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -33622,11 +39392,113 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
           "data",
           "links",
+          "meta"
+        ]
+      },
+      "alert_event_feed_meta": {
+        "type": "object",
+        "description": "Cursor-pagination meta. `total_count` and `total_pages` are nullable because the feed does not run a COUNT query.",
+        "properties": {
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "description": "Pass as `page[after]` on the next request to fetch the following page."
+          },
+          "current_page": {
+            "type": "integer",
+            "nullable": true
+          },
+          "next_page": {
+            "type": "integer",
+            "nullable": true
+          },
+          "prev_page": {
+            "type": "integer",
+            "nullable": true
+          },
+          "total_count": {
+            "type": "integer",
+            "nullable": true
+          },
+          "total_pages": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "next_cursor"
+        ]
+      },
+      "alert_event_feed_list": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique ID of the alert event"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "alert_events"
+                  ]
+                },
+                "attributes": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/alert_event"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "type",
+                "attributes"
+              ]
+            }
+          },
+          "links": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/links"
+              }
+            ]
+          },
+          "meta": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/alert_event_feed_meta"
+              }
+            ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data",
           "meta"
         ]
       },
@@ -33649,6 +39521,10 @@
                     "type": "string",
                     "description": "The name of the alert source"
                   },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Whether the alert source is enabled. Disabled sources do not create alerts from incoming events."
+                  },
                   "source_type": {
                     "type": "string",
                     "description": "The alert source type",
@@ -33656,6 +39532,7 @@
                       "email",
                       "app_dynamics",
                       "catchpoint",
+                      "cloudflare",
                       "datadog",
                       "dynatrace",
                       "alertmanager",
@@ -33822,7 +39699,7 @@
                             },
                             "json_path": {
                               "type": "string",
-                              "description": "JSON path expression to extract a specific value from the alert's payload for evaluation"
+                              "description": "JSON path expression to extract a specific value from the alert's payload for evaluation. For `notification_target_id` only: if your account has opted in to Dynamic Notification Targets, this may also be a Liquid template that resolves to a notification target id at routing time."
                             }
                           }
                         }
@@ -33985,6 +39862,10 @@
                     "type": "string",
                     "description": "The name of the alert source"
                   },
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Whether the alert source is enabled. Disabled sources do not create alerts from incoming events."
+                  },
                   "source_type": {
                     "type": "string",
                     "description": "The alert source type",
@@ -33992,6 +39873,7 @@
                       "email",
                       "app_dynamics",
                       "catchpoint",
+                      "cloudflare",
                       "datadog",
                       "dynatrace",
                       "alertmanager",
@@ -34158,7 +40040,7 @@
                             },
                             "json_path": {
                               "type": "string",
-                              "description": "JSON path expression to extract a specific value from the alert's payload for evaluation"
+                              "description": "JSON path expression to extract a specific value from the alert's payload for evaluation. For `notification_target_id` only: if your account has opted in to Dynamic Notification Targets, this may also be a Liquid template that resolves to a notification target id at routing time."
                             }
                           }
                         }
@@ -34306,6 +40188,10 @@
             "type": "string",
             "description": "The name of the alert source"
           },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the alert source is enabled. Disabled sources do not create alerts from incoming events."
+          },
           "source_type": {
             "type": "string",
             "description": "The alert source type",
@@ -34313,6 +40199,7 @@
               "email",
               "app_dynamics",
               "catchpoint",
+              "cloudflare",
               "datadog",
               "dynatrace",
               "alertmanager",
@@ -34479,7 +40366,7 @@
                     },
                     "json_path": {
                       "type": "string",
-                      "description": "JSON path expression to extract a specific value from the alert's payload for evaluation"
+                      "description": "JSON path expression to extract a specific value from the alert's payload for evaluation. For `notification_target_id` only: if your account has opted in to Dynamic Notification Targets, this may also be a Liquid template that resolves to a notification target id at routing time."
                     }
                   }
                 }
@@ -34676,6 +40563,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -34731,6 +40624,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36131,6 +42030,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36186,6 +42091,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36456,6 +42367,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36511,6 +42428,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36610,6 +42533,10 @@
       "alert_urgency": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique ID of the alert urgency"
+          },
           "name": {
             "type": "string",
             "description": "The name of the alert urgency"
@@ -36621,6 +42548,25 @@
           "position": {
             "type": "integer",
             "description": "Position of the alert urgency"
+          },
+          "urgency": {
+            "type": "string",
+            "description": "The urgency level",
+            "nullable": true
+          },
+          "color": {
+            "type": "string",
+            "description": "The color associated with this urgency level",
+            "nullable": true
+          },
+          "team_id": {
+            "type": "integer",
+            "description": "The ID of the team this urgency belongs to"
+          },
+          "deleted_at": {
+            "type": "string",
+            "description": "Date of deletion",
+            "nullable": true
           },
           "created_at": {
             "type": "string",
@@ -36669,6 +42615,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36724,6 +42676,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -36767,17 +42725,18 @@
                       "properties": {
                         "target_type": {
                           "type": "string",
-                          "description": "The type of the target.",
+                          "description": "The type of the target. Please contact support if you encounter issues using `Functionality` as a target type.",
                           "enum": [
                             "Group",
                             "Service",
-                            "EscalationPolicy"
+                            "EscalationPolicy",
+                            "Functionality"
                           ]
                         },
                         "target_id": {
                           "type": "string",
                           "format": "uuid",
-                          "description": "id for the Group, Service or EscalationPolicy"
+                          "description": "id for the Group, Service, EscalationPolicy or Functionality"
                         }
                       },
                       "required": [
@@ -36948,17 +42907,18 @@
                       "properties": {
                         "target_type": {
                           "type": "string",
-                          "description": "The type of the target.",
+                          "description": "The type of the target. Please contact support if you encounter issues using `Functionality` as a target type.",
                           "enum": [
                             "Group",
                             "Service",
-                            "EscalationPolicy"
+                            "EscalationPolicy",
+                            "Functionality"
                           ]
                         },
                         "target_id": {
                           "type": "string",
                           "format": "uuid",
-                          "description": "id for the Group, Service or EscalationPolicy"
+                          "description": "id for the Group, Service, EscalationPolicy or Functionality"
                         }
                       },
                       "required": [
@@ -37132,17 +43092,18 @@
               "properties": {
                 "target_type": {
                   "type": "string",
-                  "description": "The type of the target.",
+                  "description": "The type of the target. Please contact support if you encounter issues using `Functionality` as a target type.",
                   "enum": [
                     "Group",
                     "Service",
-                    "EscalationPolicy"
+                    "EscalationPolicy",
+                    "Functionality"
                   ]
                 },
                 "target_id": {
                   "type": "string",
                   "format": "uuid",
-                  "description": "id for the Group, Service or EscalationPolicy"
+                  "description": "id for the Group, Service, EscalationPolicy or Functionality"
                 }
               },
               "required": [
@@ -37315,6 +43276,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -37353,6 +43320,12 @@
                 "type",
                 "attributes"
               ]
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
             }
           }
         },
@@ -37610,6 +43583,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -37658,6 +43637,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -37713,6 +43698,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -37732,6 +43723,8 @@
             "type": "string",
             "description": "Describes the object in which the action was taken on",
             "enum": [
+              "AlertRoute",
+              "AlertRoutingRule",
               "Alerts::Source",
               "ApiKey",
               "Catalog",
@@ -37755,28 +43748,51 @@
               "GeniusWorkflowGroup",
               "GeniusWorkflowRun",
               "Group",
+              "GroupUser",
               "Heartbeat",
               "Incident",
               "IncidentActionItem",
               "IncidentEvent",
               "IncidentFormFieldSelection",
               "IncidentFormFieldSelectionUser",
+              "IncidentPermissionSet",
               "IncidentPostMortem",
               "IncidentRoleAssignment",
               "IncidentRoleTask",
               "IncidentStatusPageEvent",
               "IncidentTask",
               "IncidentType",
+              "Integrations::DatadogAccount",
+              "Integrations::GithubAccount",
+              "Integrations::GoogleMeetAccount",
+              "Integrations::JiraAccount",
+              "Integrations::MicrosoftTeamsAccount",
+              "Integrations::NotionAccount",
+              "Integrations::OpsgenieAccount",
+              "Integrations::PagerdutyAccount",
+              "Integrations::ServiceNowAccount",
+              "Integrations::SlackAccount",
+              "Integrations::StatusPageIoAccount",
+              "Integrations::ZendeskAccount",
+              "Integrations::ZoomAccount",
               "LiveCallRouter",
+              "LoginActivity",
+              "Membership",
               "OnCallRole",
               "Playbook",
               "PlaybookTask",
               "Role",
               "Schedule",
+              "Secret",
               "Service",
               "Severity",
               "StatusPage"
             ],
+            "nullable": true
+          },
+          "item_type_display": {
+            "type": "string",
+            "description": "Human-friendly display name for the item type",
             "nullable": true
           },
           "object": {
@@ -37792,6 +43808,36 @@
           "user_id": {
             "type": "integer",
             "description": "The ID of who took action on the object. Together with whodunnit_type can be used to find the user",
+            "nullable": true
+          },
+          "user_name": {
+            "type": "string",
+            "description": "Display name of the user who performed the action",
+            "nullable": true
+          },
+          "user_email": {
+            "type": "string",
+            "description": "Email address of the user who performed the action",
+            "nullable": true
+          },
+          "ip_address": {
+            "type": "string",
+            "description": "IP address of the client that performed the action",
+            "nullable": true
+          },
+          "user_agent": {
+            "type": "string",
+            "description": "User-Agent header of the client that performed the action",
+            "nullable": true
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Unique request ID (UUID) for the HTTP request that triggered the action",
+            "nullable": true
+          },
+          "session_id": {
+            "type": "string",
+            "description": "SHA-256 fingerprint of the web session for correlating multiple actions within the same browser session",
             "nullable": true
           },
           "created_at": {
@@ -37863,6 +43909,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38068,6 +44120,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38123,6 +44181,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38169,6 +44233,11 @@
                   "position": {
                     "type": "integer",
                     "description": "Default position of the catalog when displayed in a list.",
+                    "nullable": true
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog. Must be unique within the team.",
                     "nullable": true
                   }
                 },
@@ -38227,6 +44296,11 @@
                     "type": "integer",
                     "description": "Default position of the catalog when displayed in a list.",
                     "nullable": true
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog. Must be unique within the team.",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false
@@ -38269,6 +44343,24 @@
             "type": "integer",
             "description": "Default position of the catalog when displayed in a list.",
             "nullable": true
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An external identifier for this catalog. Must be unique within the team.",
+            "nullable": true
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "Which source manages this resource (read-only)."
           },
           "created_at": {
             "type": "string"
@@ -38315,6 +44407,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38370,6 +44468,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38403,7 +44507,6 @@
                       "text",
                       "reference",
                       "boolean",
-                      "reference",
                       "service",
                       "functionality",
                       "environment",
@@ -38443,6 +44546,11 @@
                       "service",
                       "team"
                     ]
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog field. Must be unique within the scope.",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false,
@@ -38486,7 +44594,6 @@
                       "text",
                       "reference",
                       "boolean",
-                      "reference",
                       "service",
                       "functionality",
                       "environment",
@@ -38522,6 +44629,11 @@
                       "service",
                       "team"
                     ]
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog field. Must be unique within the scope.",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false
@@ -38588,6 +44700,24 @@
               "team"
             ]
           },
+          "external_id": {
+            "type": "string",
+            "description": "An external identifier for this catalog field. Must be unique within the scope.",
+            "nullable": true
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "Which source manages this resource (read-only)."
+          },
           "created_at": {
             "type": "string"
           },
@@ -38635,6 +44765,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38690,6 +44826,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -38723,7 +44865,6 @@
                       "text",
                       "reference",
                       "boolean",
-                      "reference",
                       "service",
                       "functionality",
                       "environment",
@@ -38763,6 +44904,11 @@
                       "service",
                       "team"
                     ]
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog property. Must be unique within the scope.",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false,
@@ -38806,7 +44952,6 @@
                       "text",
                       "reference",
                       "boolean",
-                      "reference",
                       "service",
                       "functionality",
                       "environment",
@@ -38842,6 +44987,11 @@
                       "service",
                       "team"
                     ]
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog property. Must be unique within the scope.",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false
@@ -38908,6 +45058,24 @@
               "team"
             ]
           },
+          "external_id": {
+            "type": "string",
+            "description": "An external identifier for this catalog property. Must be unique within the scope.",
+            "nullable": true
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "Which source manages this resource (read-only)."
+          },
           "created_at": {
             "type": "string"
           },
@@ -38955,6 +45123,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39010,6 +45184,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39043,6 +45223,16 @@
                   "position": {
                     "type": "integer",
                     "description": "Default position of the item when displayed in a list.",
+                    "nullable": true
+                  },
+                  "backstage_id": {
+                    "type": "string",
+                    "description": "The Backstage entity ID this catalog entity is linked to.",
+                    "nullable": true
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog entity. Must be unique within the catalog.",
                     "nullable": true
                   },
                   "properties": {
@@ -39110,6 +45300,16 @@
                     "description": "Default position of the item when displayed in a list.",
                     "nullable": true
                   },
+                  "backstage_id": {
+                    "type": "string",
+                    "description": "The Backstage entity ID this catalog entity is linked to.",
+                    "nullable": true
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "An external identifier for this catalog entity. Must be unique within the catalog.",
+                    "nullable": true
+                  },
                   "properties": {
                     "type": "array",
                     "description": "Array of property values for this catalog entity",
@@ -39159,6 +45359,29 @@
             "type": "integer",
             "description": "Default position of the item when displayed in a list.",
             "nullable": true
+          },
+          "backstage_id": {
+            "type": "string",
+            "description": "The Backstage entity ID this catalog entity is linked to.",
+            "nullable": true
+          },
+          "external_id": {
+            "type": "string",
+            "description": "An external identifier for this catalog entity. Must be unique within the catalog.",
+            "nullable": true
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "Which source manages this resource (read-only)."
           },
           "created_at": {
             "type": "string"
@@ -39225,6 +45448,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39280,6 +45509,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39287,6 +45522,212 @@
           "links",
           "meta"
         ]
+      },
+      "bulk_upsert_catalog_entities": {
+        "type": "object",
+        "properties": {
+          "entities": {
+            "type": "array",
+            "description": "Array of catalog entities to upsert. Each must have an external_id. Max 100 per request. external_ids must be unique within a batch.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "external_id": {
+                  "type": "string",
+                  "description": "External identifier used as the upsert key. Must be unique within the catalog."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Required for new entities. Optional for updates (managed-fields: omitted attributes are preserved)."
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "backstage_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "fields": {
+                  "type": "array",
+                  "description": "Property values for this entity. Only mentioned fields are written; unmentioned fields are preserved.",
+                  "items": {
+                    "type": "object",
+                    "description": "Each field entry must include either catalog_field_id or catalog_property_id.",
+                    "properties": {
+                      "catalog_field_id": {
+                        "type": "string",
+                        "description": "UUID, slug, or external_id of the catalog field (required if catalog_property_id is absent)"
+                      },
+                      "catalog_property_id": {
+                        "type": "string",
+                        "description": "Alias for catalog_field_id (required if catalog_field_id is absent)"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value for this field"
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "external_id"
+              ]
+            }
+          }
+        },
+        "required": [
+          "entities"
+        ]
+      },
+      "bulk_upsert_catalog_entities_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "catalog_entities"
+                  ]
+                },
+                "attributes": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/catalog_entity"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_catalog_entities_error": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "index",
+                "external_id",
+                "errors"
+              ],
+              "properties": {
+                "index": {
+                  "type": "integer",
+                  "description": "Position of the failed entity in the batch"
+                },
+                "external_id": {
+                  "type": "string"
+                },
+                "errors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_destroy_catalog_entities": {
+        "description": "Two mutually exclusive modes. Pass exactly one of: external_ids (delete specific entities) or managed_by (prune all managed entities not in keep set).",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "external_ids"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "external_ids": {
+                "type": "array",
+                "description": "Array of external_ids to delete. Max 100 per request.",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "managed_by"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "managed_by": {
+                "type": "string",
+                "enum": [
+                  "api",
+                  "terraform",
+                  "pulumi",
+                  "backstage",
+                  "catalog_sync"
+                ],
+                "description": "Delete all entities with this managed_by value (web/admin_web not allowed)."
+              },
+              "keep_external_ids": {
+                "type": "array",
+                "description": "Entities with these external_ids are preserved.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "bulk_destroy_catalog_entities_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "deleted_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were successfully deleted"
+              },
+              "failed_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs whose deletion the record itself blocked (e.g. minimum-one guard, restrict associations). Records the caller is not authorized to destroy are NOT listed here."
+              },
+              "not_found_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were not found or not accessible to the caller (external_ids mode only)"
+              }
+            }
+          }
+        }
       },
       "new_catalog_entity_property": {
         "type": "object",
@@ -39454,6 +45895,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39511,6 +45958,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39919,6 +46372,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -39974,6 +46433,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40193,6 +46658,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40248,6 +46719,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40475,6 +46952,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40530,12 +47013,40 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
           "data",
           "links",
           "meta"
+        ]
+      },
+      "incidents_chart_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "uptime_chart_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "data"
         ]
       },
       "new_communications_stage": {
@@ -40694,6 +47205,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40749,6 +47266,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40927,6 +47450,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -40982,6 +47511,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -41323,6 +47858,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -41378,6 +47919,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -41921,6 +48468,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -41976,6 +48529,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -42142,6 +48701,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -42197,6 +48762,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -42485,6 +49056,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -42540,6 +49117,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -42709,6 +49292,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -42764,6 +49353,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -43480,6 +50075,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -43535,6 +50136,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -43821,6 +50428,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -43876,6 +50489,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -44349,6 +50968,11 @@
                     "description": "Position of the environment",
                     "nullable": true
                   },
+                  "external_id": {
+                    "type": "string",
+                    "description": "The external id associated to this environment",
+                    "nullable": true
+                  },
                   "notify_emails": {
                     "type": "array",
                     "description": "Emails to attach to the environment",
@@ -44474,6 +51098,11 @@
                     "description": "Position of the environment",
                     "nullable": true
                   },
+                  "external_id": {
+                    "type": "string",
+                    "description": "The external id associated to this environment",
+                    "nullable": true
+                  },
                   "notify_emails": {
                     "type": "array",
                     "description": "Emails to attach to the environment",
@@ -44572,6 +51201,24 @@
           "slug": {
             "type": "string",
             "description": "The slug of the environment"
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "How this environment is managed (provenance): web, api, terraform, etc. Read-only."
+          },
+          "external_id": {
+            "type": "string",
+            "description": "The external id associated to this environment",
+            "nullable": true
           },
           "description": {
             "type": "string",
@@ -44708,6 +51355,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -44763,6 +51416,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -44770,6 +51429,218 @@
           "links",
           "meta"
         ]
+      },
+      "bulk_upsert_environments": {
+        "type": "object",
+        "required": [
+          "entities"
+        ],
+        "properties": {
+          "entities": {
+            "type": "array",
+            "description": "Environments to upsert, matched by external_id. Max 100 per request; external_ids unique within a batch. Only attributes present are written (managed-fields semantics).",
+            "items": {
+              "type": "object",
+              "required": [
+                "external_id"
+              ],
+              "properties": {
+                "external_id": {
+                  "type": "string",
+                  "description": "External identifier used as the upsert key. Unique per team."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Required for new records. Optional for updates."
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "color": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "position": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "notify_emails": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true
+                },
+                "fields": {
+                  "type": "array",
+                  "description": "Catalog property values (merge semantics: only mentioned fields written).",
+                  "items": {
+                    "type": "object",
+                    "description": "Each field entry must include either catalog_field_id or catalog_property_id.",
+                    "properties": {
+                      "catalog_field_id": {
+                        "type": "string",
+                        "description": "UUID, slug, or external_id of the catalog field (required if catalog_property_id is absent)"
+                      },
+                      "catalog_property_id": {
+                        "type": "string",
+                        "description": "Alias for catalog_field_id (required if catalog_field_id is absent)"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value for this field"
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_environments_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "environments"
+                  ]
+                },
+                "attributes": {
+                  "$ref": "#/components/schemas/environment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_environments_error": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "index",
+                "external_id",
+                "errors"
+              ],
+              "properties": {
+                "index": {
+                  "type": "integer",
+                  "description": "Position of the failed record in the batch"
+                },
+                "external_id": {
+                  "type": "string"
+                },
+                "errors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_destroy_environments": {
+        "description": "Two mutually exclusive modes. Pass exactly one of: external_ids (delete specific records) or managed_by (prune all managed records not in keep set).",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "external_ids"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "external_ids": {
+                "type": "array",
+                "description": "Array of external_ids to delete. Max 100 per request.",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "managed_by"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "managed_by": {
+                "type": "string",
+                "enum": [
+                  "api",
+                  "terraform",
+                  "pulumi",
+                  "backstage",
+                  "catalog_sync"
+                ],
+                "description": "Delete all records with this managed_by value (web/admin_web not allowed)."
+              },
+              "keep_external_ids": {
+                "type": "array",
+                "description": "Records with these external_ids are preserved.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "bulk_destroy_environments_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "deleted_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were successfully deleted"
+              },
+              "failed_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs whose deletion the record itself blocked (e.g. minimum-one guard, restrict associations). Records the caller is not authorized to destroy are NOT listed here."
+              },
+              "not_found_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were not found or not accessible to the caller (external_ids mode only)"
+              }
+            }
+          }
+        }
       },
       "errors_list": {
         "type": "object",
@@ -44880,7 +51751,6 @@
                           "Guadalajara",
                           "America/Mexico_City",
                           "Mexico City",
-                          "America/Mexico_City",
                           "Monterrey",
                           "America/Monterrey",
                           "Saskatchewan",
@@ -44894,7 +51764,6 @@
                           "Lima",
                           "America/Lima",
                           "Quito",
-                          "America/Lima",
                           "Atlantic Time (Canada)",
                           "America/Halifax",
                           "Caracas",
@@ -44930,7 +51799,6 @@
                           "Lisbon",
                           "Europe/Lisbon",
                           "London",
-                          "Europe/London",
                           "Monrovia",
                           "Africa/Monrovia",
                           "UTC",
@@ -44980,7 +51848,6 @@
                           "Zagreb",
                           "Europe/Zagreb",
                           "Zurich",
-                          "Europe/Zurich",
                           "Athens",
                           "Europe/Athens",
                           "Bucharest",
@@ -45022,7 +51889,6 @@
                           "Riyadh",
                           "Asia/Riyadh",
                           "St. Petersburg",
-                          "Europe/Moscow",
                           "Volgograd",
                           "Europe/Volgograd",
                           "Tehran",
@@ -45032,7 +51898,6 @@
                           "Baku",
                           "Asia/Baku",
                           "Muscat",
-                          "Asia/Muscat",
                           "Samara",
                           "Europe/Samara",
                           "Tbilisi",
@@ -45044,23 +51909,18 @@
                           "Almaty",
                           "Asia/Almaty",
                           "Astana",
-                          "Asia/Almaty",
                           "Ekaterinburg",
                           "Asia/Yekaterinburg",
                           "Islamabad",
                           "Asia/Karachi",
                           "Karachi",
-                          "Asia/Karachi",
                           "Tashkent",
                           "Asia/Tashkent",
                           "Chennai",
                           "Asia/Kolkata",
                           "Kolkata",
-                          "Asia/Kolkata",
                           "Mumbai",
-                          "Asia/Kolkata",
                           "New Delhi",
-                          "Asia/Kolkata",
                           "Sri Jayawardenepura",
                           "Asia/Colombo",
                           "Kathmandu",
@@ -45074,7 +51934,6 @@
                           "Bangkok",
                           "Asia/Bangkok",
                           "Hanoi",
-                          "Asia/Bangkok",
                           "Jakarta",
                           "Asia/Jakarta",
                           "Krasnoyarsk",
@@ -45102,11 +51961,9 @@
                           "Osaka",
                           "Asia/Tokyo",
                           "Sapporo",
-                          "Asia/Tokyo",
                           "Seoul",
                           "Asia/Seoul",
                           "Tokyo",
-                          "Asia/Tokyo",
                           "Yakutsk",
                           "Asia/Yakutsk",
                           "Adelaide",
@@ -45146,7 +52003,6 @@
                           "Marshall Is.",
                           "Pacific/Majuro",
                           "Wellington",
-                          "Pacific/Auckland",
                           "Chatham Is.",
                           "Pacific/Chatham",
                           "Nuku'alofa",
@@ -45154,7 +52010,23 @@
                           "Samoa",
                           "Pacific/Apia",
                           "Tokelau Is.",
-                          "Pacific/Fakaofo"
+                          "Pacific/Fakaofo",
+                          "America/Adak",
+                          "America/Atka",
+                          "US/Aleutian",
+                          "America/Vancouver",
+                          "Canada/Pacific",
+                          "America/Miquelon",
+                          "Australia/Eucla",
+                          "Australia/LHI",
+                          "Australia/Lord_Howe",
+                          "Chile/EasterIsland",
+                          "Pacific/Easter",
+                          "Pacific/Gambier",
+                          "Pacific/Pitcairn",
+                          "Pacific/Marquesas",
+                          "Pacific/Kiritimati",
+                          "Pacific/Norfolk"
                         ],
                         "nullable": true
                       },
@@ -45283,7 +52155,6 @@
                           "Guadalajara",
                           "America/Mexico_City",
                           "Mexico City",
-                          "America/Mexico_City",
                           "Monterrey",
                           "America/Monterrey",
                           "Saskatchewan",
@@ -45297,7 +52168,6 @@
                           "Lima",
                           "America/Lima",
                           "Quito",
-                          "America/Lima",
                           "Atlantic Time (Canada)",
                           "America/Halifax",
                           "Caracas",
@@ -45333,7 +52203,6 @@
                           "Lisbon",
                           "Europe/Lisbon",
                           "London",
-                          "Europe/London",
                           "Monrovia",
                           "Africa/Monrovia",
                           "UTC",
@@ -45383,7 +52252,6 @@
                           "Zagreb",
                           "Europe/Zagreb",
                           "Zurich",
-                          "Europe/Zurich",
                           "Athens",
                           "Europe/Athens",
                           "Bucharest",
@@ -45425,7 +52293,6 @@
                           "Riyadh",
                           "Asia/Riyadh",
                           "St. Petersburg",
-                          "Europe/Moscow",
                           "Volgograd",
                           "Europe/Volgograd",
                           "Tehran",
@@ -45435,7 +52302,6 @@
                           "Baku",
                           "Asia/Baku",
                           "Muscat",
-                          "Asia/Muscat",
                           "Samara",
                           "Europe/Samara",
                           "Tbilisi",
@@ -45447,23 +52313,18 @@
                           "Almaty",
                           "Asia/Almaty",
                           "Astana",
-                          "Asia/Almaty",
                           "Ekaterinburg",
                           "Asia/Yekaterinburg",
                           "Islamabad",
                           "Asia/Karachi",
                           "Karachi",
-                          "Asia/Karachi",
                           "Tashkent",
                           "Asia/Tashkent",
                           "Chennai",
                           "Asia/Kolkata",
                           "Kolkata",
-                          "Asia/Kolkata",
                           "Mumbai",
-                          "Asia/Kolkata",
                           "New Delhi",
-                          "Asia/Kolkata",
                           "Sri Jayawardenepura",
                           "Asia/Colombo",
                           "Kathmandu",
@@ -45477,7 +52338,6 @@
                           "Bangkok",
                           "Asia/Bangkok",
                           "Hanoi",
-                          "Asia/Bangkok",
                           "Jakarta",
                           "Asia/Jakarta",
                           "Krasnoyarsk",
@@ -45505,11 +52365,9 @@
                           "Osaka",
                           "Asia/Tokyo",
                           "Sapporo",
-                          "Asia/Tokyo",
                           "Seoul",
                           "Asia/Seoul",
                           "Tokyo",
-                          "Asia/Tokyo",
                           "Yakutsk",
                           "Asia/Yakutsk",
                           "Adelaide",
@@ -45549,7 +52407,6 @@
                           "Marshall Is.",
                           "Pacific/Majuro",
                           "Wellington",
-                          "Pacific/Auckland",
                           "Chatham Is.",
                           "Pacific/Chatham",
                           "Nuku'alofa",
@@ -45557,7 +52414,23 @@
                           "Samoa",
                           "Pacific/Apia",
                           "Tokelau Is.",
-                          "Pacific/Fakaofo"
+                          "Pacific/Fakaofo",
+                          "America/Adak",
+                          "America/Atka",
+                          "US/Aleutian",
+                          "America/Vancouver",
+                          "Canada/Pacific",
+                          "America/Miquelon",
+                          "Australia/Eucla",
+                          "Australia/LHI",
+                          "Australia/Lord_Howe",
+                          "Chile/EasterIsland",
+                          "Pacific/Easter",
+                          "Pacific/Gambier",
+                          "Pacific/Pitcairn",
+                          "Pacific/Marquesas",
+                          "Pacific/Kiritimati",
+                          "Pacific/Norfolk"
                         ],
                         "nullable": true
                       },
@@ -45679,7 +52552,6 @@
                   "Guadalajara",
                   "America/Mexico_City",
                   "Mexico City",
-                  "America/Mexico_City",
                   "Monterrey",
                   "America/Monterrey",
                   "Saskatchewan",
@@ -45693,7 +52565,6 @@
                   "Lima",
                   "America/Lima",
                   "Quito",
-                  "America/Lima",
                   "Atlantic Time (Canada)",
                   "America/Halifax",
                   "Caracas",
@@ -45729,7 +52600,6 @@
                   "Lisbon",
                   "Europe/Lisbon",
                   "London",
-                  "Europe/London",
                   "Monrovia",
                   "Africa/Monrovia",
                   "UTC",
@@ -45779,7 +52649,6 @@
                   "Zagreb",
                   "Europe/Zagreb",
                   "Zurich",
-                  "Europe/Zurich",
                   "Athens",
                   "Europe/Athens",
                   "Bucharest",
@@ -45821,7 +52690,6 @@
                   "Riyadh",
                   "Asia/Riyadh",
                   "St. Petersburg",
-                  "Europe/Moscow",
                   "Volgograd",
                   "Europe/Volgograd",
                   "Tehran",
@@ -45831,7 +52699,6 @@
                   "Baku",
                   "Asia/Baku",
                   "Muscat",
-                  "Asia/Muscat",
                   "Samara",
                   "Europe/Samara",
                   "Tbilisi",
@@ -45843,23 +52710,18 @@
                   "Almaty",
                   "Asia/Almaty",
                   "Astana",
-                  "Asia/Almaty",
                   "Ekaterinburg",
                   "Asia/Yekaterinburg",
                   "Islamabad",
                   "Asia/Karachi",
                   "Karachi",
-                  "Asia/Karachi",
                   "Tashkent",
                   "Asia/Tashkent",
                   "Chennai",
                   "Asia/Kolkata",
                   "Kolkata",
-                  "Asia/Kolkata",
                   "Mumbai",
-                  "Asia/Kolkata",
                   "New Delhi",
-                  "Asia/Kolkata",
                   "Sri Jayawardenepura",
                   "Asia/Colombo",
                   "Kathmandu",
@@ -45873,7 +52735,6 @@
                   "Bangkok",
                   "Asia/Bangkok",
                   "Hanoi",
-                  "Asia/Bangkok",
                   "Jakarta",
                   "Asia/Jakarta",
                   "Krasnoyarsk",
@@ -45901,11 +52762,9 @@
                   "Osaka",
                   "Asia/Tokyo",
                   "Sapporo",
-                  "Asia/Tokyo",
                   "Seoul",
                   "Asia/Seoul",
                   "Tokyo",
-                  "Asia/Tokyo",
                   "Yakutsk",
                   "Asia/Yakutsk",
                   "Adelaide",
@@ -45945,7 +52804,6 @@
                   "Marshall Is.",
                   "Pacific/Majuro",
                   "Wellington",
-                  "Pacific/Auckland",
                   "Chatham Is.",
                   "Pacific/Chatham",
                   "Nuku'alofa",
@@ -45953,7 +52811,23 @@
                   "Samoa",
                   "Pacific/Apia",
                   "Tokelau Is.",
-                  "Pacific/Fakaofo"
+                  "Pacific/Fakaofo",
+                  "America/Adak",
+                  "America/Atka",
+                  "US/Aleutian",
+                  "America/Vancouver",
+                  "Canada/Pacific",
+                  "America/Miquelon",
+                  "Australia/Eucla",
+                  "Australia/LHI",
+                  "Australia/Lord_Howe",
+                  "Chile/EasterIsland",
+                  "Pacific/Easter",
+                  "Pacific/Gambier",
+                  "Pacific/Pitcairn",
+                  "Pacific/Marquesas",
+                  "Pacific/Kiritimati",
+                  "Pacific/Norfolk"
                 ],
                 "nullable": true
               },
@@ -46032,6 +52906,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -46087,6 +52967,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -46246,8 +53132,16 @@
                                 "is_not",
                                 "contains",
                                 "does_not_contain",
+                                "contains_key",
+                                "does_not_contain_key",
+                                "starts_with",
+                                "does_not_start_with",
+                                "matches",
+                                "does_not_match",
                                 "is_one_of",
-                                "is_not_one_of"
+                                "is_not_one_of",
+                                "is_set",
+                                "is_not_set"
                               ]
                             },
                             "value": {
@@ -46385,7 +53279,6 @@
                                 "Guadalajara",
                                 "America/Mexico_City",
                                 "Mexico City",
-                                "America/Mexico_City",
                                 "Monterrey",
                                 "America/Monterrey",
                                 "Saskatchewan",
@@ -46399,7 +53292,6 @@
                                 "Lima",
                                 "America/Lima",
                                 "Quito",
-                                "America/Lima",
                                 "Atlantic Time (Canada)",
                                 "America/Halifax",
                                 "Caracas",
@@ -46435,7 +53327,6 @@
                                 "Lisbon",
                                 "Europe/Lisbon",
                                 "London",
-                                "Europe/London",
                                 "Monrovia",
                                 "Africa/Monrovia",
                                 "UTC",
@@ -46485,7 +53376,6 @@
                                 "Zagreb",
                                 "Europe/Zagreb",
                                 "Zurich",
-                                "Europe/Zurich",
                                 "Athens",
                                 "Europe/Athens",
                                 "Bucharest",
@@ -46527,7 +53417,6 @@
                                 "Riyadh",
                                 "Asia/Riyadh",
                                 "St. Petersburg",
-                                "Europe/Moscow",
                                 "Volgograd",
                                 "Europe/Volgograd",
                                 "Tehran",
@@ -46537,7 +53426,6 @@
                                 "Baku",
                                 "Asia/Baku",
                                 "Muscat",
-                                "Asia/Muscat",
                                 "Samara",
                                 "Europe/Samara",
                                 "Tbilisi",
@@ -46549,23 +53437,18 @@
                                 "Almaty",
                                 "Asia/Almaty",
                                 "Astana",
-                                "Asia/Almaty",
                                 "Ekaterinburg",
                                 "Asia/Yekaterinburg",
                                 "Islamabad",
                                 "Asia/Karachi",
                                 "Karachi",
-                                "Asia/Karachi",
                                 "Tashkent",
                                 "Asia/Tashkent",
                                 "Chennai",
                                 "Asia/Kolkata",
                                 "Kolkata",
-                                "Asia/Kolkata",
                                 "Mumbai",
-                                "Asia/Kolkata",
                                 "New Delhi",
-                                "Asia/Kolkata",
                                 "Sri Jayawardenepura",
                                 "Asia/Colombo",
                                 "Kathmandu",
@@ -46579,7 +53462,6 @@
                                 "Bangkok",
                                 "Asia/Bangkok",
                                 "Hanoi",
-                                "Asia/Bangkok",
                                 "Jakarta",
                                 "Asia/Jakarta",
                                 "Krasnoyarsk",
@@ -46607,11 +53489,9 @@
                                 "Osaka",
                                 "Asia/Tokyo",
                                 "Sapporo",
-                                "Asia/Tokyo",
                                 "Seoul",
                                 "Asia/Seoul",
                                 "Tokyo",
-                                "Asia/Tokyo",
                                 "Yakutsk",
                                 "Asia/Yakutsk",
                                 "Adelaide",
@@ -46651,7 +53531,6 @@
                                 "Marshall Is.",
                                 "Pacific/Majuro",
                                 "Wellington",
-                                "Pacific/Auckland",
                                 "Chatham Is.",
                                 "Pacific/Chatham",
                                 "Nuku'alofa",
@@ -46659,7 +53538,23 @@
                                 "Samoa",
                                 "Pacific/Apia",
                                 "Tokelau Is.",
-                                "Pacific/Fakaofo"
+                                "Pacific/Fakaofo",
+                                "America/Adak",
+                                "America/Atka",
+                                "US/Aleutian",
+                                "America/Vancouver",
+                                "Canada/Pacific",
+                                "America/Miquelon",
+                                "Australia/Eucla",
+                                "Australia/LHI",
+                                "Australia/Lord_Howe",
+                                "Chile/EasterIsland",
+                                "Pacific/Easter",
+                                "Pacific/Gambier",
+                                "Pacific/Pitcairn",
+                                "Pacific/Marquesas",
+                                "Pacific/Kiritimati",
+                                "Pacific/Norfolk"
                               ]
                             },
                             "time_blocks": {
@@ -46670,31 +53565,31 @@
                                 "properties": {
                                   "monday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "tuesday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "wednesday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "thursday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "friday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "saturday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "sunday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "start_time": {
                                     "type": "string",
@@ -46706,7 +53601,7 @@
                                   },
                                   "all_day": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "position": {
                                     "type": "integer",
@@ -46720,6 +53615,62 @@
                             "rule_type",
                             "time_zone",
                             "time_blocks"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "rule_type": {
+                              "type": "string",
+                              "description": "The type of the escalation path rule",
+                              "enum": [
+                                "source"
+                              ]
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "How the alert source should be matched",
+                              "enum": [
+                                "is",
+                                "is_not",
+                                "is_one_of",
+                                "is_not_one_of"
+                              ]
+                            },
+                            "values": {
+                              "type": "array",
+                              "description": "Alert source values to match against (e.g., manual, datadog)",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": [
+                            "rule_type",
+                            "operator",
+                            "values"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "rule_type": {
+                              "type": "string",
+                              "description": "The type of the escalation path rule",
+                              "enum": [
+                                "related_incidents"
+                              ]
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "Whether the alert must (or must not) have related incidents",
+                              "enum": [
+                                "is_set",
+                                "is_not_set"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "rule_type",
+                            "operator"
                           ]
                         }
                       ]
@@ -46758,7 +53709,6 @@
                       "Guadalajara",
                       "America/Mexico_City",
                       "Mexico City",
-                      "America/Mexico_City",
                       "Monterrey",
                       "America/Monterrey",
                       "Saskatchewan",
@@ -46772,7 +53722,6 @@
                       "Lima",
                       "America/Lima",
                       "Quito",
-                      "America/Lima",
                       "Atlantic Time (Canada)",
                       "America/Halifax",
                       "Caracas",
@@ -46808,7 +53757,6 @@
                       "Lisbon",
                       "Europe/Lisbon",
                       "London",
-                      "Europe/London",
                       "Monrovia",
                       "Africa/Monrovia",
                       "UTC",
@@ -46858,7 +53806,6 @@
                       "Zagreb",
                       "Europe/Zagreb",
                       "Zurich",
-                      "Europe/Zurich",
                       "Athens",
                       "Europe/Athens",
                       "Bucharest",
@@ -46900,7 +53847,6 @@
                       "Riyadh",
                       "Asia/Riyadh",
                       "St. Petersburg",
-                      "Europe/Moscow",
                       "Volgograd",
                       "Europe/Volgograd",
                       "Tehran",
@@ -46910,7 +53856,6 @@
                       "Baku",
                       "Asia/Baku",
                       "Muscat",
-                      "Asia/Muscat",
                       "Samara",
                       "Europe/Samara",
                       "Tbilisi",
@@ -46922,23 +53867,18 @@
                       "Almaty",
                       "Asia/Almaty",
                       "Astana",
-                      "Asia/Almaty",
                       "Ekaterinburg",
                       "Asia/Yekaterinburg",
                       "Islamabad",
                       "Asia/Karachi",
                       "Karachi",
-                      "Asia/Karachi",
                       "Tashkent",
                       "Asia/Tashkent",
                       "Chennai",
                       "Asia/Kolkata",
                       "Kolkata",
-                      "Asia/Kolkata",
                       "Mumbai",
-                      "Asia/Kolkata",
                       "New Delhi",
-                      "Asia/Kolkata",
                       "Sri Jayawardenepura",
                       "Asia/Colombo",
                       "Kathmandu",
@@ -46952,7 +53892,6 @@
                       "Bangkok",
                       "Asia/Bangkok",
                       "Hanoi",
-                      "Asia/Bangkok",
                       "Jakarta",
                       "Asia/Jakarta",
                       "Krasnoyarsk",
@@ -46980,11 +53919,9 @@
                       "Osaka",
                       "Asia/Tokyo",
                       "Sapporo",
-                      "Asia/Tokyo",
                       "Seoul",
                       "Asia/Seoul",
                       "Tokyo",
-                      "Asia/Tokyo",
                       "Yakutsk",
                       "Asia/Yakutsk",
                       "Adelaide",
@@ -47024,7 +53961,6 @@
                       "Marshall Is.",
                       "Pacific/Majuro",
                       "Wellington",
-                      "Pacific/Auckland",
                       "Chatham Is.",
                       "Pacific/Chatham",
                       "Nuku'alofa",
@@ -47032,7 +53968,23 @@
                       "Samoa",
                       "Pacific/Apia",
                       "Tokelau Is.",
-                      "Pacific/Fakaofo"
+                      "Pacific/Fakaofo",
+                      "America/Adak",
+                      "America/Atka",
+                      "US/Aleutian",
+                      "America/Vancouver",
+                      "Canada/Pacific",
+                      "America/Miquelon",
+                      "Australia/Eucla",
+                      "Australia/LHI",
+                      "Australia/Lord_Howe",
+                      "Chile/EasterIsland",
+                      "Pacific/Easter",
+                      "Pacific/Gambier",
+                      "Pacific/Pitcairn",
+                      "Pacific/Marquesas",
+                      "Pacific/Kiritimati",
+                      "Pacific/Norfolk"
                     ],
                     "nullable": true
                   },
@@ -47250,8 +54202,16 @@
                                 "is_not",
                                 "contains",
                                 "does_not_contain",
+                                "contains_key",
+                                "does_not_contain_key",
+                                "starts_with",
+                                "does_not_start_with",
+                                "matches",
+                                "does_not_match",
                                 "is_one_of",
-                                "is_not_one_of"
+                                "is_not_one_of",
+                                "is_set",
+                                "is_not_set"
                               ]
                             },
                             "value": {
@@ -47389,7 +54349,6 @@
                                 "Guadalajara",
                                 "America/Mexico_City",
                                 "Mexico City",
-                                "America/Mexico_City",
                                 "Monterrey",
                                 "America/Monterrey",
                                 "Saskatchewan",
@@ -47403,7 +54362,6 @@
                                 "Lima",
                                 "America/Lima",
                                 "Quito",
-                                "America/Lima",
                                 "Atlantic Time (Canada)",
                                 "America/Halifax",
                                 "Caracas",
@@ -47439,7 +54397,6 @@
                                 "Lisbon",
                                 "Europe/Lisbon",
                                 "London",
-                                "Europe/London",
                                 "Monrovia",
                                 "Africa/Monrovia",
                                 "UTC",
@@ -47489,7 +54446,6 @@
                                 "Zagreb",
                                 "Europe/Zagreb",
                                 "Zurich",
-                                "Europe/Zurich",
                                 "Athens",
                                 "Europe/Athens",
                                 "Bucharest",
@@ -47531,7 +54487,6 @@
                                 "Riyadh",
                                 "Asia/Riyadh",
                                 "St. Petersburg",
-                                "Europe/Moscow",
                                 "Volgograd",
                                 "Europe/Volgograd",
                                 "Tehran",
@@ -47541,7 +54496,6 @@
                                 "Baku",
                                 "Asia/Baku",
                                 "Muscat",
-                                "Asia/Muscat",
                                 "Samara",
                                 "Europe/Samara",
                                 "Tbilisi",
@@ -47553,23 +54507,18 @@
                                 "Almaty",
                                 "Asia/Almaty",
                                 "Astana",
-                                "Asia/Almaty",
                                 "Ekaterinburg",
                                 "Asia/Yekaterinburg",
                                 "Islamabad",
                                 "Asia/Karachi",
                                 "Karachi",
-                                "Asia/Karachi",
                                 "Tashkent",
                                 "Asia/Tashkent",
                                 "Chennai",
                                 "Asia/Kolkata",
                                 "Kolkata",
-                                "Asia/Kolkata",
                                 "Mumbai",
-                                "Asia/Kolkata",
                                 "New Delhi",
-                                "Asia/Kolkata",
                                 "Sri Jayawardenepura",
                                 "Asia/Colombo",
                                 "Kathmandu",
@@ -47583,7 +54532,6 @@
                                 "Bangkok",
                                 "Asia/Bangkok",
                                 "Hanoi",
-                                "Asia/Bangkok",
                                 "Jakarta",
                                 "Asia/Jakarta",
                                 "Krasnoyarsk",
@@ -47611,11 +54559,9 @@
                                 "Osaka",
                                 "Asia/Tokyo",
                                 "Sapporo",
-                                "Asia/Tokyo",
                                 "Seoul",
                                 "Asia/Seoul",
                                 "Tokyo",
-                                "Asia/Tokyo",
                                 "Yakutsk",
                                 "Asia/Yakutsk",
                                 "Adelaide",
@@ -47655,7 +54601,6 @@
                                 "Marshall Is.",
                                 "Pacific/Majuro",
                                 "Wellington",
-                                "Pacific/Auckland",
                                 "Chatham Is.",
                                 "Pacific/Chatham",
                                 "Nuku'alofa",
@@ -47663,7 +54608,23 @@
                                 "Samoa",
                                 "Pacific/Apia",
                                 "Tokelau Is.",
-                                "Pacific/Fakaofo"
+                                "Pacific/Fakaofo",
+                                "America/Adak",
+                                "America/Atka",
+                                "US/Aleutian",
+                                "America/Vancouver",
+                                "Canada/Pacific",
+                                "America/Miquelon",
+                                "Australia/Eucla",
+                                "Australia/LHI",
+                                "Australia/Lord_Howe",
+                                "Chile/EasterIsland",
+                                "Pacific/Easter",
+                                "Pacific/Gambier",
+                                "Pacific/Pitcairn",
+                                "Pacific/Marquesas",
+                                "Pacific/Kiritimati",
+                                "Pacific/Norfolk"
                               ]
                             },
                             "time_blocks": {
@@ -47674,31 +54635,31 @@
                                 "properties": {
                                   "monday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "tuesday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "wednesday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "thursday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "friday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "saturday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "sunday": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "start_time": {
                                     "type": "string",
@@ -47710,7 +54671,7 @@
                                   },
                                   "all_day": {
                                     "type": "boolean",
-                                    "nullable": true
+                                    "default": false
                                   },
                                   "position": {
                                     "type": "integer",
@@ -47724,6 +54685,62 @@
                             "rule_type",
                             "time_zone",
                             "time_blocks"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "rule_type": {
+                              "type": "string",
+                              "description": "The type of the escalation path rule",
+                              "enum": [
+                                "source"
+                              ]
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "How the alert source should be matched",
+                              "enum": [
+                                "is",
+                                "is_not",
+                                "is_one_of",
+                                "is_not_one_of"
+                              ]
+                            },
+                            "values": {
+                              "type": "array",
+                              "description": "Alert source values to match against (e.g., manual, datadog)",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": [
+                            "rule_type",
+                            "operator",
+                            "values"
+                          ]
+                        },
+                        {
+                          "properties": {
+                            "rule_type": {
+                              "type": "string",
+                              "description": "The type of the escalation path rule",
+                              "enum": [
+                                "related_incidents"
+                              ]
+                            },
+                            "operator": {
+                              "type": "string",
+                              "description": "Whether the alert must (or must not) have related incidents",
+                              "enum": [
+                                "is_set",
+                                "is_not_set"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "rule_type",
+                            "operator"
                           ]
                         }
                       ],
@@ -47763,7 +54780,6 @@
                       "Guadalajara",
                       "America/Mexico_City",
                       "Mexico City",
-                      "America/Mexico_City",
                       "Monterrey",
                       "America/Monterrey",
                       "Saskatchewan",
@@ -47777,7 +54793,6 @@
                       "Lima",
                       "America/Lima",
                       "Quito",
-                      "America/Lima",
                       "Atlantic Time (Canada)",
                       "America/Halifax",
                       "Caracas",
@@ -47813,7 +54828,6 @@
                       "Lisbon",
                       "Europe/Lisbon",
                       "London",
-                      "Europe/London",
                       "Monrovia",
                       "Africa/Monrovia",
                       "UTC",
@@ -47863,7 +54877,6 @@
                       "Zagreb",
                       "Europe/Zagreb",
                       "Zurich",
-                      "Europe/Zurich",
                       "Athens",
                       "Europe/Athens",
                       "Bucharest",
@@ -47905,7 +54918,6 @@
                       "Riyadh",
                       "Asia/Riyadh",
                       "St. Petersburg",
-                      "Europe/Moscow",
                       "Volgograd",
                       "Europe/Volgograd",
                       "Tehran",
@@ -47915,7 +54927,6 @@
                       "Baku",
                       "Asia/Baku",
                       "Muscat",
-                      "Asia/Muscat",
                       "Samara",
                       "Europe/Samara",
                       "Tbilisi",
@@ -47927,23 +54938,18 @@
                       "Almaty",
                       "Asia/Almaty",
                       "Astana",
-                      "Asia/Almaty",
                       "Ekaterinburg",
                       "Asia/Yekaterinburg",
                       "Islamabad",
                       "Asia/Karachi",
                       "Karachi",
-                      "Asia/Karachi",
                       "Tashkent",
                       "Asia/Tashkent",
                       "Chennai",
                       "Asia/Kolkata",
                       "Kolkata",
-                      "Asia/Kolkata",
                       "Mumbai",
-                      "Asia/Kolkata",
                       "New Delhi",
-                      "Asia/Kolkata",
                       "Sri Jayawardenepura",
                       "Asia/Colombo",
                       "Kathmandu",
@@ -47957,7 +54963,6 @@
                       "Bangkok",
                       "Asia/Bangkok",
                       "Hanoi",
-                      "Asia/Bangkok",
                       "Jakarta",
                       "Asia/Jakarta",
                       "Krasnoyarsk",
@@ -47985,11 +54990,9 @@
                       "Osaka",
                       "Asia/Tokyo",
                       "Sapporo",
-                      "Asia/Tokyo",
                       "Seoul",
                       "Asia/Seoul",
                       "Tokyo",
-                      "Asia/Tokyo",
                       "Yakutsk",
                       "Asia/Yakutsk",
                       "Adelaide",
@@ -48029,7 +55032,6 @@
                       "Marshall Is.",
                       "Pacific/Majuro",
                       "Wellington",
-                      "Pacific/Auckland",
                       "Chatham Is.",
                       "Pacific/Chatham",
                       "Nuku'alofa",
@@ -48037,7 +55039,23 @@
                       "Samoa",
                       "Pacific/Apia",
                       "Tokelau Is.",
-                      "Pacific/Fakaofo"
+                      "Pacific/Fakaofo",
+                      "America/Adak",
+                      "America/Atka",
+                      "US/Aleutian",
+                      "America/Vancouver",
+                      "Canada/Pacific",
+                      "America/Miquelon",
+                      "Australia/Eucla",
+                      "Australia/LHI",
+                      "Australia/Lord_Howe",
+                      "Chile/EasterIsland",
+                      "Pacific/Easter",
+                      "Pacific/Gambier",
+                      "Pacific/Pitcairn",
+                      "Pacific/Marquesas",
+                      "Pacific/Kiritimati",
+                      "Pacific/Norfolk"
                     ],
                     "nullable": true
                   },
@@ -48239,8 +55257,16 @@
                         "is_not",
                         "contains",
                         "does_not_contain",
+                        "contains_key",
+                        "does_not_contain_key",
+                        "starts_with",
+                        "does_not_start_with",
+                        "matches",
+                        "does_not_match",
                         "is_one_of",
-                        "is_not_one_of"
+                        "is_not_one_of",
+                        "is_set",
+                        "is_not_set"
                       ]
                     },
                     "value": {
@@ -48378,7 +55404,6 @@
                         "Guadalajara",
                         "America/Mexico_City",
                         "Mexico City",
-                        "America/Mexico_City",
                         "Monterrey",
                         "America/Monterrey",
                         "Saskatchewan",
@@ -48392,7 +55417,6 @@
                         "Lima",
                         "America/Lima",
                         "Quito",
-                        "America/Lima",
                         "Atlantic Time (Canada)",
                         "America/Halifax",
                         "Caracas",
@@ -48428,7 +55452,6 @@
                         "Lisbon",
                         "Europe/Lisbon",
                         "London",
-                        "Europe/London",
                         "Monrovia",
                         "Africa/Monrovia",
                         "UTC",
@@ -48478,7 +55501,6 @@
                         "Zagreb",
                         "Europe/Zagreb",
                         "Zurich",
-                        "Europe/Zurich",
                         "Athens",
                         "Europe/Athens",
                         "Bucharest",
@@ -48520,7 +55542,6 @@
                         "Riyadh",
                         "Asia/Riyadh",
                         "St. Petersburg",
-                        "Europe/Moscow",
                         "Volgograd",
                         "Europe/Volgograd",
                         "Tehran",
@@ -48530,7 +55551,6 @@
                         "Baku",
                         "Asia/Baku",
                         "Muscat",
-                        "Asia/Muscat",
                         "Samara",
                         "Europe/Samara",
                         "Tbilisi",
@@ -48542,23 +55562,18 @@
                         "Almaty",
                         "Asia/Almaty",
                         "Astana",
-                        "Asia/Almaty",
                         "Ekaterinburg",
                         "Asia/Yekaterinburg",
                         "Islamabad",
                         "Asia/Karachi",
                         "Karachi",
-                        "Asia/Karachi",
                         "Tashkent",
                         "Asia/Tashkent",
                         "Chennai",
                         "Asia/Kolkata",
                         "Kolkata",
-                        "Asia/Kolkata",
                         "Mumbai",
-                        "Asia/Kolkata",
                         "New Delhi",
-                        "Asia/Kolkata",
                         "Sri Jayawardenepura",
                         "Asia/Colombo",
                         "Kathmandu",
@@ -48572,7 +55587,6 @@
                         "Bangkok",
                         "Asia/Bangkok",
                         "Hanoi",
-                        "Asia/Bangkok",
                         "Jakarta",
                         "Asia/Jakarta",
                         "Krasnoyarsk",
@@ -48600,11 +55614,9 @@
                         "Osaka",
                         "Asia/Tokyo",
                         "Sapporo",
-                        "Asia/Tokyo",
                         "Seoul",
                         "Asia/Seoul",
                         "Tokyo",
-                        "Asia/Tokyo",
                         "Yakutsk",
                         "Asia/Yakutsk",
                         "Adelaide",
@@ -48644,7 +55656,6 @@
                         "Marshall Is.",
                         "Pacific/Majuro",
                         "Wellington",
-                        "Pacific/Auckland",
                         "Chatham Is.",
                         "Pacific/Chatham",
                         "Nuku'alofa",
@@ -48652,7 +55663,23 @@
                         "Samoa",
                         "Pacific/Apia",
                         "Tokelau Is.",
-                        "Pacific/Fakaofo"
+                        "Pacific/Fakaofo",
+                        "America/Adak",
+                        "America/Atka",
+                        "US/Aleutian",
+                        "America/Vancouver",
+                        "Canada/Pacific",
+                        "America/Miquelon",
+                        "Australia/Eucla",
+                        "Australia/LHI",
+                        "Australia/Lord_Howe",
+                        "Chile/EasterIsland",
+                        "Pacific/Easter",
+                        "Pacific/Gambier",
+                        "Pacific/Pitcairn",
+                        "Pacific/Marquesas",
+                        "Pacific/Kiritimati",
+                        "Pacific/Norfolk"
                       ]
                     },
                     "time_blocks": {
@@ -48663,31 +55690,31 @@
                         "properties": {
                           "monday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "tuesday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "wednesday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "thursday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "friday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "saturday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "sunday": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "start_time": {
                             "type": "string",
@@ -48699,7 +55726,7 @@
                           },
                           "all_day": {
                             "type": "boolean",
-                            "nullable": true
+                            "default": false
                           },
                           "position": {
                             "type": "integer",
@@ -48713,6 +55740,62 @@
                     "rule_type",
                     "time_zone",
                     "time_blocks"
+                  ]
+                },
+                {
+                  "properties": {
+                    "rule_type": {
+                      "type": "string",
+                      "description": "The type of the escalation path rule",
+                      "enum": [
+                        "source"
+                      ]
+                    },
+                    "operator": {
+                      "type": "string",
+                      "description": "How the alert source should be matched",
+                      "enum": [
+                        "is",
+                        "is_not",
+                        "is_one_of",
+                        "is_not_one_of"
+                      ]
+                    },
+                    "values": {
+                      "type": "array",
+                      "description": "Alert source values to match against (e.g., manual, datadog)",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "rule_type",
+                    "operator",
+                    "values"
+                  ]
+                },
+                {
+                  "properties": {
+                    "rule_type": {
+                      "type": "string",
+                      "description": "The type of the escalation path rule",
+                      "enum": [
+                        "related_incidents"
+                      ]
+                    },
+                    "operator": {
+                      "type": "string",
+                      "description": "Whether the alert must (or must not) have related incidents",
+                      "enum": [
+                        "is_set",
+                        "is_not_set"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "rule_type",
+                    "operator"
                   ]
                 }
               ],
@@ -48752,7 +55835,6 @@
               "Guadalajara",
               "America/Mexico_City",
               "Mexico City",
-              "America/Mexico_City",
               "Monterrey",
               "America/Monterrey",
               "Saskatchewan",
@@ -48766,7 +55848,6 @@
               "Lima",
               "America/Lima",
               "Quito",
-              "America/Lima",
               "Atlantic Time (Canada)",
               "America/Halifax",
               "Caracas",
@@ -48802,7 +55883,6 @@
               "Lisbon",
               "Europe/Lisbon",
               "London",
-              "Europe/London",
               "Monrovia",
               "Africa/Monrovia",
               "UTC",
@@ -48852,7 +55932,6 @@
               "Zagreb",
               "Europe/Zagreb",
               "Zurich",
-              "Europe/Zurich",
               "Athens",
               "Europe/Athens",
               "Bucharest",
@@ -48894,7 +55973,6 @@
               "Riyadh",
               "Asia/Riyadh",
               "St. Petersburg",
-              "Europe/Moscow",
               "Volgograd",
               "Europe/Volgograd",
               "Tehran",
@@ -48904,7 +55982,6 @@
               "Baku",
               "Asia/Baku",
               "Muscat",
-              "Asia/Muscat",
               "Samara",
               "Europe/Samara",
               "Tbilisi",
@@ -48916,23 +55993,18 @@
               "Almaty",
               "Asia/Almaty",
               "Astana",
-              "Asia/Almaty",
               "Ekaterinburg",
               "Asia/Yekaterinburg",
               "Islamabad",
               "Asia/Karachi",
               "Karachi",
-              "Asia/Karachi",
               "Tashkent",
               "Asia/Tashkent",
               "Chennai",
               "Asia/Kolkata",
               "Kolkata",
-              "Asia/Kolkata",
               "Mumbai",
-              "Asia/Kolkata",
               "New Delhi",
-              "Asia/Kolkata",
               "Sri Jayawardenepura",
               "Asia/Colombo",
               "Kathmandu",
@@ -48946,7 +56018,6 @@
               "Bangkok",
               "Asia/Bangkok",
               "Hanoi",
-              "Asia/Bangkok",
               "Jakarta",
               "Asia/Jakarta",
               "Krasnoyarsk",
@@ -48974,11 +56045,9 @@
               "Osaka",
               "Asia/Tokyo",
               "Sapporo",
-              "Asia/Tokyo",
               "Seoul",
               "Asia/Seoul",
               "Tokyo",
-              "Asia/Tokyo",
               "Yakutsk",
               "Asia/Yakutsk",
               "Adelaide",
@@ -49018,7 +56087,6 @@
               "Marshall Is.",
               "Pacific/Majuro",
               "Wellington",
-              "Pacific/Auckland",
               "Chatham Is.",
               "Pacific/Chatham",
               "Nuku'alofa",
@@ -49026,7 +56094,23 @@
               "Samoa",
               "Pacific/Apia",
               "Tokelau Is.",
-              "Pacific/Fakaofo"
+              "Pacific/Fakaofo",
+              "America/Adak",
+              "America/Atka",
+              "US/Aleutian",
+              "America/Vancouver",
+              "Canada/Pacific",
+              "America/Miquelon",
+              "Australia/Eucla",
+              "Australia/LHI",
+              "Australia/Lord_Howe",
+              "Chile/EasterIsland",
+              "Pacific/Easter",
+              "Pacific/Gambier",
+              "Pacific/Pitcairn",
+              "Pacific/Marquesas",
+              "Pacific/Kiritimati",
+              "Pacific/Norfolk"
             ],
             "nullable": true
           },
@@ -49110,6 +56194,12 @@
               "id",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -49158,6 +56248,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -49222,7 +56318,7 @@
                       "properties": {
                         "id": {
                           "type": "string",
-                          "description": "The ID of notification target. If Slack channel, then id of the slack channel (eg. C06Q2JK7RQW)"
+                          "description": "The ID of notification target. If Slack channel, then id of the slack channel (eg. C06Q2JK7RQW). If Microsoft Teams channel, then the Rootly channel UUID."
                         },
                         "type": {
                           "type": "string",
@@ -49232,6 +56328,7 @@
                             "user",
                             "schedule",
                             "slack_channel",
+                            "microsoft_teams_channel",
                             "service"
                           ]
                         },
@@ -49337,6 +56434,7 @@
                             "user",
                             "schedule",
                             "slack_channel",
+                            "microsoft_teams_channel",
                             "service"
                           ]
                         },
@@ -49438,6 +56536,7 @@
                     "user",
                     "schedule",
                     "slack_channel",
+                    "microsoft_teams_channel",
                     "service"
                   ]
                 },
@@ -49496,6 +56595,12 @@
               "id",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -49544,6 +56649,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -49721,6 +56832,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -49776,6 +56893,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -49996,6 +57119,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -50051,6 +57180,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -50274,6 +57409,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -50329,6 +57470,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -50376,7 +57523,9 @@
                       "slack_incident_resolution_form",
                       "slack_incident_cancellation_form",
                       "slack_scheduled_incident_form",
-                      "slack_update_scheduled_incident_form"
+                      "slack_update_scheduled_incident_form",
+                      "web_action_item_form",
+                      "slack_action_item_form"
                     ]
                   },
                   "position": {
@@ -50441,7 +57590,9 @@
                       "slack_incident_resolution_form",
                       "slack_incident_cancellation_form",
                       "slack_scheduled_incident_form",
-                      "slack_update_scheduled_incident_form"
+                      "slack_update_scheduled_incident_form",
+                      "web_action_item_form",
+                      "slack_action_item_form"
                     ]
                   },
                   "position": {
@@ -50489,7 +57640,9 @@
               "slack_incident_resolution_form",
               "slack_incident_cancellation_form",
               "slack_scheduled_incident_form",
-              "slack_update_scheduled_incident_form"
+              "slack_update_scheduled_incident_form",
+              "web_action_item_form",
+              "slack_action_item_form"
             ]
           },
           "position": {
@@ -50533,6 +57686,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -50588,6 +57747,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -50627,6 +57792,7 @@
                       "causes",
                       "functionalities",
                       "teams",
+                      "status",
                       "visibility",
                       "mark_as_test",
                       "mark_as_backfilled",
@@ -50775,6 +57941,7 @@
                       "causes",
                       "functionalities",
                       "teams",
+                      "status",
                       "visibility",
                       "mark_as_test",
                       "mark_as_backfilled",
@@ -50907,6 +58074,7 @@
               "causes",
               "functionalities",
               "teams",
+              "status",
               "visibility",
               "mark_as_test",
               "mark_as_backfilled",
@@ -51061,6 +58229,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -51116,6 +58290,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -51288,6 +58468,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -51343,6 +58529,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -51372,10 +58564,10 @@
                   },
                   "forms": {
                     "type": "array",
-                    "description": "The forms included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`",
+                    "description": "The forms included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`, `google_chat_new_incident_form`, `google_chat_update_incident_form`",
                     "items": {
                       "type": "string",
-                      "description": "The form included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`"
+                      "description": "The form included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`, `google_chat_new_incident_form`, `google_chat_update_incident_form`"
                     }
                   }
                 },
@@ -51417,10 +58609,10 @@
                   },
                   "forms": {
                     "type": "array",
-                    "description": "The forms included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`",
+                    "description": "The forms included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`, `google_chat_new_incident_form`, `google_chat_update_incident_form`",
                     "items": {
                       "type": "string",
-                      "description": "The form included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`"
+                      "description": "The form included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`, `google_chat_new_incident_form`, `google_chat_update_incident_form`"
                     }
                   }
                 },
@@ -51454,10 +58646,10 @@
           },
           "forms": {
             "type": "array",
-            "description": "The forms included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`",
+            "description": "The forms included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`, `google_chat_new_incident_form`, `google_chat_update_incident_form`",
             "items": {
               "type": "string",
-              "description": "The form included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`"
+              "description": "The form included in the form set. Add custom forms using the custom form's `slug` field. Or choose a built-in form: `web_new_incident_form`, `web_update_incident_form`, `web_incident_post_mortem_form`, `web_incident_mitigation_form`, `web_incident_resolution_form`, `web_incident_cancellation_form`, `web_scheduled_incident_form`, `web_update_scheduled_incident_form`, `slack_new_incident_form`, `slack_update_incident_form`, `slack_update_incident_status_form`, `slack_incident_mitigation_form`, `slack_incident_resolution_form`, `slack_incident_cancellation_form`, `slack_scheduled_incident_form`, `slack_update_scheduled_incident_form`, `google_chat_new_incident_form`, `google_chat_update_incident_form`"
             }
           },
           "created_at": {
@@ -51507,6 +58699,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -51562,6 +58760,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -51698,6 +58902,11 @@
                     "items": {
                       "type": "integer"
                     },
+                    "nullable": true
+                  },
+                  "escalation_policy_id": {
+                    "type": "string",
+                    "description": "The escalation policy id of the functionality",
                     "nullable": true
                   },
                   "slack_channels": {
@@ -51897,6 +59106,11 @@
                     },
                     "nullable": true
                   },
+                  "escalation_policy_id": {
+                    "type": "string",
+                    "description": "The escalation policy id of the functionality",
+                    "nullable": true
+                  },
                   "slack_channels": {
                     "type": "array",
                     "description": "Slack Channels associated with this functionality",
@@ -51987,6 +59201,19 @@
           "slug": {
             "type": "string",
             "description": "The slug of the functionality"
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "How this functionality is managed (provenance): web, api, terraform, etc. Read-only."
           },
           "description": {
             "type": "string",
@@ -52083,6 +59310,11 @@
             },
             "nullable": true
           },
+          "escalation_policy_id": {
+            "type": "string",
+            "description": "The escalation policy id of the functionality",
+            "nullable": true
+          },
           "slack_channels": {
             "type": "array",
             "description": "Slack Channels associated with this functionality",
@@ -52165,18 +59397,6 @@
           "updated_at"
         ]
       },
-      "incidents_chart_response": {
-        "type": "object",
-        "required": [
-          "data"
-        ]
-      },
-      "uptime_chart_response": {
-        "type": "object",
-        "required": [
-          "data"
-        ]
-      },
       "functionality_response": {
         "type": "object",
         "properties": {
@@ -52207,6 +59427,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -52262,6 +59488,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -52269,6 +59501,258 @@
           "links",
           "meta"
         ]
+      },
+      "bulk_upsert_functionalities": {
+        "type": "object",
+        "required": [
+          "entities"
+        ],
+        "properties": {
+          "entities": {
+            "type": "array",
+            "description": "Functionalities to upsert, matched by external_id. Max 100 per request; external_ids unique within a batch. Only attributes present are written (managed-fields semantics).",
+            "items": {
+              "type": "object",
+              "required": [
+                "external_id"
+              ],
+              "properties": {
+                "external_id": {
+                  "type": "string",
+                  "description": "External identifier used as the upsert key. Unique per team."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Required for new records. Optional for updates."
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "public_description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "color": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "position": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "show_uptime": {
+                  "type": "boolean",
+                  "nullable": true
+                },
+                "show_uptime_last_days": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "notify_emails": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true
+                },
+                "pagerduty_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opsgenie_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opsgenie_team_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "backstage_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "cortex_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opslevel_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "service_now_ci_sys_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "fields": {
+                  "type": "array",
+                  "description": "Catalog property values (merge semantics: only mentioned fields written).",
+                  "items": {
+                    "type": "object",
+                    "description": "Each field entry must include either catalog_field_id or catalog_property_id.",
+                    "properties": {
+                      "catalog_field_id": {
+                        "type": "string",
+                        "description": "UUID, slug, or external_id of the catalog field (required if catalog_property_id is absent)"
+                      },
+                      "catalog_property_id": {
+                        "type": "string",
+                        "description": "Alias for catalog_field_id (required if catalog_field_id is absent)"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value for this field"
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_functionalities_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "functionalities"
+                  ]
+                },
+                "attributes": {
+                  "$ref": "#/components/schemas/functionality"
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_functionalities_error": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "index",
+                "external_id",
+                "errors"
+              ],
+              "properties": {
+                "index": {
+                  "type": "integer",
+                  "description": "Position of the failed record in the batch"
+                },
+                "external_id": {
+                  "type": "string"
+                },
+                "errors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_destroy_functionalities": {
+        "description": "Two mutually exclusive modes. Pass exactly one of: external_ids (delete specific records) or managed_by (prune all managed records not in keep set).",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "external_ids"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "external_ids": {
+                "type": "array",
+                "description": "Array of external_ids to delete. Max 100 per request.",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "managed_by"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "managed_by": {
+                "type": "string",
+                "enum": [
+                  "api",
+                  "terraform",
+                  "pulumi",
+                  "backstage",
+                  "catalog_sync"
+                ],
+                "description": "Delete all records with this managed_by value (web/admin_web not allowed)."
+              },
+              "keep_external_ids": {
+                "type": "array",
+                "description": "Records with these external_ids are preserved.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "bulk_destroy_functionalities_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "deleted_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were successfully deleted"
+              },
+              "failed_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs whose deletion the record itself blocked (e.g. minimum-one guard, restrict associations). Records the caller is not authorized to destroy are NOT listed here."
+              },
+              "not_found_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were not found or not accessible to the caller (external_ids mode only)"
+              }
+            }
+          }
+        }
       },
       "add_action_item_task_params": {
         "type": "object",
@@ -52552,12 +60036,25 @@
             "required": [
               "title",
               "link"
-            ]
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              }
+            }
           },
           {
             "required": [
               "playbook_id"
-            ]
+            ],
+            "properties": {
+              "playbook_id": {
+                "type": "string"
+              }
+            }
           }
         ]
       },
@@ -52845,12 +60342,38 @@
           {
             "required": [
               "schedule"
-            ]
+            ],
+            "properties": {
+              "schedule": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "escalation_policy"
-            ]
+            ],
+            "properties": {
+              "escalation_policy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -53408,6 +60931,18 @@
           "mark_post_mortem_as_published": {
             "type": "boolean",
             "default": true
+          },
+          "include_overview": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_timeline": {
+            "type": "boolean",
+            "default": true
+          },
+          "create_as_live_doc": {
+            "type": "boolean",
+            "default": false
           }
         },
         "required": [
@@ -53640,6 +61175,11 @@
           "parent_issue_number": {
             "type": "string",
             "description": "The parent issue number for sub-issue linking",
+            "nullable": true
+          },
+          "custom_fields_mapping": {
+            "type": "string",
+            "description": "Custom field mappings. Can contain liquid markup and need to be valid JSON",
             "nullable": true
           }
         },
@@ -53921,6 +61461,14 @@
           "template_id": {
             "type": "string",
             "description": "The Google Doc file ID to use as a template."
+          },
+          "include_overview": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_timeline": {
+            "type": "boolean",
+            "default": true
           }
         },
         "required": [
@@ -54193,6 +61741,14 @@
           "permissions": {
             "type": "string",
             "description": "Page permissions JSON"
+          },
+          "include_overview": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_timeline": {
+            "type": "boolean",
+            "default": true
           }
         },
         "required": [
@@ -54756,6 +62312,40 @@
           "subtask_issue_type"
         ]
       },
+      "attach_retrospective_pdf_to_jira_issue_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "attach_retrospective_pdf_to_jira_issue"
+            ]
+          },
+          "integration": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "description": "Specify integration id if you have more than one Jira instance"
+          },
+          "issue_id": {
+            "type": "string",
+            "description": "The issue id"
+          },
+          "filename": {
+            "type": "string",
+            "description": "The attachment filename"
+          }
+        },
+        "required": [
+          "issue_id"
+        ]
+      },
       "create_linear_issue_task_params": {
         "type": "object",
         "properties": {
@@ -54838,6 +62428,11 @@
           "assign_user_email": {
             "type": "string",
             "description": "The assigned user's email"
+          },
+          "custom_fields_mapping": {
+            "type": "string",
+            "description": "Custom field mappings. Can contain liquid markup and need to be valid JSON",
+            "nullable": true
           }
         },
         "required": [
@@ -54908,6 +62503,11 @@
           "assign_user_email": {
             "type": "string",
             "description": "The assigned user's email"
+          },
+          "custom_fields_mapping": {
+            "type": "string",
+            "description": "Custom field mappings. Can contain liquid markup and need to be valid JSON",
+            "nullable": true
           }
         },
         "required": [
@@ -55033,7 +62633,7 @@
           }
         },
         "required": [
-          "workspace",
+          "team",
           "title"
         ]
       },
@@ -55135,12 +62735,25 @@
             "required": [
               "title",
               "link"
-            ]
+            ],
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              }
+            }
           },
           {
             "required": [
               "playbook_id"
-            ]
+            ],
+            "properties": {
+              "playbook_id": {
+                "type": "string"
+              }
+            }
           }
         ]
       },
@@ -55177,6 +62790,246 @@
           "chat",
           "title",
           "link"
+        ]
+      },
+      "create_google_chat_space_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "create_google_chat_space"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "audience": {
+            "type": "string",
+            "description": "Target audience resource name (e.g. audiences/default). Leave blank for private space."
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "send_google_chat_message_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "send_google_chat_message"
+            ]
+          },
+          "spaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "text": {
+            "type": "string"
+          },
+          "thread_key": {
+            "type": "string",
+            "description": "Thread key to reply within a thread. Messages with the same thread key are grouped together",
+            "nullable": true
+          }
+        },
+        "required": [
+          "spaces",
+          "text"
+        ]
+      },
+      "send_google_chat_attachments_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "send_google_chat_attachments"
+            ]
+          },
+          "spaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "attachments": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "spaces",
+          "attachments"
+        ]
+      },
+      "invite_to_google_chat_space_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "invite_to_google_chat_space"
+            ]
+          },
+          "space": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "emails": {
+            "type": "string",
+            "description": "Comma separated list of emails to invite"
+          }
+        },
+        "required": [
+          "space",
+          "emails"
+        ]
+      },
+      "archive_google_chat_spaces_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "archive_google_chat_spaces"
+            ]
+          },
+          "spaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "spaces"
+        ]
+      },
+      "rename_google_chat_space_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "rename_google_chat_space"
+            ]
+          },
+          "space": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "space",
+          "title"
+        ]
+      },
+      "update_google_chat_space_description_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "update_google_chat_space_description"
+            ]
+          },
+          "space": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "description": {
+            "type": "string",
+            "description": "The space description. Supports liquid markup"
+          }
+        },
+        "required": [
+          "space",
+          "description"
+        ]
+      },
+      "change_google_chat_space_privacy_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "change_google_chat_space_privacy"
+            ]
+          },
+          "space": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "audience": {
+            "type": "string",
+            "description": "Target audience resource name (e.g. audiences/default). Leave blank to make private.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "space"
         ]
       },
       "archive_microsoft_teams_channels_task_params": {
@@ -55385,7 +63238,23 @@
           {
             "required": [
               "channels"
-            ]
+            ],
+            "properties": {
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -55431,6 +63300,20 @@
               "send_microsoft_teams_blocks"
             ]
           },
+          "channels": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "attachments": {
             "type": "string",
             "description": "Support liquid markup. Needs to be a valid JSON string after liquid is parsed"
@@ -55443,7 +63326,23 @@
           {
             "required": [
               "channels"
-            ]
+            ],
+            "properties": {
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -55526,6 +63425,18 @@
               "update_confluence_page"
             ]
           },
+          "integration": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "description": "Specify integration id if you have more than one Confluence instance"
+          },
           "file_id": {
             "type": "string",
             "description": "The Confluence page ID"
@@ -55553,6 +63464,14 @@
               }
             },
             "description": "The Confluence template to use"
+          },
+          "include_overview": {
+            "type": "boolean",
+            "default": true
+          },
+          "include_timeline": {
+            "type": "boolean",
+            "default": true
           }
         },
         "required": [
@@ -55814,12 +63733,38 @@
           {
             "required": [
               "project"
-            ]
+            ],
+            "properties": {
+              "project": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "workflow_state"
-            ]
+            ],
+            "properties": {
+              "workflow_state": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -56275,6 +64220,10 @@
             "description": "The video layout for the bot's recording (e.g. speaker_view, gallery_view, gallery_view_v2, audio_only)",
             "nullable": true
           },
+          "enable_zoom_bot_auto_join": {
+            "type": "boolean",
+            "description": "Allow the Rootly bot to start recording without waiting for host approval"
+          },
           "post_to_incident_timeline": {
             "type": "boolean"
           },
@@ -56357,12 +64306,28 @@
           {
             "required": [
               "service_ids"
-            ]
+            ],
+            "properties": {
+              "service_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           },
           {
             "required": [
               "github_repository_names"
-            ]
+            ],
+            "properties": {
+              "github_repository_names": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           }
         ]
       },
@@ -56426,12 +64391,28 @@
           {
             "required": [
               "service_ids"
-            ]
+            ],
+            "properties": {
+              "service_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           },
           {
             "required": [
               "gitlab_repository_names"
-            ]
+            ],
+            "properties": {
+              "gitlab_repository_names": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
           }
         ]
       },
@@ -56667,6 +64648,18 @@
                 }
               }
             }
+          },
+          "retry_count": {
+            "type": "integer",
+            "description": "Number of times to retry on HTTP 429 responses (0-4). 0 disables retry.",
+            "default": 0,
+            "example": 3
+          },
+          "retry_wait_time": {
+            "type": "integer",
+            "description": "Seconds to wait before each retry (1-15). Retry-After header is honored when present and <= 90s, taking the larger of retry_wait_time and the header value.",
+            "default": 1,
+            "example": 2
           }
         },
         "required": [
@@ -56797,6 +64790,98 @@
           "channels"
         ]
       },
+      "invite_to_microsoft_teams_channel_rootly_task_params": {
+        "type": "object",
+        "properties": {
+          "task_type": {
+            "type": "string",
+            "enum": [
+              "invite_to_microsoft_teams_channel_rootly"
+            ]
+          },
+          "team": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "channel": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "escalation_policy_target": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "service_target": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "user_target": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "group_target": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "schedule_target": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "team",
+          "channel"
+        ]
+      },
       "invite_to_slack_channel_pagerduty_task_params": {
         "type": "object",
         "properties": {
@@ -56861,12 +64946,38 @@
           {
             "required": [
               "escalation_policy"
-            ]
+            ],
+            "properties": {
+              "escalation_policy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "schedule"
-            ]
+            ],
+            "properties": {
+              "schedule": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -56930,17 +65041,54 @@
           {
             "required": [
               "slack_users"
-            ]
+            ],
+            "properties": {
+              "slack_users": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "slack_user_groups"
-            ]
+            ],
+            "properties": {
+              "slack_user_groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "slack_emails"
-            ]
+            ],
+            "properties": {
+              "slack_emails": {
+                "type": "string"
+              }
+            }
           }
         ]
       },
@@ -57223,7 +65371,6 @@
               "P3",
               "P1",
               "P2",
-              "P3",
               "P4",
               "P5",
               "auto"
@@ -57296,7 +65443,6 @@
               "P3",
               "P1",
               "P2",
-              "P3",
               "P4",
               "P5",
               "auto"
@@ -57481,6 +65627,11 @@
           },
           "escalation_note": {
             "type": "string"
+          },
+          "create_new_alert": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, always create a new alert instead of re-paging the alert that triggered the workflow"
           }
         },
         "required": [
@@ -57614,12 +65765,44 @@
           {
             "required": [
               "users"
-            ]
+            ],
+            "properties": {
+              "users": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "escalation_policies"
-            ]
+            ],
+            "properties": {
+              "escalation_policies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -57829,7 +66012,7 @@
           "task_type": {
             "type": "string",
             "enum": [
-              "rename_slack_channel"
+              "change_slack_channel_privacy"
             ]
           },
           "channel": {
@@ -57852,7 +66035,7 @@
           }
         },
         "required": [
-          "title",
+          "channel",
           "privacy"
         ]
       },
@@ -58183,17 +66366,65 @@
           {
             "required": [
               "channels"
-            ]
+            ],
+            "properties": {
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "slack_users"
-            ]
+            ],
+            "properties": {
+              "slack_users": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "slack_user_groups"
-            ]
+            ],
+            "properties": {
+              "slack_user_groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -58631,6 +66862,15 @@
               }
             }
           },
+          "labels_mode": {
+            "type": "string",
+            "description": "How to apply labels. 'replace' (default) overwrites all existing labels. 'append' adds to existing labels without removing them.",
+            "enum": [
+              "replace",
+              "append"
+            ],
+            "default": "replace"
+          },
           "issue_type": {
             "type": "object",
             "description": "The issue type",
@@ -58653,6 +66893,11 @@
                 "type": "string"
               }
             }
+          },
+          "custom_fields_mapping": {
+            "type": "string",
+            "description": "Custom field mappings. Can contain liquid markup and need to be valid JSON",
+            "nullable": true
           }
         },
         "required": [
@@ -58880,6 +67125,18 @@
               "update_jira_issue"
             ]
           },
+          "integration": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "description": "Specify integration id if you have more than one Jira instance"
+          },
           "issue_id": {
             "type": "string",
             "description": "The issue id"
@@ -59027,6 +67284,11 @@
           "assign_user_email": {
             "type": "string",
             "description": "The assigned user's email"
+          },
+          "custom_fields_mapping": {
+            "type": "string",
+            "description": "Custom field mappings. Can contain liquid markup and need to be valid JSON",
+            "nullable": true
           }
         },
         "required": [
@@ -59708,17 +67970,65 @@
           {
             "required": [
               "channels"
-            ]
+            ],
+            "properties": {
+              "channels": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "slack_users"
-            ]
+            ],
+            "properties": {
+              "slack_users": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           {
             "required": [
               "slack_user_groups"
-            ]
+            ],
+            "properties": {
+              "slack_user_groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           }
         ]
       },
@@ -60118,6 +68428,9 @@
                         "$ref": "#/components/schemas/create_jira_subtask_task_params"
                       },
                       {
+                        "$ref": "#/components/schemas/attach_retrospective_pdf_to_jira_issue_task_params"
+                      },
+                      {
                         "$ref": "#/components/schemas/create_linear_issue_task_params"
                       },
                       {
@@ -60140,6 +68453,30 @@
                       },
                       {
                         "$ref": "#/components/schemas/add_microsoft_teams_chat_tab_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/create_google_chat_space_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/send_google_chat_message_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/send_google_chat_attachments_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/invite_to_google_chat_space_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/archive_google_chat_spaces_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/rename_google_chat_space_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/update_google_chat_space_description_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/change_google_chat_space_privacy_task_params"
                       },
                       {
                         "$ref": "#/components/schemas/archive_microsoft_teams_channels_task_params"
@@ -60230,6 +68567,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/invite_to_slack_channel_rootly_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/invite_to_microsoft_teams_channel_rootly_task_params"
                       },
                       {
                         "$ref": "#/components/schemas/invite_to_slack_channel_pagerduty_task_params"
@@ -60582,6 +68922,9 @@
                         "$ref": "#/components/schemas/create_jira_subtask_task_params"
                       },
                       {
+                        "$ref": "#/components/schemas/attach_retrospective_pdf_to_jira_issue_task_params"
+                      },
+                      {
                         "$ref": "#/components/schemas/create_linear_issue_task_params"
                       },
                       {
@@ -60604,6 +68947,30 @@
                       },
                       {
                         "$ref": "#/components/schemas/add_microsoft_teams_chat_tab_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/create_google_chat_space_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/send_google_chat_message_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/send_google_chat_attachments_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/invite_to_google_chat_space_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/archive_google_chat_spaces_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/rename_google_chat_space_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/update_google_chat_space_description_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/change_google_chat_space_privacy_task_params"
                       },
                       {
                         "$ref": "#/components/schemas/archive_microsoft_teams_channels_task_params"
@@ -60694,6 +69061,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/invite_to_slack_channel_rootly_task_params"
+                      },
+                      {
+                        "$ref": "#/components/schemas/invite_to_microsoft_teams_channel_rootly_task_params"
                       },
                       {
                         "$ref": "#/components/schemas/invite_to_slack_channel_pagerduty_task_params"
@@ -61018,6 +69388,9 @@
                 "$ref": "#/components/schemas/create_jira_subtask_task_params"
               },
               {
+                "$ref": "#/components/schemas/attach_retrospective_pdf_to_jira_issue_task_params"
+              },
+              {
                 "$ref": "#/components/schemas/create_linear_issue_task_params"
               },
               {
@@ -61040,6 +69413,30 @@
               },
               {
                 "$ref": "#/components/schemas/add_microsoft_teams_chat_tab_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/create_google_chat_space_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/send_google_chat_message_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/send_google_chat_attachments_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/invite_to_google_chat_space_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/archive_google_chat_spaces_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/rename_google_chat_space_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/update_google_chat_space_description_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/change_google_chat_space_privacy_task_params"
               },
               {
                 "$ref": "#/components/schemas/archive_microsoft_teams_channels_task_params"
@@ -61130,6 +69527,9 @@
               },
               {
                 "$ref": "#/components/schemas/invite_to_slack_channel_rootly_task_params"
+              },
+              {
+                "$ref": "#/components/schemas/invite_to_microsoft_teams_channel_rootly_task_params"
               },
               {
                 "$ref": "#/components/schemas/invite_to_slack_channel_pagerduty_task_params"
@@ -61367,6 +69767,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -61422,6 +69828,462 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data",
+          "links",
+          "meta"
+        ]
+      },
+      "new_workflow_action_item_form_field_condition": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "workflow_action_item_form_field_conditions"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "form_field_id": {
+                    "type": "string",
+                    "description": "The custom field for this condition"
+                  },
+                  "action_item_condition": {
+                    "type": "string",
+                    "description": "The trigger condition",
+                    "enum": [
+                      "IS",
+                      "IS NOT",
+                      "ANY",
+                      "CONTAINS",
+                      "CONTAINS_ALL",
+                      "CONTAINS_NONE",
+                      "NONE",
+                      "SET",
+                      "UNSET"
+                    ],
+                    "default": "ANY"
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The value to associate with the custom field trigger"
+                    }
+                  },
+                  "selected_catalog_entity_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected catalog entities for select and multi_select kinds"
+                    }
+                  },
+                  "selected_functionality_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected functionalities for select and multi_select kinds"
+                    }
+                  },
+                  "selected_group_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected groups (teams) for select and multi_select kinds"
+                    }
+                  },
+                  "selected_option_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected option id for select and multi_select kinds"
+                    }
+                  },
+                  "selected_service_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected services for select and multi_select kinds"
+                    }
+                  },
+                  "selected_user_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "description": "The selected user id for select and multi_select kinds"
+                    }
+                  },
+                  "selected_cause_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected causes for select and multi_select kinds"
+                    }
+                  },
+                  "selected_environment_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected environments for select and multi_select kinds"
+                    }
+                  },
+                  "selected_incident_type_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected incident types for select and multi_select kinds"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "action_item_condition",
+                  "form_field_id"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "update_workflow_action_item_form_field_condition": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "workflow_action_item_form_field_conditions"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "action_item_condition": {
+                    "type": "string",
+                    "description": "The trigger condition",
+                    "enum": [
+                      "IS",
+                      "IS NOT",
+                      "ANY",
+                      "CONTAINS",
+                      "CONTAINS_ALL",
+                      "CONTAINS_NONE",
+                      "NONE",
+                      "SET",
+                      "UNSET"
+                    ],
+                    "default": "ANY"
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The value to associate with the custom field trigger"
+                    }
+                  },
+                  "selected_catalog_entity_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected catalog entities for select and multi_select kinds"
+                    }
+                  },
+                  "selected_functionality_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected functionalities for select and multi_select kinds"
+                    }
+                  },
+                  "selected_group_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected groups (teams) for select and multi_select kinds"
+                    }
+                  },
+                  "selected_option_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected option id for select and multi_select kinds"
+                    }
+                  },
+                  "selected_service_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected services for select and multi_select kinds"
+                    }
+                  },
+                  "selected_user_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer",
+                      "description": "The selected user id for select and multi_select kinds"
+                    }
+                  },
+                  "selected_cause_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected causes for select and multi_select kinds"
+                    }
+                  },
+                  "selected_environment_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected environments for select and multi_select kinds"
+                    }
+                  },
+                  "selected_incident_type_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The selected incident types for select and multi_select kinds"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "workflow_action_item_form_field_condition": {
+        "type": "object",
+        "properties": {
+          "workflow_id": {
+            "type": "string",
+            "description": "The workflow for this condition"
+          },
+          "form_field_id": {
+            "type": "string",
+            "description": "The custom field for this condition"
+          },
+          "action_item_condition": {
+            "type": "string",
+            "description": "The trigger condition",
+            "enum": [
+              "IS",
+              "IS NOT",
+              "ANY",
+              "CONTAINS",
+              "CONTAINS_ALL",
+              "CONTAINS_NONE",
+              "NONE",
+              "SET",
+              "UNSET"
+            ],
+            "default": "ANY"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The value to associate with the custom field trigger"
+            }
+          },
+          "selected_catalog_entity_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected catalog entities for select and multi_select kinds"
+            }
+          },
+          "selected_functionality_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected functionalities for select and multi_select kinds"
+            }
+          },
+          "selected_group_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected groups (teams) for select and multi_select kinds"
+            }
+          },
+          "selected_option_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected option id for select and multi_select kinds"
+            }
+          },
+          "selected_service_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected services for select and multi_select kinds"
+            }
+          },
+          "selected_user_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "description": "The selected user id for select and multi_select kinds"
+            }
+          },
+          "selected_cause_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected causes for select and multi_select kinds"
+            }
+          },
+          "selected_environment_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected environments for select and multi_select kinds"
+            }
+          },
+          "selected_incident_type_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "The selected incident types for select and multi_select kinds"
+            }
+          }
+        },
+        "required": [
+          "workflow_id",
+          "form_field_id",
+          "action_item_condition",
+          "selected_catalog_entity_ids",
+          "selected_option_ids",
+          "selected_user_ids"
+        ]
+      },
+      "workflow_action_item_form_field_condition_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique ID of the workflow_action_item_form_field_condition"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "workflow_action_item_form_field_conditions"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/workflow_action_item_form_field_condition"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "attributes"
+            ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "workflow_action_item_form_field_condition_list": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique ID of the workflow_action_item_form_field_condition"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "workflow_action_item_form_field_conditions"
+                  ]
+                },
+                "attributes": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/workflow_action_item_form_field_condition"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "type",
+                "attributes"
+              ]
+            }
+          },
+          "links": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/links"
+              }
+            ]
+          },
+          "meta": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/meta"
+              }
+            ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -61639,6 +70501,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -61694,6 +70562,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62081,6 +70955,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62136,6 +71016,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62348,6 +71234,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62403,6 +71295,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62695,6 +71593,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62750,6 +71654,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -62960,7 +71870,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "description": "Actions that trigger the workflow. One of custom_fields.<slug>.updated, incident_in_triage, incident_created, incident_started, incident_updated, title_updated, summary_updated, status_updated, severity_updated, environments_added, environments_removed, environments_updated, incident_types_added, incident_types_removed, incident_types_updated, services_added, services_removed, services_updated, visibility_updated, functionalities_added, functionalities_removed, functionalities_updated, teams_added, teams_removed, teams_updated, causes_added, causes_removed, causes_updated, timeline_updated, status_page_timeline_updated, role_assignments_updated, role_assignments_added, role_assignments_removed, slack_command, slack_channel_created, slack_channel_converted, microsoft_teams_channel_created, microsoft_teams_chat_created, subscribers_updated, subscribers_added, subscribers_removed, user_joined_slack_channel, user_left_slack_channel"
+              "description": "Actions that trigger the workflow. One of custom_fields.<slug>.updated, incident_in_triage, incident_created, incident_started, incident_updated, title_updated, summary_updated, status_updated, severity_updated, environments_added, environments_removed, environments_updated, incident_types_added, incident_types_removed, incident_types_updated, services_added, services_removed, services_updated, visibility_updated, functionalities_added, functionalities_removed, functionalities_updated, teams_added, teams_removed, teams_updated, causes_added, causes_removed, causes_updated, timeline_updated, status_page_timeline_updated, role_assignments_updated, role_assignments_added, role_assignments_removed, slack_command, slack_channel_created, slack_channel_converted, microsoft_teams_channel_created, microsoft_teams_chat_created, google_chat_space_created, subscribers_updated, subscribers_added, subscribers_removed, user_joined_slack_channel, user_left_slack_channel, meeting_summary_created"
             }
           },
           "incident_visibilities": {
@@ -63006,17 +71916,9 @@
             }
           },
           "incident_inactivity_duration": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "description": "ex. 10 min, 1h, 3 days, 2 weeks"
-              }
-            ]
+            "type": "string",
+            "description": "ex. 10 min, 1h, 3 days, 2 weeks",
+            "nullable": true
           },
           "incident_condition": {
             "type": "string",
@@ -63207,6 +72109,31 @@
             ],
             "default": "ANY"
           },
+          "incident_condition_label": {
+            "type": "string",
+            "enum": [
+              "IS",
+              "IS NOT",
+              "ANY",
+              "CONTAINS",
+              "CONTAINS_ALL",
+              "CONTAINS_NONE",
+              "NONE",
+              "SET",
+              "UNSET"
+            ],
+            "default": "ANY"
+          },
+          "incident_condition_label_use_regexp": {
+            "type": "boolean",
+            "default": false
+          },
+          "incident_labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "incident_post_mortem_condition_cause": {
             "type": "string",
             "enum": [
@@ -63224,115 +72151,59 @@
             "description": "[DEPRECATED] Use incident_condition_cause instead"
           },
           "incident_condition_summary": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_started_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_detected_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_acknowledged_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_mitigated_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_resolved_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_conditional_inactivity": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "IS"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "IS"
+            ],
+            "nullable": true
           }
         },
         "required": [
@@ -63398,17 +72269,9 @@
             }
           },
           "incident_inactivity_duration": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "description": "ex. 10 min, 1h, 3 days, 2 weeks"
-              }
-            ]
+            "type": "string",
+            "description": "ex. 10 min, 1h, 3 days, 2 weeks",
+            "nullable": true
           },
           "incident_condition": {
             "type": "string",
@@ -63599,6 +72462,31 @@
             ],
             "default": "ANY"
           },
+          "incident_condition_label": {
+            "type": "string",
+            "enum": [
+              "IS",
+              "IS NOT",
+              "ANY",
+              "CONTAINS",
+              "CONTAINS_ALL",
+              "CONTAINS_NONE",
+              "NONE",
+              "SET",
+              "UNSET"
+            ],
+            "default": "ANY"
+          },
+          "incident_condition_label_use_regexp": {
+            "type": "boolean",
+            "default": false
+          },
+          "incident_labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "incident_post_mortem_condition_cause": {
             "type": "string",
             "enum": [
@@ -63616,115 +72504,59 @@
             "description": "[DEPRECATED] Use incident_condition_cause instead"
           },
           "incident_condition_summary": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_started_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_detected_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_acknowledged_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_mitigated_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_resolved_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_conditional_inactivity": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "IS"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "IS"
+            ],
+            "nullable": true
           },
           "incident_post_mortem_condition": {
             "type": "string",
@@ -63823,17 +72655,9 @@
             }
           },
           "incident_inactivity_duration": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "description": "ex. 10 min, 1h, 3 days, 2 weeks"
-              }
-            ]
+            "type": "string",
+            "description": "ex. 10 min, 1h, 3 days, 2 weeks",
+            "nullable": true
           },
           "incident_condition": {
             "type": "string",
@@ -64009,116 +72833,85 @@
             ],
             "default": "ANY"
           },
+          "incident_condition_label": {
+            "type": "string",
+            "enum": [
+              "IS",
+              "IS NOT",
+              "ANY",
+              "CONTAINS",
+              "CONTAINS_ALL",
+              "CONTAINS_NONE",
+              "NONE",
+              "SET",
+              "UNSET"
+            ],
+            "default": "ANY"
+          },
+          "incident_condition_label_use_regexp": {
+            "type": "boolean",
+            "default": false
+          },
+          "incident_labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "incident_condition_summary": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_started_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_detected_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_acknowledged_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_mitigated_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_condition_resolved_at": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "SET",
-                  "UNSET"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "SET",
+              "UNSET"
+            ],
+            "nullable": true
           },
           "incident_conditional_inactivity": {
-            "anyOf": [
-              {
-                "enum": [
-                  null
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "IS"
-                ]
-              }
-            ]
+            "type": "string",
+            "enum": [
+              "IS"
+            ],
+            "nullable": true
           },
           "incident_action_item_condition": {
             "type": "string",
@@ -64974,6 +73767,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -65029,6 +73828,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -65078,6 +73883,7 @@
                       "NL",
                       "NZ",
                       "SE",
+                      "CH",
                       "GB",
                       "US"
                     ]
@@ -65102,6 +73908,12 @@
                   "caller_greeting": {
                     "type": "string",
                     "description": "The caller greeting message of the live_call_router"
+                  },
+                  "unavailable_responder_message": {
+                    "type": "string",
+                    "nullable": true,
+                    "maxLength": 300,
+                    "description": "The message played to the caller when a responder doesn't answer and the call moves on to the next person in the escalation. Leave blank to use the default message."
                   },
                   "waiting_music_url": {
                     "type": "string",
@@ -65131,6 +73943,20 @@
                   "should_auto_resolve_alert_on_call_end": {
                     "type": "boolean",
                     "description": "This overrides the delay (seconds) in escalation levels"
+                  },
+                  "notify_via_sms": {
+                    "type": "boolean",
+                    "description": "Whether responders are also notified via SMS when this router pages them"
+                  },
+                  "notify_via_push_notification": {
+                    "type": "boolean",
+                    "description": "Whether responders are also notified via push notification when this router pages them"
+                  },
+                  "informational_notification_message": {
+                    "type": "string",
+                    "nullable": true,
+                    "maxLength": 160,
+                    "description": "Optional message included in the SMS/push notification. Supports variables such as {{ alert.url }}, {{ alert.data.* }}, and {{ alert.alert_urgency.name }}."
                   },
                   "alert_urgency_id": {
                     "type": "string",
@@ -65264,6 +74090,7 @@
                       "NL",
                       "NZ",
                       "SE",
+                      "CH",
                       "GB",
                       "US"
                     ]
@@ -65284,6 +74111,12 @@
                   "caller_greeting": {
                     "type": "string",
                     "description": "The caller greeting message of the live_call_router"
+                  },
+                  "unavailable_responder_message": {
+                    "type": "string",
+                    "nullable": true,
+                    "maxLength": 300,
+                    "description": "The message played to the caller when a responder doesn't answer and the call moves on to the next person in the escalation. Leave blank to use the default message."
                   },
                   "waiting_music_url": {
                     "type": "string",
@@ -65313,6 +74146,20 @@
                   "should_auto_resolve_alert_on_call_end": {
                     "type": "boolean",
                     "description": "This overrides the delay (seconds) in escalation levels"
+                  },
+                  "notify_via_sms": {
+                    "type": "boolean",
+                    "description": "Whether responders are also notified via SMS when this router pages them"
+                  },
+                  "notify_via_push_notification": {
+                    "type": "boolean",
+                    "description": "Whether responders are also notified via push notification when this router pages them"
+                  },
+                  "informational_notification_message": {
+                    "type": "string",
+                    "nullable": true,
+                    "maxLength": 160,
+                    "description": "Optional message included in the SMS/push notification. Supports variables such as {{ alert.url }}, {{ alert.data.* }}, and {{ alert.alert_urgency.name }}."
                   },
                   "alert_urgency_id": {
                     "type": "string",
@@ -65425,6 +74272,7 @@
               "NL",
               "NZ",
               "SE",
+              "CH",
               "GB",
               "US"
             ]
@@ -65449,6 +74297,12 @@
           "caller_greeting": {
             "type": "string",
             "description": "The caller greeting message of the live_call_router"
+          },
+          "unavailable_responder_message": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 300,
+            "description": "The message played to the caller when a responder doesn't answer and the call moves on to the next person in the escalation. Leave blank to use the default message."
           },
           "waiting_music_url": {
             "type": "string",
@@ -65478,6 +74332,20 @@
           "should_auto_resolve_alert_on_call_end": {
             "type": "boolean",
             "description": "This overrides the delay (seconds) in escalation levels"
+          },
+          "notify_via_sms": {
+            "type": "boolean",
+            "description": "Whether responders are also notified via SMS when this router pages them"
+          },
+          "notify_via_push_notification": {
+            "type": "boolean",
+            "description": "Whether responders are also notified via push notification when this router pages them"
+          },
+          "informational_notification_message": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 160,
+            "description": "Optional message included in the SMS/push notification. Supports variables such as {{ alert.url }}, {{ alert.data.* }}, and {{ alert.alert_urgency.name }}."
           },
           "alert_urgency_id": {
             "type": "string",
@@ -65588,6 +74456,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -65643,6 +74517,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -65713,6 +74593,13 @@
                       "EscalationPolicy",
                       "Functionality"
                     ]
+                  },
+                  "owner_group_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "List of team IDs that own this heartbeat"
                   },
                   "enabled": {
                     "type": "boolean",
@@ -65803,6 +74690,13 @@
                       "Functionality"
                     ]
                   },
+                  "owner_group_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "List of team IDs that own this heartbeat"
+                  },
                   "enabled": {
                     "type": "boolean",
                     "description": "Whether to trigger alerts when heartbeat is expired."
@@ -65871,6 +74765,13 @@
               "EscalationPolicy",
               "Functionality"
             ]
+          },
+          "owner_group_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of team IDs that own this heartbeat"
           },
           "enabled": {
             "type": "boolean",
@@ -65961,6 +74862,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66016,6 +74923,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66106,6 +75019,111 @@
                     "type": "string",
                     "description": "The Jira issue URL.",
                     "nullable": true
+                  },
+                  "form_field_selections": {
+                    "type": "array",
+                    "nullable": true,
+                    "description": "Custom field values to set on the action item. Ignored unless custom fields for action items are enabled for the organization.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "ID of an existing selection. Required when updating or removing a field's existing value."
+                        },
+                        "form_field_id": {
+                          "type": "string",
+                          "description": "ID of the custom field"
+                        },
+                        "value": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "description": "Value for text, textarea, rich text, date, datetime, number, checkbox, or tag fields"
+                        },
+                        "selected_option_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected custom field options",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_user_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected users",
+                          "items": {
+                            "type": "integer"
+                          }
+                        },
+                        "selected_group_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected teams",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_service_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected services",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_functionality_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected functionalities",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_catalog_entity_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected catalog entities",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_environment_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected environments",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_cause_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected causes",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_incident_type_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected incident types",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "_destroy": {
+                          "type": "boolean",
+                          "nullable": true,
+                          "description": "Set to true to remove the field's value from the action item"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "form_field_id"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": false,
@@ -66207,6 +75225,111 @@
                     "type": "string",
                     "description": "The Jira issue URL.",
                     "nullable": true
+                  },
+                  "form_field_selections": {
+                    "type": "array",
+                    "nullable": true,
+                    "description": "Custom field values to set on the action item. Ignored unless custom fields for action items are enabled for the organization.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "ID of an existing selection. Required when updating or removing a field's existing value."
+                        },
+                        "form_field_id": {
+                          "type": "string",
+                          "description": "ID of the custom field"
+                        },
+                        "value": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          ],
+                          "description": "Value for text, textarea, rich text, date, datetime, number, checkbox, or tag fields"
+                        },
+                        "selected_option_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected custom field options",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_user_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected users",
+                          "items": {
+                            "type": "integer"
+                          }
+                        },
+                        "selected_group_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected teams",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_service_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected services",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_functionality_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected functionalities",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_catalog_entity_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected catalog entities",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_environment_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected environments",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_cause_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected causes",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "selected_incident_type_ids": {
+                          "type": "array",
+                          "description": "IDs of the selected incident types",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "_destroy": {
+                          "type": "boolean",
+                          "nullable": true,
+                          "description": "Set to true to remove the field's value from the action item"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "form_field_id"
+                      ]
+                    }
                   }
                 },
                 "additionalProperties": false
@@ -66299,6 +75422,16 @@
             "description": "The Jira issue URL.",
             "nullable": true
           },
+          "created_by": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/user_flat_response"
+              }
+            ],
+            "description": "User who created this action item",
+            "nullable": true
+          },
           "created_at": {
             "type": "string",
             "description": "Date of creation"
@@ -66344,6 +75477,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66399,6 +75538,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66554,6 +75699,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66609,6 +75760,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66767,6 +75924,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66822,6 +75985,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -66980,6 +76149,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67035,6 +76210,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67193,6 +76374,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67248,6 +76435,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67425,6 +76618,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67480,6 +76679,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67807,6 +77012,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -67862,6 +77073,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68109,6 +77326,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68164,6 +77387,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68397,6 +77626,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68452,6 +77687,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68670,6 +77911,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68725,6 +77972,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -68966,6 +78219,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69021,6 +78280,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69187,6 +78452,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69362,6 +78633,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69417,6 +78694,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69622,6 +78905,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69677,6 +78966,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69731,6 +79026,12 @@
                     "type": "boolean",
                     "description": "For Statuspage.io integrated pages auto publishes a tweet for your update",
                     "default": false,
+                    "nullable": true
+                  },
+                  "started_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the event started. Defaults to the time of creation.",
                     "nullable": true
                   }
                 },
@@ -69796,6 +79097,12 @@
                     "type": "boolean",
                     "description": "For Statuspage.io integrated pages auto publishes a tweet for your update",
                     "default": false,
+                    "nullable": true
+                  },
+                  "started_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "When the event started.",
                     "nullable": true
                   }
                 },
@@ -69894,6 +79201,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -69949,6 +79262,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -70349,6 +79668,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -70404,6 +79729,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -71596,6 +80927,91 @@
             "description": "Google meeting URL",
             "nullable": true
           },
+          "microsoft_teams_meeting_id": {
+            "type": "string",
+            "description": "Microsoft Teams meeting ID",
+            "nullable": true
+          },
+          "microsoft_teams_meeting_url": {
+            "type": "string",
+            "description": "Microsoft Teams meeting URL",
+            "nullable": true
+          },
+          "microsoft_teams_channel_id": {
+            "type": "string",
+            "description": "Microsoft Teams channel ID",
+            "nullable": true
+          },
+          "microsoft_teams_channel_name": {
+            "type": "string",
+            "description": "Microsoft Teams channel name",
+            "nullable": true
+          },
+          "microsoft_teams_channel_url": {
+            "type": "string",
+            "description": "Microsoft Teams channel URL",
+            "nullable": true
+          },
+          "microsoft_teams_channel_short_url": {
+            "type": "string",
+            "description": "Microsoft Teams channel short URL",
+            "nullable": true
+          },
+          "microsoft_teams_chat_id": {
+            "type": "string",
+            "description": "Microsoft Teams chat ID",
+            "nullable": true
+          },
+          "microsoft_teams_chat_url": {
+            "type": "string",
+            "description": "Microsoft Teams chat URL",
+            "nullable": true
+          },
+          "microsoft_teams_team_id": {
+            "type": "string",
+            "description": "Microsoft Teams team ID",
+            "nullable": true
+          },
+          "google_chat_space_id": {
+            "type": "string",
+            "description": "Google Chat space ID",
+            "nullable": true
+          },
+          "google_chat_space_name": {
+            "type": "string",
+            "description": "Google Chat space name",
+            "nullable": true
+          },
+          "google_chat_space_url": {
+            "type": "string",
+            "description": "Google Chat space URL",
+            "nullable": true
+          },
+          "google_chat_space_short_url": {
+            "type": "string",
+            "description": "Google Chat space short URL",
+            "nullable": true
+          },
+          "google_chat_space_archived": {
+            "type": "boolean",
+            "description": "Whether the Google Chat space is archived",
+            "nullable": true
+          },
+          "google_chat_space_domain_id": {
+            "type": "string",
+            "description": "Google Chat space domain ID",
+            "nullable": true
+          },
+          "webex_meeting_id": {
+            "type": "string",
+            "description": "Webex meeting ID",
+            "nullable": true
+          },
+          "webex_meeting_url": {
+            "type": "string",
+            "description": "Webex meeting URL",
+            "nullable": true
+          },
           "jira_issue_key": {
             "type": "string",
             "description": "Jira issue key",
@@ -72025,6 +81441,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -72080,6 +81502,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -72193,6 +81621,144 @@
           "last"
         ]
       },
+      "import_meeting_recording": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Import source (currently only \"recall_desktop_sdk\")",
+            "enum": [
+              "recall_desktop_sdk"
+            ]
+          },
+          "recall_recording_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "External recording UUID (required when source is recall_desktop_sdk)"
+          },
+          "platform": {
+            "type": "string",
+            "description": "Meeting platform",
+            "enum": [
+              "zoom",
+              "google_meet",
+              "microsoft_teams",
+              "webex"
+            ]
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the recording started",
+            "nullable": true
+          },
+          "ended_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the recording ended",
+            "nullable": true
+          },
+          "meeting_url": {
+            "type": "string",
+            "description": "Original meeting URL",
+            "nullable": true
+          }
+        },
+        "required": [
+          "source",
+          "recall_recording_id",
+          "platform"
+        ]
+      },
+      "start_session_request": {
+        "type": "object",
+        "properties": {
+          "platform": {
+            "type": "string",
+            "description": "Meeting platform",
+            "enum": [
+              "zoom",
+              "google_meet",
+              "microsoft_teams",
+              "webex"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Human-readable label for the recording session",
+            "nullable": true
+          }
+        }
+      },
+      "start_session_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "session_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Meeting recording UUID"
+              },
+              "stream_token": {
+                "type": "string",
+                "description": "Token for the desktop client to stream audio"
+              },
+              "meeting_recording_id": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Meeting recording UUID"
+              }
+            },
+            "required": [
+              "session_id",
+              "stream_token",
+              "meeting_recording_id"
+            ]
+          }
+        }
+      },
+      "meeting_recording_transcript_word": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Transcribed word"
+          },
+          "start_timestamp": {
+            "type": "number",
+            "description": "Start time in seconds from recording start"
+          },
+          "end_timestamp": {
+            "type": "number",
+            "description": "End time in seconds from recording start"
+          }
+        },
+        "required": [
+          "text"
+        ]
+      },
+      "meeting_recording_transcript_segment": {
+        "type": "object",
+        "properties": {
+          "speaker": {
+            "type": "string",
+            "description": "Speaker label (e.g. Speaker 1)"
+          },
+          "words": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/meeting_recording_transcript_word"
+            },
+            "description": "Timestamped words spoken by this speaker"
+          }
+        },
+        "required": [
+          "speaker",
+          "words"
+        ]
+      },
       "meeting_recording": {
         "type": "object",
         "properties": {
@@ -72253,9 +81819,25 @@
             "description": "AI-generated summary of the meeting transcript (null if no transcript or not yet analyzed)",
             "nullable": true
           },
-          "has_video": {
-            "type": "boolean",
-            "description": "Whether a video recording file is attached"
+          "title": {
+            "type": "string",
+            "description": "Human-readable label for the recording session",
+            "nullable": true
+          },
+          "meeting_url": {
+            "type": "string",
+            "nullable": true,
+            "description": "Original meeting URL"
+          },
+          "video_url": {
+            "type": "string",
+            "nullable": true,
+            "description": "Signed URL to stream/download the video recording"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "Source that created the recording (e.g. desktop_sdk, recall_bot)",
+            "nullable": true
           },
           "created_at": {
             "type": "string",
@@ -72274,6 +81856,121 @@
           "status",
           "created_at",
           "updated_at"
+        ]
+      },
+      "meeting_recording_detail": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/meeting_recording"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "transcript": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/meeting_recording_transcript_segment"
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "maxProperties": 0
+                  }
+                ],
+                "description": "Array of speaker segments when populated, empty object when no transcript exists."
+              },
+              "recall_upload_id": {
+                "type": "string",
+                "nullable": true,
+                "description": "Recall upload identifier"
+              },
+              "recordable_id": {
+                "type": "string",
+                "nullable": true,
+                "description": "UUID of the associated recordable (e.g. incident)"
+              },
+              "recordable_type": {
+                "type": "string",
+                "nullable": true,
+                "description": "Type of the associated recordable (e.g. Incident)"
+              }
+            }
+          }
+        ]
+      },
+      "meeting_recording_detail_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique UUID of the meeting recording"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "meeting_recordings"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/meeting_recording_detail"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "attributes"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "meeting_recording_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique UUID of the meeting recording"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "meeting_recordings"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/meeting_recording"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "attributes"
+            ]
+          }
+        },
+        "required": [
+          "data"
         ]
       },
       "meeting_recording_list": {
@@ -72357,6 +82054,191 @@
           "total_pages"
         ]
       },
+      "oncall": {
+        "type": "object",
+        "properties": {
+          "escalation_policy_id": {
+            "type": "string",
+            "description": "ID of the escalation policy"
+          },
+          "escalation_policy_name": {
+            "type": "string",
+            "description": "Name of the escalation policy"
+          },
+          "escalation_policy_path_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the escalation policy path"
+          },
+          "escalation_policy_path_name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Name of the escalation policy path"
+          },
+          "notification_type": {
+            "type": "string",
+            "enum": [
+              "audible",
+              "quiet"
+            ],
+            "nullable": true,
+            "description": "Notification type of the escalation path (audible or quiet)"
+          },
+          "is_default_path": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether this is the default escalation path"
+          },
+          "escalation_level": {
+            "type": "integer",
+            "description": "Level within the escalation policy"
+          },
+          "schedule_id": {
+            "type": "string",
+            "description": "ID of the schedule",
+            "nullable": true
+          },
+          "schedule_name": {
+            "type": "string",
+            "description": "Name of the schedule",
+            "nullable": true
+          },
+          "user_id": {
+            "type": "integer",
+            "description": "ID of the on-call user"
+          },
+          "starts_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Start datetime of the on-call shift"
+          },
+          "ends_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "End datetime of the on-call shift"
+          }
+        },
+        "required": [
+          "escalation_policy_id",
+          "escalation_policy_name",
+          "user_id",
+          "starts_at",
+          "ends_at"
+        ]
+      },
+      "oncall_list": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique ID of the on-call entry"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "on_call_resources"
+                  ]
+                },
+                "attributes": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/oncall"
+                    }
+                  ]
+                },
+                "relationships": {
+                  "$ref": "#/components/schemas/oncall_relationships"
+                }
+              },
+              "required": [
+                "id",
+                "type",
+                "attributes"
+              ]
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "oncall_relationships": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "users"
+                    ]
+                  }
+                },
+                "nullable": true
+              }
+            }
+          },
+          "schedule": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "schedules"
+                    ]
+                  }
+                },
+                "nullable": true
+              }
+            }
+          },
+          "escalation_policy": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "escalation_policies"
+                    ]
+                  }
+                },
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
       "new_on_call_pay_report": {
         "type": "object",
         "properties": {
@@ -72388,6 +82270,14 @@
                       "type": "string"
                     },
                     "description": "List of schedule UUIDs to scope the report."
+                  },
+                  "time_zone": {
+                    "type": "string",
+                    "description": "IANA timezone used to compute day and weekend boundaries. Defaults to the team's timezone."
+                  },
+                  "use_responders_time_zone": {
+                    "type": "boolean",
+                    "description": "When true, day and weekend boundaries are computed in each responder's personal timezone instead of the report-wide timezone."
                   }
                 },
                 "additionalProperties": false,
@@ -72438,6 +82328,14 @@
                       "type": "string"
                     },
                     "description": "List of schedule UUIDs to scope the report."
+                  },
+                  "time_zone": {
+                    "type": "string",
+                    "description": "IANA timezone used to compute day and weekend boundaries."
+                  },
+                  "use_responders_time_zone": {
+                    "type": "boolean",
+                    "description": "When true, day and weekend boundaries are computed in each responder's personal timezone instead of the report-wide timezone."
                   }
                 },
                 "additionalProperties": false
@@ -72531,8 +82429,12 @@
           },
           "time_zone": {
             "type": "string",
-            "description": "The team's IANA timezone used to interpret start_date and end_date.",
+            "description": "The IANA timezone used to compute day and weekend boundaries for this report. Defaults to the team's timezone.",
             "nullable": true
+          },
+          "use_responders_time_zone": {
+            "type": "boolean",
+            "description": "When true, each responder's personal timezone is used for their pay calculation; otherwise the report-wide time_zone is used."
           },
           "csv_file_url": {
             "type": "string",
@@ -72593,6 +82495,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -72648,6 +82556,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -72869,6 +82783,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -72924,6 +82844,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -73198,6 +83124,18 @@
                       ]
                     }
                   },
+                  "functionalities_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "create",
+                        "read",
+                        "update",
+                        "delete"
+                      ]
+                    }
+                  },
                   "webhooks_permissions": {
                     "type": "array",
                     "items": {
@@ -73211,6 +83149,18 @@
                     }
                   },
                   "workflows_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "create",
+                        "read",
+                        "update",
+                        "delete"
+                      ]
+                    }
+                  },
+                  "catalogs_permissions": {
                     "type": "array",
                     "items": {
                       "type": "string",
@@ -73505,6 +83455,18 @@
                       ]
                     }
                   },
+                  "functionalities_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "create",
+                        "read",
+                        "update",
+                        "delete"
+                      ]
+                    }
+                  },
                   "webhooks_permissions": {
                     "type": "array",
                     "items": {
@@ -73518,6 +83480,18 @@
                     }
                   },
                   "workflows_permissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "create",
+                        "read",
+                        "update",
+                        "delete"
+                      ]
+                    }
+                  },
+                  "catalogs_permissions": {
                     "type": "array",
                     "items": {
                       "type": "string",
@@ -73801,6 +83775,18 @@
               ]
             }
           },
+          "functionalities_permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            }
+          },
           "webhooks_permissions": {
             "type": "array",
             "items": {
@@ -73814,6 +83800,18 @@
             }
           },
           "workflows_permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "create",
+                "read",
+                "update",
+                "delete"
+              ]
+            }
+          },
+          "catalogs_permissions": {
             "type": "array",
             "items": {
               "type": "string",
@@ -73868,6 +83866,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -73923,6 +83927,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74118,6 +84128,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74173,6 +84189,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74238,6 +84260,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74398,6 +84426,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74453,6 +84487,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74756,6 +84796,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -74811,6 +84857,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -75053,6 +85105,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -75108,6 +85166,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -75346,7 +85410,7 @@
               }
             },
             "required": [
-              "summary",
+              "type",
               "attributes"
             ]
           }
@@ -75488,6 +85552,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -75543,12 +85613,53 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
           "data",
           "links",
           "meta"
+        ]
+      },
+      "receipt": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Delivery state of the receipt.",
+            "enum": [
+              "pending",
+              "done",
+              "failed"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason a receipt failed. Present when state is failed.",
+            "enum": [
+              "no_route_matched",
+              "deduplicated",
+              "suppressed",
+              "validation_error"
+            ]
+          },
+          "resource_type": {
+            "type": "string",
+            "description": "Type of the referenced resource (present when set)."
+          },
+          "resource_id": {
+            "type": "string",
+            "description": "ID of the referenced resource (present when set)."
+          }
+        },
+        "required": [
+          "state"
         ]
       },
       "update_retrospective_configuration": {
@@ -75679,6 +85790,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -75717,6 +85834,12 @@
                 "type",
                 "attributes"
               ]
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
             }
           }
         },
@@ -76024,6 +86147,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -76079,6 +86208,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -76289,6 +86424,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -76344,6 +86485,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -77667,6 +87814,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -77722,6 +87875,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -77935,6 +88094,12 @@
                 ]
               }
             }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         }
       },
@@ -77987,6 +88152,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -78145,6 +88316,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -78183,6 +88360,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -78386,14 +88569,14 @@
                   },
                   "start_time": {
                     "type": "string",
-                    "format": "date",
-                    "description": "ISO8601 date and time when rotation starts. Shifts will only be created after this time.",
+                    "format": "date-time",
+                    "description": "RFC3339 date-time when rotation starts. Shifts will only be created after this time.",
                     "nullable": true
                   },
                   "end_time": {
                     "type": "string",
-                    "format": "date",
-                    "description": "ISO8601 date and time when rotation ends. Shifts will only be created before this time.",
+                    "format": "date-time",
+                    "description": "RFC3339 date-time when rotation ends. Shifts will only be created before this time.",
                     "nullable": true
                   },
                   "schedule_rotation_members": {
@@ -78642,14 +88825,14 @@
                   },
                   "start_time": {
                     "type": "string",
-                    "format": "time",
-                    "description": "ISO8601 date and time when rotation starts. Shifts will only be created after this time.",
+                    "format": "date-time",
+                    "description": "RFC3339 date-time when rotation starts. Shifts will only be created after this time.",
                     "nullable": true
                   },
                   "end_time": {
                     "type": "string",
-                    "format": "time",
-                    "description": "ISO8601 date and time when rotation ends. Shifts will only be created before this time.",
+                    "format": "date-time",
+                    "description": "RFC3339 date-time when rotation ends. Shifts will only be created before this time.",
                     "nullable": true
                   },
                   "schedule_rotation_members": {
@@ -78888,14 +89071,14 @@
           },
           "start_time": {
             "type": "string",
-            "format": "date",
-            "description": "ISO8601 date and time when rotation starts. Shifts will only be created after this time.",
+            "format": "date-time",
+            "description": "RFC3339 date-time when rotation starts. Shifts will only be created after this time.",
             "nullable": true
           },
           "end_time": {
             "type": "string",
-            "format": "date",
-            "description": "ISO8601 date and time when rotation ends. Shifts will only be created before this time.",
+            "format": "date-time",
+            "description": "RFC3339 date-time when rotation ends. Shifts will only be created before this time.",
             "nullable": true
           }
         },
@@ -78936,6 +89119,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -78991,6 +89180,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -79065,6 +89260,55 @@
                   "owner_user_id": {
                     "type": "integer",
                     "description": "ID of the owner of the schedule"
+                  },
+                  "sync_linear_enabled": {
+                    "type": "boolean",
+                    "description": "Whether the schedule is synced with Linear",
+                    "nullable": true
+                  },
+                  "include_shadows_in_slack_notifications": {
+                    "type": "boolean",
+                    "description": "Whether shadow users are included in Slack notifications and user group syncing. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_start_notifications_enabled": {
+                    "type": "boolean",
+                    "description": "Whether shift-start notifications are enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_update_notifications_enabled": {
+                    "type": "boolean",
+                    "description": "Whether shift-update notifications are enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_report_enabled": {
+                    "type": "boolean",
+                    "description": "Whether the weekly shift summary report is enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_report_day_of_week": {
+                    "type": "string",
+                    "enum": [
+                      "monday",
+                      "tuesday",
+                      "wednesday",
+                      "thursday",
+                      "friday",
+                      "saturday",
+                      "sunday"
+                    ],
+                    "description": "Day of week the weekly shift summary is sent",
+                    "nullable": true
+                  },
+                  "shift_report_time_of_day": {
+                    "type": "string",
+                    "description": "Time of day the weekly shift summary is sent, in HH:MM 24-hour format",
+                    "nullable": true
+                  },
+                  "shift_report_time_zone": {
+                    "type": "string",
+                    "description": "IANA time zone used for the weekly shift summary",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false,
@@ -79151,6 +89395,55 @@
                     "type": "integer",
                     "description": "ID of the owner of the schedule",
                     "nullable": true
+                  },
+                  "sync_linear_enabled": {
+                    "type": "boolean",
+                    "description": "Whether the schedule is synced with Linear",
+                    "nullable": true
+                  },
+                  "include_shadows_in_slack_notifications": {
+                    "type": "boolean",
+                    "description": "Whether shadow users are included in Slack notifications and user group syncing. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_start_notifications_enabled": {
+                    "type": "boolean",
+                    "description": "Whether shift-start notifications are enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_update_notifications_enabled": {
+                    "type": "boolean",
+                    "description": "Whether shift-update notifications are enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_report_enabled": {
+                    "type": "boolean",
+                    "description": "Whether the weekly shift summary report is enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save.",
+                    "nullable": true
+                  },
+                  "shift_report_day_of_week": {
+                    "type": "string",
+                    "enum": [
+                      "monday",
+                      "tuesday",
+                      "wednesday",
+                      "thursday",
+                      "friday",
+                      "saturday",
+                      "sunday"
+                    ],
+                    "description": "Day of week the weekly shift summary is sent",
+                    "nullable": true
+                  },
+                  "shift_report_time_of_day": {
+                    "type": "string",
+                    "description": "Time of day the weekly shift summary is sent, in HH:MM 24-hour format",
+                    "nullable": true
+                  },
+                  "shift_report_time_zone": {
+                    "type": "string",
+                    "description": "IANA time zone used for the weekly shift summary",
+                    "nullable": true
                   }
                 },
                 "additionalProperties": false
@@ -79224,6 +89517,47 @@
             "type": "integer",
             "description": "ID of user assigned as owner of the schedule"
           },
+          "sync_linear_enabled": {
+            "type": "boolean",
+            "description": "Whether the schedule is synced with Linear"
+          },
+          "include_shadows_in_slack_notifications": {
+            "type": "boolean",
+            "description": "Whether shadow users are included in Slack notifications and user group syncing. Requires `slack_channel` to be set; otherwise this value is forced to false on save."
+          },
+          "shift_start_notifications_enabled": {
+            "type": "boolean",
+            "description": "Whether shift-start notifications are enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save."
+          },
+          "shift_update_notifications_enabled": {
+            "type": "boolean",
+            "description": "Whether shift-update notifications are enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save."
+          },
+          "shift_report_enabled": {
+            "type": "boolean",
+            "description": "Whether the weekly shift summary report is enabled. Requires `slack_channel` to be set; otherwise this value is forced to false on save."
+          },
+          "shift_report_day_of_week": {
+            "type": "string",
+            "enum": [
+              "monday",
+              "tuesday",
+              "wednesday",
+              "thursday",
+              "friday",
+              "saturday",
+              "sunday"
+            ],
+            "description": "Day of week the weekly shift summary is sent"
+          },
+          "shift_report_time_of_day": {
+            "type": "string",
+            "description": "Time of day the weekly shift summary is sent, in HH:MM 24-hour format"
+          },
+          "shift_report_time_zone": {
+            "type": "string",
+            "description": "IANA time zone used for the weekly shift summary"
+          },
           "created_at": {
             "type": "string",
             "description": "Date of creation"
@@ -79270,6 +89604,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -79325,6 +89665,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -80171,6 +90517,19 @@
             "type": "string",
             "description": "The slug of the service"
           },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "How this service is managed (provenance): web, api, terraform, etc. Read-only."
+          },
           "description": {
             "type": "string",
             "description": "The description of the service",
@@ -80458,6 +90817,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -80513,6 +90878,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -80520,6 +90891,282 @@
           "links",
           "meta"
         ]
+      },
+      "bulk_upsert_services": {
+        "type": "object",
+        "required": [
+          "entities"
+        ],
+        "properties": {
+          "entities": {
+            "type": "array",
+            "description": "Services to upsert, matched by external_id. Max 100 per request; external_ids unique within a batch. Only attributes present are written (managed-fields semantics).",
+            "items": {
+              "type": "object",
+              "required": [
+                "external_id"
+              ],
+              "properties": {
+                "external_id": {
+                  "type": "string",
+                  "description": "External identifier used as the upsert key. Unique per team."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Required for new records. Optional for updates."
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "public_description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "color": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "position": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "show_uptime": {
+                  "type": "boolean",
+                  "nullable": true
+                },
+                "show_uptime_last_days": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "github_repository_name": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "github_repository_branch": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "gitlab_repository_name": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "gitlab_repository_branch": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "kubernetes_deployment_name": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "pagerduty_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opsgenie_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opsgenie_team_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "cortex_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opslevel_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "backstage_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "service_now_ci_sys_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "notify_emails": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true
+                },
+                "alerts_email_enabled": {
+                  "type": "boolean",
+                  "nullable": true
+                },
+                "fields": {
+                  "type": "array",
+                  "description": "Catalog property values (merge semantics: only mentioned fields written).",
+                  "items": {
+                    "type": "object",
+                    "description": "Each field entry must include either catalog_field_id or catalog_property_id.",
+                    "properties": {
+                      "catalog_field_id": {
+                        "type": "string",
+                        "description": "UUID, slug, or external_id of the catalog field (required if catalog_property_id is absent)"
+                      },
+                      "catalog_property_id": {
+                        "type": "string",
+                        "description": "Alias for catalog_field_id (required if catalog_field_id is absent)"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value for this field"
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_services_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "services"
+                  ]
+                },
+                "attributes": {
+                  "$ref": "#/components/schemas/service"
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_services_error": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "index",
+                "external_id",
+                "errors"
+              ],
+              "properties": {
+                "index": {
+                  "type": "integer",
+                  "description": "Position of the failed record in the batch"
+                },
+                "external_id": {
+                  "type": "string"
+                },
+                "errors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_destroy_services": {
+        "description": "Two mutually exclusive modes. Pass exactly one of: external_ids (delete specific records) or managed_by (prune all managed records not in keep set).",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "external_ids"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "external_ids": {
+                "type": "array",
+                "description": "Array of external_ids to delete. Max 100 per request.",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "managed_by"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "managed_by": {
+                "type": "string",
+                "enum": [
+                  "api",
+                  "terraform",
+                  "pulumi",
+                  "backstage",
+                  "catalog_sync"
+                ],
+                "description": "Delete all records with this managed_by value (web/admin_web not allowed)."
+              },
+              "keep_external_ids": {
+                "type": "array",
+                "description": "Records with these external_ids are preserved.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "bulk_destroy_services_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "deleted_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were successfully deleted"
+              },
+              "failed_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs whose deletion the record itself blocked (e.g. minimum-one guard, restrict associations). Records the caller is not authorized to destroy are NOT listed here."
+              },
+              "not_found_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were not found or not accessible to the caller (external_ids mode only)"
+              }
+            }
+          }
+        }
       },
       "new_severity": {
         "type": "object",
@@ -80877,6 +91524,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -80932,6 +91585,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -81030,6 +91689,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -81098,6 +91763,281 @@
             }
           }
         }
+      },
+      "new_shift_coverage_request": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "shift_coverage_requests"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "starts_at": {
+                    "type": "string",
+                    "description": "Start datetime of the time range to request coverage for",
+                    "format": "date-time",
+                    "nullable": false
+                  },
+                  "ends_at": {
+                    "type": "string",
+                    "description": "End datetime of the time range to request coverage for",
+                    "format": "date-time",
+                    "nullable": false
+                  },
+                  "user_id": {
+                    "type": "integer",
+                    "description": "Optional. Restrict coverage to shifts assigned to this user. When omitted, every shift overlapping the time range is covered.",
+                    "nullable": false
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "starts_at",
+                  "ends_at"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "attributes"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "shift_coverage_request": {
+        "type": "object",
+        "properties": {
+          "schedule_id": {
+            "type": "string",
+            "description": "ID of schedule",
+            "nullable": false
+          },
+          "shift_id": {
+            "type": "string",
+            "description": "ID of the shift being covered",
+            "nullable": false
+          },
+          "original_shift_user_id": {
+            "type": "integer",
+            "description": "ID of the user whose shift is being covered",
+            "nullable": false
+          },
+          "created_by_user_id": {
+            "type": "integer",
+            "description": "ID of the user who created the coverage request",
+            "nullable": false
+          },
+          "starts_at": {
+            "type": "string",
+            "description": "Start datetime of the coverage request",
+            "nullable": false
+          },
+          "ends_at": {
+            "type": "string",
+            "description": "End datetime of the coverage request",
+            "nullable": false
+          },
+          "created_at": {
+            "type": "string",
+            "description": "Date of creation"
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "Date of last update"
+          },
+          "schedule": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/schedule_response"
+              }
+            ],
+            "description": "Schedule metadata",
+            "nullable": false
+          },
+          "shift": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/shift"
+              }
+            ],
+            "description": "Shift metadata",
+            "nullable": false
+          },
+          "original_shift_user": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/user_response"
+              }
+            ],
+            "description": "User whose shift is being covered",
+            "nullable": false
+          },
+          "created_by_user": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/user_response"
+              }
+            ],
+            "description": "User who created the coverage request",
+            "nullable": false
+          }
+        },
+        "required": [
+          "schedule_id",
+          "shift_id",
+          "original_shift_user_id",
+          "created_by_user_id",
+          "starts_at",
+          "ends_at"
+        ]
+      },
+      "shift_coverage_request_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique ID of the coverage request"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "shift_coverage_requests"
+                ]
+              },
+              "attributes": {
+                "type": "object",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/shift_coverage_request"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "attributes"
+            ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "shift_coverage_request_list": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Unique ID of the coverage request"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "shift_coverage_requests"
+                  ]
+                },
+                "attributes": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/shift_coverage_request"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "type",
+                "attributes"
+              ]
+            }
+          },
+          "links": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/links"
+              }
+            ]
+          },
+          "meta": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/meta"
+              }
+            ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "slack_channel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "slack_channel_name": {
+            "type": "string"
+          },
+          "slack_channel_id": {
+            "type": "string"
+          },
+          "slack_team_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "slack_channel_name",
+          "slack_channel_id",
+          "slack_team_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "new_status_page_template": {
         "type": "object",
@@ -81362,6 +92302,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -81417,6 +92363,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -82093,6 +93045,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -82148,6 +93106,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -82367,6 +93331,17 @@
                   "auto_add_members_when_attached": {
                     "type": "boolean",
                     "description": "Auto add members to incident channel when team is attached",
+                    "nullable": true
+                  },
+                  "auto_add_members_scope": {
+                    "type": "string",
+                    "enum": [
+                      "off",
+                      "public_only",
+                      "public_and_test",
+                      "all"
+                    ],
+                    "description": "Visibility-scoped auto-add behavior. Only present when the `enable_scoped_incident_channel_auto_add` feature flag is on for the organization. When set, it overrides `auto_add_members_when_attached`.",
                     "nullable": true
                   },
                   "properties": {
@@ -82616,6 +93591,17 @@
                     "description": "Auto add members to incident channel when team is attached",
                     "nullable": true
                   },
+                  "auto_add_members_scope": {
+                    "type": "string",
+                    "enum": [
+                      "off",
+                      "public_only",
+                      "public_and_test",
+                      "all"
+                    ],
+                    "description": "Visibility-scoped auto-add behavior. Only present when the `enable_scoped_incident_channel_auto_add` feature flag is on for the organization. When set, it overrides `auto_add_members_when_attached`.",
+                    "nullable": true
+                  },
                   "properties": {
                     "type": "array",
                     "items": {
@@ -82661,6 +93647,19 @@
           },
           "slug": {
             "type": "string"
+          },
+          "managed_by": {
+            "type": "string",
+            "enum": [
+              "web",
+              "admin_web",
+              "api",
+              "terraform",
+              "pulumi",
+              "backstage",
+              "catalog_sync"
+            ],
+            "description": "How this team is managed (provenance): web, api, terraform, etc. Read-only."
           },
           "description": {
             "type": "string",
@@ -82850,6 +93849,17 @@
             "description": "Auto add members to incident channel when team is attached",
             "nullable": true
           },
+          "auto_add_members_scope": {
+            "type": "string",
+            "enum": [
+              "off",
+              "public_only",
+              "public_and_test",
+              "all"
+            ],
+            "description": "Visibility-scoped auto-add behavior. Only present when the `enable_scoped_incident_channel_auto_add` feature flag is on for the organization. When set, it overrides `auto_add_members_when_attached`.",
+            "nullable": true
+          },
           "properties": {
             "type": "array",
             "items": {
@@ -82918,6 +93928,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -82973,6 +93989,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -82980,6 +94002,258 @@
           "links",
           "meta"
         ]
+      },
+      "bulk_upsert_teams": {
+        "type": "object",
+        "required": [
+          "entities"
+        ],
+        "properties": {
+          "entities": {
+            "type": "array",
+            "description": "Teams to upsert, matched by external_id. Max 100 per request; external_ids unique within a batch. Only attributes present are written (managed-fields semantics).",
+            "items": {
+              "type": "object",
+              "required": [
+                "external_id"
+              ],
+              "properties": {
+                "external_id": {
+                  "type": "string",
+                  "description": "External identifier used as the upsert key. Unique per team."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Required for new records. Optional for updates."
+                },
+                "description": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "color": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "position": {
+                  "type": "integer",
+                  "nullable": true
+                },
+                "notify_emails": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true
+                },
+                "pagerduty_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "pagerduty_service_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opsgenie_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "victor_ops_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "pagertree_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "backstage_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "cortex_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "opslevel_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "service_now_ci_sys_id": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "alerts_email_enabled": {
+                  "type": "boolean",
+                  "nullable": true
+                },
+                "fields": {
+                  "type": "array",
+                  "description": "Catalog property values (merge semantics: only mentioned fields written).",
+                  "items": {
+                    "type": "object",
+                    "description": "Each field entry must include either catalog_field_id or catalog_property_id.",
+                    "properties": {
+                      "catalog_field_id": {
+                        "type": "string",
+                        "description": "UUID, slug, or external_id of the catalog field (required if catalog_property_id is absent)"
+                      },
+                      "catalog_property_id": {
+                        "type": "string",
+                        "description": "Alias for catalog_field_id (required if catalog_field_id is absent)"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value for this field"
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_teams_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "groups"
+                  ]
+                },
+                "attributes": {
+                  "$ref": "#/components/schemas/team"
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_upsert_teams_error": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "index",
+                "external_id",
+                "errors"
+              ],
+              "properties": {
+                "index": {
+                  "type": "integer",
+                  "description": "Position of the failed record in the batch"
+                },
+                "external_id": {
+                  "type": "string"
+                },
+                "errors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "bulk_destroy_teams": {
+        "description": "Two mutually exclusive modes. Pass exactly one of: external_ids (delete specific records) or managed_by (prune all managed records not in keep set).",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "external_ids"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "external_ids": {
+                "type": "array",
+                "description": "Array of external_ids to delete. Max 100 per request.",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "minItems": 1
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "managed_by"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "managed_by": {
+                "type": "string",
+                "enum": [
+                  "api",
+                  "terraform",
+                  "pulumi",
+                  "backstage",
+                  "catalog_sync"
+                ],
+                "description": "Delete all records with this managed_by value (web/admin_web not allowed)."
+              },
+              "keep_external_ids": {
+                "type": "array",
+                "description": "Records with these external_ids are preserved.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "bulk_destroy_teams_response": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "deleted_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were successfully deleted"
+              },
+              "failed_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs whose deletion the record itself blocked (e.g. minimum-one guard, restrict associations). Records the caller is not authorized to destroy are NOT listed here."
+              },
+              "not_found_external_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "External IDs that were not found or not accessible to the caller (external_ids mode only)"
+              }
+            }
+          }
+        }
       },
       "new_user_notification_rule": {
         "type": "object",
@@ -83037,7 +94311,8 @@
                         "call",
                         "device",
                         "non_critical_device",
-                        "slack"
+                        "slack",
+                        "google_chat"
                       ]
                     },
                     "nullable": false
@@ -83115,7 +94390,8 @@
                         "call",
                         "device",
                         "non_critical_device",
-                        "slack"
+                        "slack",
+                        "google_chat"
                       ]
                     },
                     "nullable": false
@@ -83181,7 +94457,8 @@
                 "call",
                 "device",
                 "non_critical_device",
-                "slack"
+                "slack",
+                "google_chat"
               ]
             },
             "nullable": false
@@ -83235,6 +94512,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83290,6 +94573,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83431,6 +94720,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83486,6 +94781,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83643,6 +94944,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83698,6 +95005,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83755,48 +95068,72 @@
       },
       "user_flat_response": {
         "type": "object",
-        "description": "Flat user object as returned by serializer",
+        "description": "Flat user attributes as returned by UserFlatSerializer (no nested associations)",
         "properties": {
           "id": {
             "type": "integer",
             "description": "User ID"
           },
+          "name": {
+            "type": "string",
+            "description": "Display name"
+          },
           "email": {
             "type": "string",
-            "description": "User email"
+            "description": "Email address"
+          },
+          "phone": {
+            "type": "string",
+            "description": "Primary phone number",
+            "nullable": true
+          },
+          "phone_2": {
+            "type": "string",
+            "description": "Secondary phone number",
+            "nullable": true
           },
           "first_name": {
             "type": "string",
-            "description": "User first name",
+            "description": "First name",
             "nullable": true
           },
           "last_name": {
             "type": "string",
-            "description": "User last name",
+            "description": "Last name",
+            "nullable": true
+          },
+          "preferred_name": {
+            "type": "string",
+            "description": "Preferred name",
             "nullable": true
           },
           "full_name": {
             "type": "string",
-            "description": "User full name",
+            "description": "Full name",
             "nullable": true
           },
           "full_name_with_team": {
             "type": "string",
-            "description": "User full name with team",
+            "description": "Full name with team context",
+            "nullable": true
+          },
+          "slack_id": {
+            "type": "string",
+            "description": "Slack user ID",
             "nullable": true
           },
           "time_zone": {
             "type": "string",
-            "description": "User time zone",
+            "description": "IANA time zone",
             "nullable": true
           },
           "created_at": {
             "type": "string",
-            "description": "User creation timestamp"
+            "description": "Date of creation"
           },
           "updated_at": {
             "type": "string",
-            "description": "User last update timestamp"
+            "description": "Date of last update"
           }
         },
         "required": [
@@ -83939,6 +95276,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -83997,6 +95340,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84065,6 +95414,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84120,6 +95475,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84182,16 +95543,41 @@
                         "incident_event.deleted",
                         "alert.created",
                         "pulse.created",
+                        "shift.started",
                         "genius_workflow_run.queued",
                         "genius_workflow_run.started",
                         "genius_workflow_run.completed",
                         "genius_workflow_run.failed",
-                        "genius_workflow_run.canceled"
+                        "genius_workflow_run.canceled",
+                        "audit_log.created"
                       ]
                     }
                   },
                   "enabled": {
                     "type": "boolean"
+                  },
+                  "custom_headers": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "maxLength": 256
+                        },
+                        "value": {
+                          "type": "string",
+                          "maxLength": 8192
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "Custom HTTP headers sent with each delivery. Max 10. Reserved names (Content-Type, X-Rootly-Signature, Host, etc.) are rejected."
                   }
                 },
                 "additionalProperties": false,
@@ -84259,16 +95645,41 @@
                         "incident_event.deleted",
                         "alert.created",
                         "pulse.created",
+                        "shift.started",
                         "genius_workflow_run.queued",
                         "genius_workflow_run.started",
                         "genius_workflow_run.completed",
                         "genius_workflow_run.failed",
-                        "genius_workflow_run.canceled"
+                        "genius_workflow_run.canceled",
+                        "audit_log.created"
                       ]
                     }
                   },
                   "enabled": {
                     "type": "boolean"
+                  },
+                  "custom_headers": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "maxLength": 256
+                        },
+                        "value": {
+                          "type": "string",
+                          "maxLength": 8192
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "Custom HTTP headers sent with each delivery. Max 10. Reserved names (Content-Type, X-Rootly-Signature, Host, etc.) are rejected."
                   }
                 },
                 "additionalProperties": false
@@ -84328,11 +95739,13 @@
                 "incident_event.deleted",
                 "alert.created",
                 "pulse.created",
+                "shift.started",
                 "genius_workflow_run.queued",
                 "genius_workflow_run.started",
                 "genius_workflow_run.completed",
                 "genius_workflow_run.failed",
-                "genius_workflow_run.canceled"
+                "genius_workflow_run.canceled",
+                "audit_log.created"
               ]
             }
           },
@@ -84342,6 +95755,29 @@
           },
           "enabled": {
             "type": "boolean"
+          },
+          "custom_headers": {
+            "type": "array",
+            "maxItems": 10,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "maxLength": 256
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 8192
+                }
+              },
+              "required": [
+                "name",
+                "value"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Custom HTTP headers sent with each delivery. Max 10. Reserved names (Content-Type, X-Rootly-Signature, Host, etc.) are rejected."
           },
           "created_at": {
             "type": "string",
@@ -84392,6 +95828,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84447,6 +95889,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84517,6 +95965,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84572,6 +96026,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84747,6 +96207,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84802,6 +96268,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -84948,6 +96420,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -85003,6 +96481,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -85133,6 +96617,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -85188,6 +96678,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -85315,6 +96811,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -85370,6 +96872,12 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -85518,7 +97026,7 @@
                         },
                         "property": {
                           "type": "string",
-                          "description": "The property to evaluate (for built-in field conditions)",
+                          "description": "The property to evaluate (for built-in field conditions). When the team has custom lifecycle statuses enabled, use 'sub_status' (with sub-status IDs as values); otherwise use 'status' (with parent status names). Sending the wrong one will return a validation error.",
                           "enum": [
                             "severity",
                             "environment",
@@ -85757,7 +97265,7 @@
                         },
                         "property": {
                           "type": "string",
-                          "description": "The property to evaluate (for built-in field conditions)",
+                          "description": "The property to evaluate (for built-in field conditions). When the team has custom lifecycle statuses enabled, use 'sub_status' (with sub-status IDs as values); otherwise use 'status' (with parent status names). Sending the wrong one will return a validation error.",
                           "enum": [
                             "severity",
                             "environment",
@@ -86065,6 +97573,12 @@
               "type",
               "attributes"
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
@@ -86120,12 +97634,41 @@
                 "$ref": "#/components/schemas/meta"
               }
             ]
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/jsonapi_included_resource"
+            }
           }
         },
         "required": [
           "data",
           "links",
           "meta"
+        ]
+      },
+      "jsonapi_included_resource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "relationships": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "id",
+          "type"
         ]
       }
     }

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -68,6 +68,7 @@ DEFAULT_HOSTED_ENABLED_TOOLS: frozenset[str] = frozenset(
         "get_escalation_policy",
         "get_functionality",
         "get_incident",
+        "get_meeting_recording",
         "get_oncall_handoff_summary",
         "get_oncall_schedule_summary",
         "get_schedule",
@@ -96,6 +97,7 @@ DEFAULT_HOSTED_ENABLED_TOOLS: frozenset[str] = frozenset(
         "list_incident_roles",
         "list_incident_types",
         "list_incidents",
+        "list_meeting_recordings",
         "list_override_shifts",
         "list_schedule_rotation_active_days",
         "list_schedule_rotation_users",
@@ -414,6 +416,13 @@ DEFAULT_ALLOWED_PATHS = [
     "/incident_retrospective_steps/{id}",
     "/incidents/{incident_id}/status_pages",
     "/incident_status_pages/{id}",
+    # Meeting recordings and transcripts (read-only).  The detail lookup
+    # (`/meeting_recordings/{id}`) returns the full transcript when called
+    # with `include=transcript`; the list endpoints return the transcript
+    # summary per recording.
+    "/meeting_recordings",
+    "/meeting_recordings/{id}",
+    "/incidents/{incident_id}/meeting_recordings",
     # Advanced form management
     "/custom_fields",
     "/custom_fields/{id}",

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -64,6 +64,9 @@ class TestServerDefaultsModule:
         assert "/causes/{id}" in DEFAULT_ALLOWED_PATHS
         assert "/shifts" in DEFAULT_ALLOWED_PATHS
         assert "/on_call_roles" in DEFAULT_ALLOWED_PATHS
+        assert "/meeting_recordings" in DEFAULT_ALLOWED_PATHS
+        assert "/meeting_recordings/{id}" in DEFAULT_ALLOWED_PATHS
+        assert "/incidents/{incident_id}/meeting_recordings" in DEFAULT_ALLOWED_PATHS
 
     def test_generate_recommendation_when_no_solutions(self):
         result = _generate_recommendation({"solutions": [], "average_resolution_time": None})

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -540,14 +540,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.3.1"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
 ]
 
 [package.optional-dependencies]
@@ -557,7 +557,7 @@ code-mode = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.3.1"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -567,9 +567,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -580,6 +580,7 @@ client = [
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 code-mode = [
     { name = "pydantic-monty" },
@@ -590,6 +591,7 @@ server = [
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -600,6 +602,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -1401,49 +1404,49 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.16"
+version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/d2/ddf8381f782e00721feed7000ce1393425dfb82aa8fae95b2cdc50ed4264/pydantic_monty-0.0.16.tar.gz", hash = "sha256:0c4310a3daa8edd3ea3622aed3f72f16042f0909f9b8e6880719feff23e8b10f", size = 1004038, upload-time = "2026-04-19T17:45:20.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/f8/431ba0b79d02922811392c4e3d283d6508f7052ceaa1936cc34878703ecc/pydantic_monty-0.0.17.tar.gz", hash = "sha256:9c4904a8fbc63282793f3afd2d180124494c7fc371783f365e5691c9586360af", size = 1007724, upload-time = "2026-04-22T20:13:48.915Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/14/001815665ad793d334d926cd1a3d0a86ceab9ddb042d63da2dfce4f153b2/pydantic_monty-0.0.16-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f62efa2ebc1305826b646b60e1857a90b0ea8c370788a02b9d40d2ab5d505777", size = 7333666, upload-time = "2026-04-19T17:45:27.915Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/87/22423a512b649ea1ff02d37c72b247b137ef91688a4bda88b5978584d099/pydantic_monty-0.0.16-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4f963ea23bfb352da29dd1976821e1e47162e0e2b98065f092534dde85e41ccb", size = 7293613, upload-time = "2026-04-19T17:45:33.312Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1d/fd31f7bbfbc004970209d4895a176d332f533b0337b75aa774d527a4fd09/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93087d3ec044c5e929f10823fb563e809dbc7c623eb619362872403da7c406a6", size = 7847877, upload-time = "2026-04-19T17:46:02.478Z" },
-    { url = "https://files.pythonhosted.org/packages/91/a7/85b22d367787816ce3637f514df07eef06ec081c566edd6ce59e7a8ea319/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb6cd319731e404bcc190d7867cf0ea1f5bf7124114893e277693f9b8b987201", size = 7134554, upload-time = "2026-04-19T17:44:43.392Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/5e/998a7aeebf3e12640f5300e8e42cc97dcbb4aeb94a4df6846f1704d73d9d/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49e58d4e00d2721560f40ae92998b5b3670166e56db678f7c16853b916d888da", size = 7431773, upload-time = "2026-04-19T17:45:04.834Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/c5/5554c3df0e20be6bb0bf3a59ce96e47238a630156a9ab5f568eeb6370265/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:320d4bc67e58a17a526a2361737de874cc8824c610701551e75b456b7421feb8", size = 7952070, upload-time = "2026-04-19T17:44:51.742Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fa/173e3d8738de03c0ad53aa8f6180d56a10ff62d059b90a47e915fc4db5ce/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a5eda5ecc4841bce0a9a9e1e059b71646a7bd5c990bc106edf717d2ec13d6cd", size = 8178124, upload-time = "2026-04-19T17:45:06.61Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/8c/c879f7d925c09e89e371a00597f6391cb4a547ce63b207897e7ef82e48a1/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa7834fdee5db13f75bfe74ab91ef4d056be643ad841b9cec5338d097c1513ed", size = 7718778, upload-time = "2026-04-19T17:45:38.162Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e3/69741eecc269c12e94dc9c6fc7513e3200aafaf602ca794ea11dadb0d9ee/pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5df4c31ac9d5b91b39eb9cdf81e4fdf1ccfe372fea1f4133cfc02e5654c62a5d", size = 7308908, upload-time = "2026-04-19T17:44:46.98Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f5/a5f010527c59cb8f8c7fe616c17f9016b5fe9ae6e1d077ad2213cd344349/pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:6f13db1f0c1c970ad6289262273273f9d2e241e141539ad874e06ff0c736d86d", size = 7759289, upload-time = "2026-04-19T17:46:09.222Z" },
-    { url = "https://files.pythonhosted.org/packages/05/4d/ea909241588f38dee4e039c7b40896070f4ea49a71388ff3bf312cbed720/pydantic_monty-0.0.16-cp312-cp312-win32.whl", hash = "sha256:8585dd6a186a3d17d25237ea6f8ea4a8af3717c9503c08a3a582f5e5162e36a6", size = 7213401, upload-time = "2026-04-19T17:46:10.803Z" },
-    { url = "https://files.pythonhosted.org/packages/08/bd/a8cbee968d8df9cae0906de331affee8af33b68772f86c9500f498c74268/pydantic_monty-0.0.16-cp312-cp312-win_amd64.whl", hash = "sha256:326cddda37f0a684a5d8ca54113bd17657bf48399a0e022cdb8ae05581976bce", size = 8035415, upload-time = "2026-04-19T17:44:37.494Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/58/6efd919433d5fb80503a0d6e971ed1b28295a6fe4cba7a4706e9e484fe1b/pydantic_monty-0.0.16-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9615d19bcccd7f4ad95364368cfd74d5451f1eeeb7f0363ad292c56f75bbdac5", size = 7334030, upload-time = "2026-04-19T17:44:55.331Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/cd/d53c86d58983e7203c2ab9ac21defdff4e5b4e2a318a0ae435f825e381bf/pydantic_monty-0.0.16-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9da2475d37d7614691d94b21035ad00161373592df9de2282c2929c00f2504e", size = 7293738, upload-time = "2026-04-19T17:45:11.487Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/64/b085a0b192c8aecec4ad225e6f1895a963ac584b3a2f8970201e70ff5347/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:07372b15eab8996ec6720a8ee4879f7b5fd53dd0589d818550d5244eacd68a96", size = 7847921, upload-time = "2026-04-19T17:44:58.659Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/9a/a169c6f3da169fdb49b7c679b7c9b04b2dc3c9ecff01cc470753a35634ca/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a694ea0501f2ad115ec1b169d7665b554eb9448779fce11727472a4e8378d2c3", size = 7132619, upload-time = "2026-04-19T17:45:09.797Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d9/d04fe911ee70a07e9e30ebbd0a8665acc39c4fd1ba0fa4ca6fe022c113f7/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f00c529865554b5edaefc796c4f52ed3686f91cb9cae2b164428353c2f2a773b", size = 7430974, upload-time = "2026-04-19T17:46:14.641Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cd/3110b6ab4e8b237ce1ca47799d8ee0df409475011502c9ca21392466ca54/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:95be0c370eeea1c185d96ff8d459e510fbce1508115bbed489f8d7b9a79e7505", size = 7951214, upload-time = "2026-04-19T17:45:36.475Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1b/a42f7ae39f99a36d07e03625615fb35685dfa78721c1ff9429e0620cd202/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6edd9338861544e9983a3d8412f27257cb246428b0a6dab945848af0790b294", size = 8177227, upload-time = "2026-04-19T17:44:31.815Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/8b/364cf60bba989a8a50d9127a8f3818437590c435ade07f4e81ddc9bc77a0/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:011ab47525340b2802e2aa32ccac92fafc4fb516a48dd07ff563f2cd40203e37", size = 7717367, upload-time = "2026-04-19T17:45:40.103Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f3/6726e51d8a86aadcc638d26c33643e77d7f1f971475046d55bfc5af3f7fb/pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e5d25973f2884e0b845d2f028e1f972811c2a98708eb425bf5809747360939ad", size = 7308198, upload-time = "2026-04-19T17:45:02.364Z" },
-    { url = "https://files.pythonhosted.org/packages/69/a1/9fd2cdfc5720b34c822a0b34ad6c555e8d32c2fd6e35b52cdf3eeb2e5820/pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:944a0ab7e81e4523ff9120f45b0ca22f377ad291d2257d251db02eb25727c5ac", size = 7757710, upload-time = "2026-04-19T17:46:05.935Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/52/8f742f63c10f7bf9696e428ba16970fa76ba8bb4d5cf9d3c19f7973d3d51/pydantic_monty-0.0.16-cp313-cp313-win32.whl", hash = "sha256:e6d4023ee3f0530edf57097ebc004f73d67636b39d2ebb21fca0eaed7bab9977", size = 7213500, upload-time = "2026-04-19T17:46:16.403Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5b/e58bbae39114ffcfefcd9afd87d215f65af2689356bb3100cfe1c85684d4/pydantic_monty-0.0.16-cp313-cp313-win_amd64.whl", hash = "sha256:c7c27b717ccba5a4cdd7321bc3a33fc97aede032784c41a1ce7d5906be04cf44", size = 8035107, upload-time = "2026-04-19T17:46:07.638Z" },
-    { url = "https://files.pythonhosted.org/packages/af/16/43c0c9220590b620fb1283221bb1565d64721666a863a0d1b11d5f617f51/pydantic_monty-0.0.16-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d42f100eda125bded8ba38f17c9998cca2ab645c4a795aa1be4bf754075899c5", size = 7333854, upload-time = "2026-04-19T17:45:53.604Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/56/ecb342362161b47cd8bcc604adaebc035acc87a094be30a31fb62943bf4e/pydantic_monty-0.0.16-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:483ced987c4f0082cdc9980ac7b4ea5882876aa82c548d43944f96f13da9aca6", size = 7307315, upload-time = "2026-04-19T17:45:57.526Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/2f7113aa9ec2566ee0859258a8757a7b521eda012c9629603ae65d59e7f2/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c4c8477264e417475bcaf3ceb4044233407272cefd58356f062a3726e0a32a90", size = 7848117, upload-time = "2026-04-19T17:46:18.129Z" },
-    { url = "https://files.pythonhosted.org/packages/81/a8/101f38b27db1f14bbc5eb6ef8e3cbc0debd22a380f4c42fbedd08ada6c8c/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:751ea6e8f4ae62085b43c2b891ae6e5a072e3ea26486bae2653337e8d132459e", size = 7132076, upload-time = "2026-04-19T17:46:19.733Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/72/f8555b887879e75bb1a69638fe7a0ce4444bc552520759471bbce383bc36/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f29f66645a690e96e9a1b892c0c0c0736341d32251ec5035612259ca03d2102", size = 7432492, upload-time = "2026-04-19T17:44:53.533Z" },
-    { url = "https://files.pythonhosted.org/packages/44/38/2af6af1f99de9db2d69da0304bb98751e643f45a0649d3fcb261e04dea03/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ffc6730b0ed5f6f3c88f8f719df3925bfa77abb71d0259c7f175b9be79b25cfe", size = 7951882, upload-time = "2026-04-19T17:45:15.014Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/92/e51dd904ffb683557fd0f1d1527bc0dbe56d7d4bed0eacbabad51d62087d/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9a79337e78f3182ae029714c634c33f15dee3c75a14b0fa2c54caf041433120", size = 8177474, upload-time = "2026-04-19T17:45:34.903Z" },
-    { url = "https://files.pythonhosted.org/packages/46/22/d2f27bc1a5a057bb83c40a1b6d61950d2be63dd02aeaa2d2efc11d5422e1/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6935b421938f31f1414a10980d27f9bd62fbd7b35228253a751ac1488abcac1d", size = 7729472, upload-time = "2026-04-19T17:44:35.557Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/d3/7a604089596bdb1fcfc7fceed782cc9f0dc03486859926bf08cf10481d75/pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:60c87b02e81f20fc621517bfc1359dd4f5f75e54e384456e583d9e7b8b728c88", size = 7305551, upload-time = "2026-04-19T17:45:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/72/b9/cac4251a33ec43918d018b8718aa0de00a70f374583f4a63002c072a60de/pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:dd0b67dab0fcfe1e4371b7e8e0527e4c7f1cd010d41596ba2e8a7c4aa98b476d", size = 7756871, upload-time = "2026-04-19T17:45:46.157Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b8/f5510575bbdbdd286068d6d01ed6f7fac957d42454f69f933d038ab3ff97/pydantic_monty-0.0.16-cp314-cp314-win32.whl", hash = "sha256:300bba8175bd1b92a14de19e91315e343181e3ff248990874ddb6e29a78749c5", size = 7213168, upload-time = "2026-04-19T17:45:17.07Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/63/4697d1fcbf5783c583d011d008c4e8827cc0df5a93b97e896acd688f536a/pydantic_monty-0.0.16-cp314-cp314-win_amd64.whl", hash = "sha256:adac06c7e412504fd02d16a258d39d0e8e5a82e99158caa18f0d519ba96b393d", size = 8048722, upload-time = "2026-04-19T17:44:50.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/31/95827babdb35149f076c5d191b6b1e7a7c58f4bc72432f905e02e4e3231e/pydantic_monty-0.0.17-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:27c2254fa7a7b05e969f79578889230d293c62e0b1ee28371ec4f3c54b14426a", size = 7342248, upload-time = "2026-04-22T20:15:18.775Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/67/ca9cfc07cd445d22def53e9db86912f9ae3e11ef772ce41c2ff41a47eac5/pydantic_monty-0.0.17-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:445cc471ce6f5a88ef06741b7ebc7002a2253d182f55a2f47094d4adedaaf497", size = 7311255, upload-time = "2026-04-22T20:15:27.913Z" },
+    { url = "https://files.pythonhosted.org/packages/df/96/abc9c4972d91a9673435b84e12b99d038e42d1f99648fc9e5f242e09d00e/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:39121038405911f59da7bf61164251f59bad3fb1b0cd28f43c42c3949eee2c8a", size = 7868109, upload-time = "2026-04-22T20:15:04.779Z" },
+    { url = "https://files.pythonhosted.org/packages/75/82/9e4d55529bb99d882b9277a721762537a8bc1345ab1d052bb614a88bd15b/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dafc8ffe57c257002f623afdb7d0e41f73de850179ebd90b42611e4f2b6f9884", size = 7139709, upload-time = "2026-04-22T20:15:25.386Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/f1af6acefb7bb38d73934d6853998bbd327de7418b811372519080d9fd84/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ea00838ef8f37dcd8085defcbdfe89fdd05297a6533f1d3f4cad857d13cedc7b", size = 7450444, upload-time = "2026-04-22T20:13:37.974Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/91/af92ef409e1c065345cf1451bbcf19e00f70a250b8372ec65143ca9a9238/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:683d18089acf14d0de293245b9e37c7f0ec64e6d266f6773144211931aa3ec97", size = 7967525, upload-time = "2026-04-22T20:13:42.674Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1f/23ecd6e268ef24ce6b0fe4a1e76a314990d2e923ac5791e29d657418243d/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1829993dd50cf497cbed66ea9f6c8ff7d157d22592a05c7399f92fb8a549e3c", size = 8199124, upload-time = "2026-04-22T20:15:00.02Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2a/36b694ea0c7e202250a81a57faf00f218738da6c5d070c752f2d81cd34ce/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a7869e3f41a54cc588096c52a8a4de25ecd81e75c867ea4164b14ea1ae1a57f", size = 7739623, upload-time = "2026-04-22T20:14:37.57Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e5/090357d7bc0f0751d1afbb71330695fa26554699c88ba56ecaad91657088/pydantic_monty-0.0.17-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f9c17663e2c6f07aec5bc54cd7e39a9e20f250a97a9081e1b2b932eb00d0afc5", size = 7317755, upload-time = "2026-04-22T20:14:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/15/63/67200070cf33325ecfda81d4aee3bf312250ce80bd73058103e04e0f3587/pydantic_monty-0.0.17-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5d2cf98afe2fb124f6ade91d9663d54277478cad417164f83df1854a41ef450c", size = 7769158, upload-time = "2026-04-22T20:14:39.611Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/9ecfbc2f45406cfb247fafdea4f4a8412db3e559a22c4385eb15266ba2c1/pydantic_monty-0.0.17-cp312-cp312-win32.whl", hash = "sha256:b2185cc4effbbd6793eed4e0f0bcb6a3dbfbb3289ea4d47888708813f0a3dd47", size = 7227917, upload-time = "2026-04-22T20:14:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/80/9be3bef8273817ccc17da25c3ce4ff5d5d45e5629c17eacc90cdef073821/pydantic_monty-0.0.17-cp312-cp312-win_amd64.whl", hash = "sha256:7833daed757ec9b09b627cc3577a4a76b114c5148f779531d7cfdb1095bcf0a9", size = 8043469, upload-time = "2026-04-22T20:13:22.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/44/0e106b8b27eb93b66e4f3d279486464e05ba5ee31088848e58b5f506f879/pydantic_monty-0.0.17-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e0cdac8c3c16477596bc96ee1cec4f2fbaccd089e2daa1e7b9f227cc89f97cb1", size = 7341507, upload-time = "2026-04-22T20:14:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/88/a0315fa08e62e2d1ef00c03d8202d7bef3f1f71543bebfb916fea265c0a2/pydantic_monty-0.0.17-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37290d6a1c35aba5cfb8b490bb31c0d822e8ddca8f3ca9ea068e30930d80dd1e", size = 7311916, upload-time = "2026-04-22T20:13:34.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e5/e4da6acb408594cbfbfb8dd3c0491b9b2ee54e9183e7ebc5f584baa07af9/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:49f252b2fb918686d3e8f76cb30245e782d1560a7fa68dbc0f6940d83c12bd41", size = 7867465, upload-time = "2026-04-22T20:13:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/64c2f8eb708a743b0944ea8f71dfd51bc655285b4be28d55577dafbb29fa/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2254d25c34463d67069f5f1567157bde9311654cd5371f8933b8ea9815bfa26a", size = 7139262, upload-time = "2026-04-22T20:14:10.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/67/5d766f9cd304e871a5dfe5f0a85eaa533538ef07e9b2858fdf9f37f83694/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0688a1fa5dc045ac7b7e996d7269b94f74f116d7b1e352c7b5bb5ad53d4fe03", size = 7450119, upload-time = "2026-04-22T20:13:44.515Z" },
+    { url = "https://files.pythonhosted.org/packages/33/98/fa16779021d93edb19807e87cdba56bbec6adfad21f10b41a212572ce513/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b35121ac555ed201405c69d531e4cb916da6984b8cd2e15c8a319117349faf6", size = 7967398, upload-time = "2026-04-22T20:13:55.576Z" },
+    { url = "https://files.pythonhosted.org/packages/92/64/287a42720bc9e975ab5b52625aa9fc6bcef8298dd821022cc45c6ee1808d/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c97dc44af25d4392b474902fc40f78f09fe8f44ba791364670334fe12abc077", size = 8198835, upload-time = "2026-04-22T20:15:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/97/37/03edb1fd582b79b2b462afc3fea5e1c8fea73afefc4870dc35fc3c7c492e/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ed2fb365ef9ca921de9a17786ecfa2efe06e65678e6ca57be51658a2a880f31", size = 7739241, upload-time = "2026-04-22T20:13:46.925Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/b765c9ca2ae27def1caa07345aba073ae1239fc2d9cca7a375f3dc2195f7/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5bf9f07b38dd12747e3c95b169a5afb3e2e9107622e01e548246c84d19a69c99", size = 7316719, upload-time = "2026-04-22T20:14:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3b/64fe872cd575ab5262e1ba2959554ead198c939cfaa425f7f8e9b1ad2694/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a5e9bafd4b5acbc0a8e12ee8403a3ce37281c3b0fa5909d3f412bee76c69003c", size = 7769150, upload-time = "2026-04-22T20:13:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/b6a0bb41f39bac2e11e6a2fd42ca0886893fafa6344fb17c3f0a94e22e83/pydantic_monty-0.0.17-cp313-cp313-win32.whl", hash = "sha256:1c239ae3e610d3f39cd1609285209a4e2d046b465ac1bfed0d4374c615eed0fa", size = 7227705, upload-time = "2026-04-22T20:15:12.262Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e7/d8cd62f537f7ab17714ee19ea221a0e341dab407215376ab1c41d79794c9/pydantic_monty-0.0.17-cp313-cp313-win_amd64.whl", hash = "sha256:1886c3590b02f359ae991f1e76691064f167330eda4fbf22762127ce17d0eb48", size = 8043469, upload-time = "2026-04-22T20:14:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c0/8354baf835e1a04c4b9e11d253f82df7d625a9305e6a23a177fb895b1484/pydantic_monty-0.0.17-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a166bd04d1996f0d144fbb5e1391cd1c0fbdacd4fa3b689dd48931388679fe98", size = 7341303, upload-time = "2026-04-22T20:14:35.653Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ac/d58221b5e17915421ca00bb08b805ac121b6accb194785d5422da4a2f5fc/pydantic_monty-0.0.17-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d82f319e3fd79707a7b81bbb68596509d14ac73502d2f0daf4ab5d281efdfbdc", size = 7318912, upload-time = "2026-04-22T20:13:59.966Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3f/8eeb8f652f6cd6e06a737aa9f00de2949e37a669b31756bc51b6182457b4/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f38b9875f7ff56fe69538b60b2ecbdcbe2b8b7780407ceb05fe0ee1414bf8d19", size = 7867027, upload-time = "2026-04-22T20:13:51.426Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/ec6620c27c8b4cada6ce53378c52c245e238e50a20b968cafdc1b8573c4e/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74a778bb5a4dcdbc85b3b9002f9a72a43fb6ffd88635bfdd502e8d3053008337", size = 7137542, upload-time = "2026-04-22T20:13:35.939Z" },
+    { url = "https://files.pythonhosted.org/packages/41/78/5419785630511b54b15cfb094871bcb53ec9025ba8d91bd7ab5b22b6c98f/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e2ab074a65738e9c1b4be9a432e7ca1e9987a6706018dc7a5af6d4ce7cecdf3", size = 7450222, upload-time = "2026-04-22T20:13:53.378Z" },
+    { url = "https://files.pythonhosted.org/packages/61/04/cec11fa96a47034da3c21af53e73f43d2270f5ce96cd710809859fe9c0b2/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00fd1cd28b4200c9ccd02629868486b366af1bfe1f0584d4c9e513b7a941a868", size = 7967405, upload-time = "2026-04-22T20:14:03.826Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e3/f2be0fb975100b6936ca36a8410098f10fab3b26729c0b0d1de2fac59ff3/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ea6684555bfd00cbe9d2df3e73caada3d82200c168c63cc475197b55b88401", size = 8199028, upload-time = "2026-04-22T20:13:26.802Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/43/358bdaa9c50d21fe4a25a71d43ce9af2d6796616fa47aca84f807433564e/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f804a03a3bbd0cf0ade1d4ce11b50ca6858e9c4440b27c746faf1d3c0a272954", size = 7749903, upload-time = "2026-04-22T20:15:09.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/8bcd0a78abf13edceca36aaf5c180fad963e4c2e042fd7247b9e96048306/pydantic_monty-0.0.17-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:b5476e6c08b86b0bea554b97ce9b142aac1177447f2d3c5751864b27991fd1b1", size = 7312704, upload-time = "2026-04-22T20:14:33.668Z" },
+    { url = "https://files.pythonhosted.org/packages/88/49/5de8bb7f8b82c3ebb8f2485e0b7a40055b072193039d95dcb5d35fcba72c/pydantic_monty-0.0.17-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b5fcdcca45439844bee268686f37226dbf5803ec7a5945f5536c41419f151dac", size = 7768902, upload-time = "2026-04-22T20:14:29.389Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7c/500a002f1a52f17c8b8a989875da3e1590c18ce95c89856aa967e2348a36/pydantic_monty-0.0.17-cp314-cp314-win32.whl", hash = "sha256:4dd3e6e80a415e7272f7a7583a4f8e045096653f6074e181117eb61fc8fe3b45", size = 7227049, upload-time = "2026-04-22T20:14:01.871Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/b8f552f2a863778f49ebb708f18aaf0bfb275480a48965786e06efacf1c4/pydantic_monty-0.0.17-cp314-cp314-win_amd64.whl", hash = "sha256:36a8090a628e8cf91df8f66c721a71050ac8f48473d4992b9afbd9585941a647", size = 8062999, upload-time = "2026-04-22T20:14:44.006Z" },
 ]
 
 [[package]]
@@ -1502,15 +1505,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.404"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/6e/026be64c43af681d5632722acd100b06d3d39f383ec382ff50a71a6d5bce/pyright-1.1.404.tar.gz", hash = "sha256:455e881a558ca6be9ecca0b30ce08aa78343ecc031d37a198ffa9a7a1abeb63e", size = 4065679, upload-time = "2025-08-20T18:46:14.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/30/89aa7f7d7a875bbb9a577d4b1dc5a3e404e3d2ae2657354808e905e358e0/pyright-1.1.404-py3-none-any.whl", hash = "sha256:c7b7ff1fdb7219c643079e4c3e7d4125f0dafcc19d253b47e898d130ea426419", size = 5902951, upload-time = "2025-08-20T18:46:12.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -1821,7 +1824,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1" },
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastmcp", extras = ["code-mode"], specifier = "==3.3.1" },
+    { name = "fastmcp", extras = ["code-mode"], specifier = "==3.4.4" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "msgpack", specifier = ">=1.2.1" },
@@ -1845,7 +1848,7 @@ dev = [
     { name = "bandit", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pip-audit", specifier = ">=2.7.0" },
-    { name = "pyright", specifier = ">=1.1.404" },
+    { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

Adds read-only access to Rootly's meeting-recordings endpoints so agents can retrieve call transcripts — the same data as the `meeting_transcript` / `meeting_transcript_formatted` liquid variables. Also lands the dev-tooling this surfaced (Makefile, spec-refresh workflow).

| Tool | Endpoint | Returns |
|---|---|---|
| `get_meeting_recording` | `GET /v1/meeting_recordings/{id}` | metadata + transcript summary; **full transcript with `include=transcript`** |
| `list_meeting_recordings` | `GET /v1/incidents/{incident_id}/meeting_recordings` | incident-scoped list |
| `list_all_meeting_recordings` | `GET /v1/meeting_recordings` | org-wide list |

## Commits

1. **`build: add Makefile and wire dev tooling`** — Makefile mirroring CI (`make check` = lint + format-check + typecheck + unit tests; `make ci` adds security scan + OpenAPI audit; plus build/test/docker/`fetch-spec`). The pre-commit hook now delegates to `make check`, and CONTRIBUTING documents the targets + the "regenerate, never hand-edit swagger.json" rule.
2. **`chore: migrate dev dependencies to PEP 735 dependency-groups`** — `[tool.uv] dev-dependencies` → `[dependency-groups] dev`, clearing the deprecation warning that printed on every `uv` command.
3. **`chore: refresh data/swagger.json from source spec`** — stale snapshot (248 paths) → regenerated via `make fetch-spec` (274 paths). Brings in the meeting-recordings endpoints and the `include=transcript` query param. Large but faithful diff; committed file matches `make fetch-spec` output byte-for-byte.
4. **`feat: expose meeting recordings and transcripts`** — allowlist the three read paths, add `get_meeting_recording` + `list_meeting_recordings` to the slim hosted profile, tests + CHANGELOG.

## Scope / safety

Only `GET` is exposed. Destructive/control verbs — `DELETE /meeting_recordings/{id}`, and the `start_session` / `pause` / `resume` / `stop` / `leave` POSTs — are **not** allowlisted (excluded by the delete/write policies).

## Verification

- `make check` green: `ruff` lint + format, `pyright` (0 errors), `mypy` (clean), unit tests (497 passed). Full suite: **527 passed, 13 skipped**.
- `uv sync --dev` resolves cleanly post-migration (no deprecation warning); `uv.lock` unchanged.
- `make fetch-spec` idempotent; `make audit-spec` reports ok.
- Tool registration: all three present; `get_meeting_recording` exposes `include` (enum `["transcript"]`); slim profile validates 74/74.