### PR TITLE
feat: add MCP tool annotations and address directory review feedback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
 
 [tool.uv]
 dev-dependencies = [
-    "pyright>=1.1.404",
+    "pyright>=1.1.411",
     "ruff>=0.7.3",
     "pytest>=9.0.3",
     "pytest-cov>=4.0.0", # Coverage reporting

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -126,7 +126,9 @@ def _apply_annotations_to_autogen_tools(mcp: FastMCP, openapi_spec: dict[str, An
 
     annotated_count = 0
     for tool_name in autogen_names:
-        method = op_id_to_method.get(tool_name, "get")
+        method = op_id_to_method.get(tool_name)
+        if method is None:
+            continue
         tool = autogen_provider._tools.get(tool_name)
         if tool is None:
             continue

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -104,9 +104,7 @@ def _provider_tool_inventory(
     return curated_names, autogen_provider, autogen_names
 
 
-def _apply_annotations_to_autogen_tools(
-    mcp: FastMCP, openapi_spec: dict[str, Any]
-) -> None:
+def _apply_annotations_to_autogen_tools(mcp: FastMCP, openapi_spec: dict[str, Any]) -> None:
     """Apply ToolAnnotations to autogen OpenAPI tools based on their HTTP method.
 
     GET operations are marked read-only; POST/PUT/PATCH are non-destructive writes;

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -104,6 +104,64 @@ def _provider_tool_inventory(
     return curated_names, autogen_provider, autogen_names
 
 
+def _apply_annotations_to_autogen_tools(
+    mcp: FastMCP, openapi_spec: dict[str, Any]
+) -> None:
+    """Apply ToolAnnotations to autogen OpenAPI tools based on their HTTP method.
+
+    GET operations are marked read-only; POST/PUT/PATCH are non-destructive writes;
+    DELETE operations are marked destructive. All autogen tools interact with
+    external APIs so openWorldHint is True.
+    """
+    _, autogen_provider, autogen_names = _provider_tool_inventory(mcp)
+    if autogen_provider is None:
+        return
+
+    op_id_to_method: dict[str, str] = {}
+    for _path, path_item in openapi_spec.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            op_id = operation.get("operationId")
+            if op_id:
+                op_id_to_method[op_id] = method.lower()
+
+    annotated_count = 0
+    for tool_name in autogen_names:
+        method = op_id_to_method.get(tool_name, "get")
+        tool = autogen_provider._tools.get(tool_name)
+        if tool is None:
+            continue
+
+        if method == "get":
+            tool.annotations = mt.ToolAnnotations(readOnlyHint=True, openWorldHint=True)
+        elif method == "delete":
+            tool.annotations = mt.ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=True,
+                idempotentHint=True,
+                openWorldHint=True,
+            )
+        elif method in {"put", "patch"}:
+            tool.annotations = mt.ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            )
+        else:
+            tool.annotations = mt.ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            )
+        annotated_count += 1
+
+    if annotated_count:
+        logger.info("Applied annotations to %d autogen tool(s)", annotated_count)
+
+
 def _remove_autogen_tools_shadowed_by_curated(mcp: FastMCP) -> None:
     """Drop autogen tools whose name a curated `@mcp.tool` registration provides.
 
@@ -755,7 +813,9 @@ def create_rootly_mcp_server(
 
     # Add some custom tools for enhanced functionality
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=mt.ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+    )
     def list_endpoints() -> list:
         """List all available Rootly API endpoints with their descriptions."""
         endpoints = []
@@ -778,7 +838,9 @@ def create_rootly_mcp_server(
 
         return endpoints
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=mt.ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+    )
     def get_server_version() -> dict:
         """Get the Rootly MCP server version.
 
@@ -879,6 +941,11 @@ def create_rootly_mcp_server(
     # A curated tool and an autogen tool can resolve to the same name; drop the
     # autogen duplicate so only the richer curated implementation is surfaced.
     _remove_autogen_tools_shadowed_by_curated(mcp)
+
+    # Apply MCP tool annotations (readOnlyHint, destructiveHint, etc.) to
+    # autogen tools based on HTTP method. Curated tools set their own annotations
+    # via @mcp.tool(annotations=...) at registration time.
+    _apply_annotations_to_autogen_tools(mcp, filtered_spec)
 
     # Validate the allowlist against the fully-registered tool set (autogen + curated).
     # This must happen after all register_*_tools() calls so curated tool names — which

--- a/src/rootly_mcp_server/tools/alerts.py
+++ b/src/rootly_mcp_server/tools/alerts.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Protocol
 from urllib.parse import quote
 
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 JsonDict = dict[str, Any]
@@ -33,7 +34,9 @@ def register_alert_tools(
 ) -> None:
     """Register alert tools on the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def get_alert_by_short_id(
         short_id: Annotated[
             str,

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -7,6 +7,7 @@ import re
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Literal, cast
 
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from ..smart_utils import SolutionExtractor, TextSimilarityAnalyzer
@@ -327,7 +328,9 @@ def register_incident_tools(
 
         return params, filters
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def list_incidents(
         query: Annotated[
             str,
@@ -451,7 +454,9 @@ def register_incident_tools(
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(JsonDict, mcp_error.tool_error(error_message, error_type))
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def collect_incidents(
         query: Annotated[
             str,
@@ -609,7 +614,9 @@ def register_incident_tools(
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(JsonDict, mcp_error.tool_error(error_message, error_type))
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def search_incidents(
         query: Annotated[
             str, Field(description="Search query to filter incidents by title/summary")
@@ -742,16 +749,18 @@ def register_incident_tools(
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(JsonDict, mcp_error.tool_error(error_message, error_type))
 
-    @mcp.tool(name="get_incident")
+    @mcp.tool(
+        name="get_incident",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def get_incident(
         incident_id: Annotated[
             str,
             Field(
                 description=(
                     "Incident reference to retrieve. "
-                    "ARGUMENT NAME IS `incident_id` (not `id`). "
-                    "Accepts: UUID (`7e83d9f4-6bc1-...`), bare sequential number "
-                    "(`4460`), `#4460`, or `INC-4460`."
+                    "Accepts: UUID, bare sequential number "
+                    "(4460), #4460, or INC-4460."
                 )
             ),
         ],
@@ -797,16 +806,18 @@ def register_incident_tools(
                 ),
             )
 
-    @mcp.tool(name="list_incident_roles")
+    @mcp.tool(
+        name="list_incident_roles",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def list_incident_roles(
         incident_id: Annotated[
             str,
             Field(
                 description=(
                     "Incident reference whose role assignments to list. "
-                    "ARGUMENT NAME IS `incident_id` (not `id`). "
-                    "Accepts: UUID, bare sequential number (`4460`), "
-                    "`#4460`, or `INC-4460`."
+                    "Accepts: UUID, bare sequential number (4460), "
+                    "#4460, or INC-4460."
                 )
             ),
         ],
@@ -917,7 +928,15 @@ def register_incident_tools(
 
     if enable_write_tools:
 
-        @mcp.tool(name="create_incident")
+        @mcp.tool(
+            name="create_incident",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=False,
+                openWorldHint=True,
+            ),
+        )
         async def create_incident(
             title: Annotated[
                 str | None,
@@ -1011,7 +1030,15 @@ def register_incident_tools(
                     ),
                 )
 
-        @mcp.tool(name="update_incident")
+        @mcp.tool(
+            name="update_incident",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=True,
+            ),
+        )
         async def update_incident(
             incident_id: Annotated[
                 str,
@@ -1088,7 +1115,9 @@ def register_incident_tools(
                     ),
                 )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def find_related_incidents(
         incident_id: str = "",
         incident_description: str = "",
@@ -1245,7 +1274,9 @@ def register_incident_tools(
                 ),
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def suggest_solutions(
         incident_id: str = "",
         incident_title: str = "",

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any, Protocol, cast
 
 import httpx
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from ..och_client import OnCallHealthClient
@@ -101,7 +102,9 @@ def register_oncall_tools(
 ) -> None:
     """Register on-call analysis and scheduling tools on the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def get_oncall_shift_metrics(
         start_date: Annotated[
             str,
@@ -479,7 +482,9 @@ def register_oncall_tools(
                 },
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def get_oncall_handoff_summary(
         team_ids: Annotated[
             str,
@@ -491,7 +496,7 @@ def register_oncall_tools(
         timezone: Annotated[
             str,
             Field(
-                description="Timezone to use for display and filtering (e.g., 'America/Los_Angeles', 'Europe/London', 'Asia/Tokyo'). IMPORTANT: If user mentions a city, location, or region (e.g., 'Toronto', 'APAC', 'my time'), infer the appropriate IANA timezone. Defaults to UTC if not specified."
+                description="IANA timezone for display and filtering (e.g., 'America/Los_Angeles', 'Europe/London', 'Asia/Tokyo'). Defaults to UTC."
             ),
         ] = "UTC",
         filter_by_region: Annotated[
@@ -511,15 +516,9 @@ def register_oncall_tools(
         Get current on-call handoff summary. Shows who's currently on-call and who's next.
         Optionally fetch incidents (set include_incidents=True, but slower).
 
-        Timezone handling: If user mentions their location/timezone, infer it (e.g., "Toronto" → "America/Toronto",
-        "my time" → ask clarifying question or use a common timezone).
-
-        Regional filtering: Use timezone + filter_by_region=True to see only people on-call
+        Use filter_by_region=True with a timezone to see only people on-call
         during business hours in that region (e.g., timezone='Asia/Tokyo', filter_by_region=True
         shows only APAC on-call during APAC business hours).
-
-        Performance: By default, incidents are NOT fetched for faster response. Set include_incidents=True
-        to fetch incidents for each shift (slower, may timeout with many schedules).
 
         Useful for:
         - Quick on-call status checks
@@ -1176,7 +1175,9 @@ def register_oncall_tools(
                 },
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def get_shift_incidents(
         start_time: Annotated[
             str,
@@ -1393,7 +1394,9 @@ def register_oncall_tools(
 
             return result
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def list_shifts(
         from_date: Annotated[
             str,
@@ -1604,24 +1607,21 @@ def register_oncall_tools(
                 },
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def get_oncall_schedule_summary(
         start_date: Annotated[
             str,
-            Field(description="REQUIRED. Start date (ISO 8601, e.g., '2026-02-09')"),
+            Field(description="Start date (ISO 8601, e.g., '2026-02-09')"),
         ],
         end_date: Annotated[
             str,
-            Field(description="REQUIRED. End date (ISO 8601, e.g., '2026-02-15')"),
+            Field(description="End date (ISO 8601, e.g., '2026-02-15')"),
         ],
         schedule_ids: Annotated[
             str,
-            Field(
-                description=(
-                    "Comma-separated schedule IDs to filter (optional). "
-                    "NOTE: argument name is `schedule_ids` (plural), not `schedule_id`."
-                )
-            ),
+            Field(description="Comma-separated schedule IDs to filter (optional)"),
         ] = "",
         team_ids: Annotated[
             str,
@@ -1634,9 +1634,6 @@ def register_oncall_tools(
     ) -> dict:
         """
         Get compact on-call schedule summary for a date range.
-
-        REQUIRED ARGUMENTS: start_date, end_date (both ISO 8601 date strings).
-        Optional: schedule_ids (comma-separated, plural), team_ids.
 
         Returns one entry per user per schedule (not raw shifts), with
         aggregated hours. Optimized for AI agent context windows.
@@ -1870,7 +1867,9 @@ def register_oncall_tools(
                 },
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def check_responder_availability(
         start_date: Annotated[
             str,
@@ -1885,18 +1884,13 @@ def register_oncall_tools(
             Field(
                 description=(
                     "Comma-separated Rootly user IDs to check (e.g., '2381,94178,27965'). "
-                    "REQUIRED — this tool does not accept email lookup. Resolve emails "
-                    "to numeric user IDs first via `listUsers` with `filter[email]`."
+                    "Accepts numeric IDs only — use list_users with filter[email] to resolve emails to IDs first."
                 )
             ),
         ],
     ) -> dict:
         """
         Check if specific users are scheduled for on-call in a date range.
-
-        REQUIRED ARGUMENTS: start_date (ISO 8601), end_date (ISO 8601), user_ids
-        (comma-separated numeric IDs — not emails). Resolve emails to user IDs
-        via `listUsers` filtered by email before calling this.
 
         Use this to verify if at-risk users (from On-Call Health) are scheduled,
         or to check availability before assigning new shifts.
@@ -2052,7 +2046,9 @@ def register_oncall_tools(
                 },
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def create_override_recommendation(
         schedule_id: Annotated[
             str,
@@ -2296,7 +2292,9 @@ def register_oncall_tools(
                 },
             )
 
-    @mcp.tool()
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def check_oncall_health_risk(
         start_date: Annotated[
             str,
@@ -2326,6 +2324,12 @@ def register_oncall_tools(
         Integrates with On-Call Health (oncallhealth.ai) to identify responders with elevated
         workload health risk and checks if they are scheduled during the specified period.
         Optionally recommends safe replacement responders.
+
+        Privacy: This tool surfaces identifiable employee workload health data from On-Call Health.
+        It is an opt-in feature — an administrator must explicitly configure the ONCALLHEALTH_API_KEY
+        environment variable to enable it. On-Call Health displays a visible indicator on each
+        responder's profile page showing their health score and risk level, ensuring employees
+        are aware that workload analytics are collected and visible to their organization.
 
         Requires ONCALLHEALTH_API_KEY environment variable.
         """

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1610,3 +1610,107 @@ class TestOAuthProtectedResourceRoute:
             routes = server._get_additional_http_routes()
             route_paths = [getattr(r, "path", None) for r in routes]
             assert OAUTH_PROTECTED_RESOURCE_PATH not in route_paths
+
+
+@pytest.mark.unit
+class TestApplyAnnotationsToAutogenTools:
+    """Tests for _apply_annotations_to_autogen_tools."""
+
+    @staticmethod
+    def _make_mock_mcp(tool_names: list[str]) -> tuple[Any, dict[str, Any]]:
+        """Build a mock FastMCP with an autogen provider holding named tools."""
+        tools = {}
+        for name in tool_names:
+            tool = SimpleNamespace(annotations=None)
+            tools[name] = tool
+
+        autogen_provider = SimpleNamespace(_tools=tools)
+        mcp = SimpleNamespace(providers=[autogen_provider])
+        return mcp, tools
+
+    def test_get_marked_read_only(self):
+        mcp, tools = self._make_mock_mcp(["list_items"])
+        spec = {"paths": {"/items": {"get": {"operationId": "list_items"}}}}
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        ann = tools["list_items"].annotations
+        assert ann.readOnlyHint is True
+        assert ann.openWorldHint is True
+
+    def test_post_marked_write_non_idempotent(self):
+        mcp, tools = self._make_mock_mcp(["create_item"])
+        spec = {"paths": {"/items": {"post": {"operationId": "create_item"}}}}
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        ann = tools["create_item"].annotations
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is False
+        assert ann.openWorldHint is True
+
+    def test_put_marked_idempotent(self):
+        mcp, tools = self._make_mock_mcp(["update_item"])
+        spec = {"paths": {"/items/{id}": {"put": {"operationId": "update_item"}}}}
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        ann = tools["update_item"].annotations
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is True
+
+    def test_patch_marked_idempotent(self):
+        mcp, tools = self._make_mock_mcp(["patch_item"])
+        spec = {"paths": {"/items/{id}": {"patch": {"operationId": "patch_item"}}}}
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        ann = tools["patch_item"].annotations
+        assert ann.readOnlyHint is False
+        assert ann.idempotentHint is True
+
+    def test_delete_marked_destructive(self):
+        mcp, tools = self._make_mock_mcp(["delete_item"])
+        spec = {"paths": {"/items/{id}": {"delete": {"operationId": "delete_item"}}}}
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        ann = tools["delete_item"].annotations
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is True
+        assert ann.idempotentHint is True
+        assert ann.openWorldHint is True
+
+    def test_unknown_tool_skipped(self):
+        mcp, tools = self._make_mock_mcp(["mystery_tool"])
+        spec = {"paths": {"/items": {"get": {"operationId": "list_items"}}}}
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        assert tools["mystery_tool"].annotations is None
+
+    def test_no_autogen_provider_is_noop(self):
+        mcp = SimpleNamespace(providers=[SimpleNamespace(_components={})])
+        server_module._apply_annotations_to_autogen_tools(mcp, {"paths": {}})
+
+    def test_multiple_methods_all_annotated(self):
+        mcp, tools = self._make_mock_mcp(["list_items", "create_item", "delete_item"])
+        spec = {
+            "paths": {
+                "/items": {
+                    "get": {"operationId": "list_items"},
+                    "post": {"operationId": "create_item"},
+                },
+                "/items/{id}": {
+                    "delete": {"operationId": "delete_item"},
+                },
+            }
+        }
+
+        server_module._apply_annotations_to_autogen_tools(mcp, spec)
+
+        assert tools["list_items"].annotations.readOnlyHint is True
+        assert tools["create_item"].annotations.readOnlyHint is False
+        assert tools["delete_item"].annotations.destructiveHint is True

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1693,7 +1693,7 @@ class TestApplyAnnotationsToAutogenTools:
 
     def test_no_autogen_provider_is_noop(self):
         mcp = SimpleNamespace(providers=[SimpleNamespace(_components={})])
-        server_module._apply_annotations_to_autogen_tools(mcp, {"paths": {}})
+        server_module._apply_annotations_to_autogen_tools(mcp, {"paths": {}})  # type: ignore[arg-type]
 
     def test_multiple_methods_all_annotated(self):
         mcp, tools = self._make_mock_mcp(["list_items", "create_item", "delete_item"])


### PR DESCRIPTION
## Summary

- Add `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all 21 curated tools and auto-apply annotations to autogen OpenAPI tools based on HTTP method
- Remove model-directed imperatives (`ARGUMENT NAME IS`, `REQUIRED`, `IMPORTANT`, `NOTE`) from parameter descriptions per MCP directory review feedback
- Add privacy disclosure to `check_oncall_health_risk` documenting the admin opt-in mechanism (ONCALLHEALTH_API_KEY env var) and On-Call Health's employee-visible profile indicator
- Confirm `context` parameter (flagged by reviewer) is already absent from all tools — no changes needed

## Test plan

- [x] All 527 existing tests pass
- [ ] Verify annotations appear in `tools/list` response
- [ ] Verify autogen tools get correct annotations based on HTTP method (GET→readOnly, DELETE→destructive, POST→write, PUT/PATCH→idempotent)
- [ ] Verify cleaned parameter descriptions still render correctly in MCP clients