### PR TITLE
chore(deps): bump vulnerable transitive dependencies (mcp, joserfc, idna, click)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pyjwt` 2.12.1 → 2.13.0 (GHSA-xgmm-8j9v-c9wx, -993g-76c3-p5m4, -w7vc-732c-9m39, -jq35-7prp-9v3f, -fhv5-28vv-h8m8 — token forgery / DoS)
   - `msgpack` 1.1.2 → 1.2.1 (GHSA-6v7p-g79w-8964 — out-of-bounds read)
   - `authlib` 1.7.0 → 1.7.2 (GHSA-w8p2-r796-3vmq — OAuth open redirect)
+- **Follow-up Dependency Bumps**: Raised override constraints for newly disclosed vulnerabilities in transitive dependencies (`uv.lock` regenerated):
+  - `mcp` 1.26.0 → 1.28.1 (CVE-2026-52870, CVE-2026-52869, CVE-2026-59950)
+  - `joserfc` 1.6.4 → 1.7.4 (PYSEC-2026-2528, PYSEC-2026-2530)
+  - `idna` 3.10 → 3.18 (PYSEC-2026-215)
+  - `click` 8.1.8 → 8.4.2 (PYSEC-2026-2132)
 
 ### Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ dependencies = [
     "pyjwt>=2.13.0",  # Override vulnerable transitive pyjwt (GHSA-xgmm-8j9v-c9wx and others)
     "msgpack>=1.2.1",  # Override vulnerable transitive msgpack (GHSA-6v7p-g79w-8964)
     "starlette>=1.3.1",  # Override vulnerable transitive starlette (GHSA-82w8-qh3p-5jfq and others)
+    "mcp>=1.28.1",  # Override vulnerable transitive mcp (CVE-2026-52870, CVE-2026-52869, CVE-2026-59950)
+    "joserfc>=1.6.8",  # Override vulnerable transitive joserfc (PYSEC-2026-2528, PYSEC-2026-2530)
+    "idna>=3.15",  # Override vulnerable transitive idna (PYSEC-2026-215)
+    "click>=8.3.3",  # Override vulnerable transitive click (PYSEC-2026-2132)
     "requests==2.34.2", # Pin to patched version
     "httpx==0.28.1",   # Pin to specific version
     "pydantic==2.13.4",  # Pin to specific version

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiofile"
@@ -313,14 +319,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -540,14 +546,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.3.1"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
 ]
 
 [package.optional-dependencies]
@@ -557,7 +563,7 @@ code-mode = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.3.1"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -567,9 +573,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -580,6 +586,7 @@ client = [
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
 ]
 code-mode = [
     { name = "pydantic-monty" },
@@ -590,6 +597,7 @@ server = [
     { name = "exceptiongroup" },
     { name = "griffelib" },
     { name = "httpx" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
@@ -600,6 +608,7 @@ server = [
     { name = "pyperclip" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -672,11 +681,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -762,14 +771,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.4"
+version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]
@@ -917,7 +926,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -935,9 +944,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -1401,49 +1410,49 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.16"
+version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/d2/ddf8381f782e00721feed7000ce1393425dfb82aa8fae95b2cdc50ed4264/pydantic_monty-0.0.16.tar.gz", hash = "sha256:0c4310a3daa8edd3ea3622aed3f72f16042f0909f9b8e6880719feff23e8b10f", size = 1004038, upload-time = "2026-04-19T17:45:20.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/f8/431ba0b79d02922811392c4e3d283d6508f7052ceaa1936cc34878703ecc/pydantic_monty-0.0.17.tar.gz", hash = "sha256:9c4904a8fbc63282793f3afd2d180124494c7fc371783f365e5691c9586360af", size = 1007724, upload-time = "2026-04-22T20:13:48.915Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/14/001815665ad793d334d926cd1a3d0a86ceab9ddb042d63da2dfce4f153b2/pydantic_monty-0.0.16-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f62efa2ebc1305826b646b60e1857a90b0ea8c370788a02b9d40d2ab5d505777", size = 7333666, upload-time = "2026-04-19T17:45:27.915Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/87/22423a512b649ea1ff02d37c72b247b137ef91688a4bda88b5978584d099/pydantic_monty-0.0.16-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4f963ea23bfb352da29dd1976821e1e47162e0e2b98065f092534dde85e41ccb", size = 7293613, upload-time = "2026-04-19T17:45:33.312Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1d/fd31f7bbfbc004970209d4895a176d332f533b0337b75aa774d527a4fd09/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93087d3ec044c5e929f10823fb563e809dbc7c623eb619362872403da7c406a6", size = 7847877, upload-time = "2026-04-19T17:46:02.478Z" },
-    { url = "https://files.pythonhosted.org/packages/91/a7/85b22d367787816ce3637f514df07eef06ec081c566edd6ce59e7a8ea319/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb6cd319731e404bcc190d7867cf0ea1f5bf7124114893e277693f9b8b987201", size = 7134554, upload-time = "2026-04-19T17:44:43.392Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/5e/998a7aeebf3e12640f5300e8e42cc97dcbb4aeb94a4df6846f1704d73d9d/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49e58d4e00d2721560f40ae92998b5b3670166e56db678f7c16853b916d888da", size = 7431773, upload-time = "2026-04-19T17:45:04.834Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/c5/5554c3df0e20be6bb0bf3a59ce96e47238a630156a9ab5f568eeb6370265/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:320d4bc67e58a17a526a2361737de874cc8824c610701551e75b456b7421feb8", size = 7952070, upload-time = "2026-04-19T17:44:51.742Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fa/173e3d8738de03c0ad53aa8f6180d56a10ff62d059b90a47e915fc4db5ce/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a5eda5ecc4841bce0a9a9e1e059b71646a7bd5c990bc106edf717d2ec13d6cd", size = 8178124, upload-time = "2026-04-19T17:45:06.61Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/8c/c879f7d925c09e89e371a00597f6391cb4a547ce63b207897e7ef82e48a1/pydantic_monty-0.0.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa7834fdee5db13f75bfe74ab91ef4d056be643ad841b9cec5338d097c1513ed", size = 7718778, upload-time = "2026-04-19T17:45:38.162Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e3/69741eecc269c12e94dc9c6fc7513e3200aafaf602ca794ea11dadb0d9ee/pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5df4c31ac9d5b91b39eb9cdf81e4fdf1ccfe372fea1f4133cfc02e5654c62a5d", size = 7308908, upload-time = "2026-04-19T17:44:46.98Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f5/a5f010527c59cb8f8c7fe616c17f9016b5fe9ae6e1d077ad2213cd344349/pydantic_monty-0.0.16-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:6f13db1f0c1c970ad6289262273273f9d2e241e141539ad874e06ff0c736d86d", size = 7759289, upload-time = "2026-04-19T17:46:09.222Z" },
-    { url = "https://files.pythonhosted.org/packages/05/4d/ea909241588f38dee4e039c7b40896070f4ea49a71388ff3bf312cbed720/pydantic_monty-0.0.16-cp312-cp312-win32.whl", hash = "sha256:8585dd6a186a3d17d25237ea6f8ea4a8af3717c9503c08a3a582f5e5162e36a6", size = 7213401, upload-time = "2026-04-19T17:46:10.803Z" },
-    { url = "https://files.pythonhosted.org/packages/08/bd/a8cbee968d8df9cae0906de331affee8af33b68772f86c9500f498c74268/pydantic_monty-0.0.16-cp312-cp312-win_amd64.whl", hash = "sha256:326cddda37f0a684a5d8ca54113bd17657bf48399a0e022cdb8ae05581976bce", size = 8035415, upload-time = "2026-04-19T17:44:37.494Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/58/6efd919433d5fb80503a0d6e971ed1b28295a6fe4cba7a4706e9e484fe1b/pydantic_monty-0.0.16-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9615d19bcccd7f4ad95364368cfd74d5451f1eeeb7f0363ad292c56f75bbdac5", size = 7334030, upload-time = "2026-04-19T17:44:55.331Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/cd/d53c86d58983e7203c2ab9ac21defdff4e5b4e2a318a0ae435f825e381bf/pydantic_monty-0.0.16-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9da2475d37d7614691d94b21035ad00161373592df9de2282c2929c00f2504e", size = 7293738, upload-time = "2026-04-19T17:45:11.487Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/64/b085a0b192c8aecec4ad225e6f1895a963ac584b3a2f8970201e70ff5347/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:07372b15eab8996ec6720a8ee4879f7b5fd53dd0589d818550d5244eacd68a96", size = 7847921, upload-time = "2026-04-19T17:44:58.659Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/9a/a169c6f3da169fdb49b7c679b7c9b04b2dc3c9ecff01cc470753a35634ca/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a694ea0501f2ad115ec1b169d7665b554eb9448779fce11727472a4e8378d2c3", size = 7132619, upload-time = "2026-04-19T17:45:09.797Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d9/d04fe911ee70a07e9e30ebbd0a8665acc39c4fd1ba0fa4ca6fe022c113f7/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f00c529865554b5edaefc796c4f52ed3686f91cb9cae2b164428353c2f2a773b", size = 7430974, upload-time = "2026-04-19T17:46:14.641Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cd/3110b6ab4e8b237ce1ca47799d8ee0df409475011502c9ca21392466ca54/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:95be0c370eeea1c185d96ff8d459e510fbce1508115bbed489f8d7b9a79e7505", size = 7951214, upload-time = "2026-04-19T17:45:36.475Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1b/a42f7ae39f99a36d07e03625615fb35685dfa78721c1ff9429e0620cd202/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6edd9338861544e9983a3d8412f27257cb246428b0a6dab945848af0790b294", size = 8177227, upload-time = "2026-04-19T17:44:31.815Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/8b/364cf60bba989a8a50d9127a8f3818437590c435ade07f4e81ddc9bc77a0/pydantic_monty-0.0.16-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:011ab47525340b2802e2aa32ccac92fafc4fb516a48dd07ff563f2cd40203e37", size = 7717367, upload-time = "2026-04-19T17:45:40.103Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/f3/6726e51d8a86aadcc638d26c33643e77d7f1f971475046d55bfc5af3f7fb/pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:e5d25973f2884e0b845d2f028e1f972811c2a98708eb425bf5809747360939ad", size = 7308198, upload-time = "2026-04-19T17:45:02.364Z" },
-    { url = "https://files.pythonhosted.org/packages/69/a1/9fd2cdfc5720b34c822a0b34ad6c555e8d32c2fd6e35b52cdf3eeb2e5820/pydantic_monty-0.0.16-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:944a0ab7e81e4523ff9120f45b0ca22f377ad291d2257d251db02eb25727c5ac", size = 7757710, upload-time = "2026-04-19T17:46:05.935Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/52/8f742f63c10f7bf9696e428ba16970fa76ba8bb4d5cf9d3c19f7973d3d51/pydantic_monty-0.0.16-cp313-cp313-win32.whl", hash = "sha256:e6d4023ee3f0530edf57097ebc004f73d67636b39d2ebb21fca0eaed7bab9977", size = 7213500, upload-time = "2026-04-19T17:46:16.403Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5b/e58bbae39114ffcfefcd9afd87d215f65af2689356bb3100cfe1c85684d4/pydantic_monty-0.0.16-cp313-cp313-win_amd64.whl", hash = "sha256:c7c27b717ccba5a4cdd7321bc3a33fc97aede032784c41a1ce7d5906be04cf44", size = 8035107, upload-time = "2026-04-19T17:46:07.638Z" },
-    { url = "https://files.pythonhosted.org/packages/af/16/43c0c9220590b620fb1283221bb1565d64721666a863a0d1b11d5f617f51/pydantic_monty-0.0.16-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d42f100eda125bded8ba38f17c9998cca2ab645c4a795aa1be4bf754075899c5", size = 7333854, upload-time = "2026-04-19T17:45:53.604Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/56/ecb342362161b47cd8bcc604adaebc035acc87a094be30a31fb62943bf4e/pydantic_monty-0.0.16-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:483ced987c4f0082cdc9980ac7b4ea5882876aa82c548d43944f96f13da9aca6", size = 7307315, upload-time = "2026-04-19T17:45:57.526Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/2f7113aa9ec2566ee0859258a8757a7b521eda012c9629603ae65d59e7f2/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c4c8477264e417475bcaf3ceb4044233407272cefd58356f062a3726e0a32a90", size = 7848117, upload-time = "2026-04-19T17:46:18.129Z" },
-    { url = "https://files.pythonhosted.org/packages/81/a8/101f38b27db1f14bbc5eb6ef8e3cbc0debd22a380f4c42fbedd08ada6c8c/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:751ea6e8f4ae62085b43c2b891ae6e5a072e3ea26486bae2653337e8d132459e", size = 7132076, upload-time = "2026-04-19T17:46:19.733Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/72/f8555b887879e75bb1a69638fe7a0ce4444bc552520759471bbce383bc36/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f29f66645a690e96e9a1b892c0c0c0736341d32251ec5035612259ca03d2102", size = 7432492, upload-time = "2026-04-19T17:44:53.533Z" },
-    { url = "https://files.pythonhosted.org/packages/44/38/2af6af1f99de9db2d69da0304bb98751e643f45a0649d3fcb261e04dea03/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ffc6730b0ed5f6f3c88f8f719df3925bfa77abb71d0259c7f175b9be79b25cfe", size = 7951882, upload-time = "2026-04-19T17:45:15.014Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/92/e51dd904ffb683557fd0f1d1527bc0dbe56d7d4bed0eacbabad51d62087d/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d9a79337e78f3182ae029714c634c33f15dee3c75a14b0fa2c54caf041433120", size = 8177474, upload-time = "2026-04-19T17:45:34.903Z" },
-    { url = "https://files.pythonhosted.org/packages/46/22/d2f27bc1a5a057bb83c40a1b6d61950d2be63dd02aeaa2d2efc11d5422e1/pydantic_monty-0.0.16-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6935b421938f31f1414a10980d27f9bd62fbd7b35228253a751ac1488abcac1d", size = 7729472, upload-time = "2026-04-19T17:44:35.557Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/d3/7a604089596bdb1fcfc7fceed782cc9f0dc03486859926bf08cf10481d75/pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:60c87b02e81f20fc621517bfc1359dd4f5f75e54e384456e583d9e7b8b728c88", size = 7305551, upload-time = "2026-04-19T17:45:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/72/b9/cac4251a33ec43918d018b8718aa0de00a70f374583f4a63002c072a60de/pydantic_monty-0.0.16-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:dd0b67dab0fcfe1e4371b7e8e0527e4c7f1cd010d41596ba2e8a7c4aa98b476d", size = 7756871, upload-time = "2026-04-19T17:45:46.157Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b8/f5510575bbdbdd286068d6d01ed6f7fac957d42454f69f933d038ab3ff97/pydantic_monty-0.0.16-cp314-cp314-win32.whl", hash = "sha256:300bba8175bd1b92a14de19e91315e343181e3ff248990874ddb6e29a78749c5", size = 7213168, upload-time = "2026-04-19T17:45:17.07Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/63/4697d1fcbf5783c583d011d008c4e8827cc0df5a93b97e896acd688f536a/pydantic_monty-0.0.16-cp314-cp314-win_amd64.whl", hash = "sha256:adac06c7e412504fd02d16a258d39d0e8e5a82e99158caa18f0d519ba96b393d", size = 8048722, upload-time = "2026-04-19T17:44:50.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/31/95827babdb35149f076c5d191b6b1e7a7c58f4bc72432f905e02e4e3231e/pydantic_monty-0.0.17-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:27c2254fa7a7b05e969f79578889230d293c62e0b1ee28371ec4f3c54b14426a", size = 7342248, upload-time = "2026-04-22T20:15:18.775Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/67/ca9cfc07cd445d22def53e9db86912f9ae3e11ef772ce41c2ff41a47eac5/pydantic_monty-0.0.17-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:445cc471ce6f5a88ef06741b7ebc7002a2253d182f55a2f47094d4adedaaf497", size = 7311255, upload-time = "2026-04-22T20:15:27.913Z" },
+    { url = "https://files.pythonhosted.org/packages/df/96/abc9c4972d91a9673435b84e12b99d038e42d1f99648fc9e5f242e09d00e/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:39121038405911f59da7bf61164251f59bad3fb1b0cd28f43c42c3949eee2c8a", size = 7868109, upload-time = "2026-04-22T20:15:04.779Z" },
+    { url = "https://files.pythonhosted.org/packages/75/82/9e4d55529bb99d882b9277a721762537a8bc1345ab1d052bb614a88bd15b/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dafc8ffe57c257002f623afdb7d0e41f73de850179ebd90b42611e4f2b6f9884", size = 7139709, upload-time = "2026-04-22T20:15:25.386Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/f1af6acefb7bb38d73934d6853998bbd327de7418b811372519080d9fd84/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ea00838ef8f37dcd8085defcbdfe89fdd05297a6533f1d3f4cad857d13cedc7b", size = 7450444, upload-time = "2026-04-22T20:13:37.974Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/91/af92ef409e1c065345cf1451bbcf19e00f70a250b8372ec65143ca9a9238/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:683d18089acf14d0de293245b9e37c7f0ec64e6d266f6773144211931aa3ec97", size = 7967525, upload-time = "2026-04-22T20:13:42.674Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1f/23ecd6e268ef24ce6b0fe4a1e76a314990d2e923ac5791e29d657418243d/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1829993dd50cf497cbed66ea9f6c8ff7d157d22592a05c7399f92fb8a549e3c", size = 8199124, upload-time = "2026-04-22T20:15:00.02Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2a/36b694ea0c7e202250a81a57faf00f218738da6c5d070c752f2d81cd34ce/pydantic_monty-0.0.17-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a7869e3f41a54cc588096c52a8a4de25ecd81e75c867ea4164b14ea1ae1a57f", size = 7739623, upload-time = "2026-04-22T20:14:37.57Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e5/090357d7bc0f0751d1afbb71330695fa26554699c88ba56ecaad91657088/pydantic_monty-0.0.17-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f9c17663e2c6f07aec5bc54cd7e39a9e20f250a97a9081e1b2b932eb00d0afc5", size = 7317755, upload-time = "2026-04-22T20:14:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/15/63/67200070cf33325ecfda81d4aee3bf312250ce80bd73058103e04e0f3587/pydantic_monty-0.0.17-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5d2cf98afe2fb124f6ade91d9663d54277478cad417164f83df1854a41ef450c", size = 7769158, upload-time = "2026-04-22T20:14:39.611Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/9ecfbc2f45406cfb247fafdea4f4a8412db3e559a22c4385eb15266ba2c1/pydantic_monty-0.0.17-cp312-cp312-win32.whl", hash = "sha256:b2185cc4effbbd6793eed4e0f0bcb6a3dbfbb3289ea4d47888708813f0a3dd47", size = 7227917, upload-time = "2026-04-22T20:14:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/80/9be3bef8273817ccc17da25c3ce4ff5d5d45e5629c17eacc90cdef073821/pydantic_monty-0.0.17-cp312-cp312-win_amd64.whl", hash = "sha256:7833daed757ec9b09b627cc3577a4a76b114c5148f779531d7cfdb1095bcf0a9", size = 8043469, upload-time = "2026-04-22T20:13:22.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/44/0e106b8b27eb93b66e4f3d279486464e05ba5ee31088848e58b5f506f879/pydantic_monty-0.0.17-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e0cdac8c3c16477596bc96ee1cec4f2fbaccd089e2daa1e7b9f227cc89f97cb1", size = 7341507, upload-time = "2026-04-22T20:14:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/88/a0315fa08e62e2d1ef00c03d8202d7bef3f1f71543bebfb916fea265c0a2/pydantic_monty-0.0.17-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37290d6a1c35aba5cfb8b490bb31c0d822e8ddca8f3ca9ea068e30930d80dd1e", size = 7311916, upload-time = "2026-04-22T20:13:34.022Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e5/e4da6acb408594cbfbfb8dd3c0491b9b2ee54e9183e7ebc5f584baa07af9/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:49f252b2fb918686d3e8f76cb30245e782d1560a7fa68dbc0f6940d83c12bd41", size = 7867465, upload-time = "2026-04-22T20:13:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d4/64c2f8eb708a743b0944ea8f71dfd51bc655285b4be28d55577dafbb29fa/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2254d25c34463d67069f5f1567157bde9311654cd5371f8933b8ea9815bfa26a", size = 7139262, upload-time = "2026-04-22T20:14:10.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/67/5d766f9cd304e871a5dfe5f0a85eaa533538ef07e9b2858fdf9f37f83694/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0688a1fa5dc045ac7b7e996d7269b94f74f116d7b1e352c7b5bb5ad53d4fe03", size = 7450119, upload-time = "2026-04-22T20:13:44.515Z" },
+    { url = "https://files.pythonhosted.org/packages/33/98/fa16779021d93edb19807e87cdba56bbec6adfad21f10b41a212572ce513/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b35121ac555ed201405c69d531e4cb916da6984b8cd2e15c8a319117349faf6", size = 7967398, upload-time = "2026-04-22T20:13:55.576Z" },
+    { url = "https://files.pythonhosted.org/packages/92/64/287a42720bc9e975ab5b52625aa9fc6bcef8298dd821022cc45c6ee1808d/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c97dc44af25d4392b474902fc40f78f09fe8f44ba791364670334fe12abc077", size = 8198835, upload-time = "2026-04-22T20:15:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/97/37/03edb1fd582b79b2b462afc3fea5e1c8fea73afefc4870dc35fc3c7c492e/pydantic_monty-0.0.17-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ed2fb365ef9ca921de9a17786ecfa2efe06e65678e6ca57be51658a2a880f31", size = 7739241, upload-time = "2026-04-22T20:13:46.925Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/b765c9ca2ae27def1caa07345aba073ae1239fc2d9cca7a375f3dc2195f7/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5bf9f07b38dd12747e3c95b169a5afb3e2e9107622e01e548246c84d19a69c99", size = 7316719, upload-time = "2026-04-22T20:14:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3b/64fe872cd575ab5262e1ba2959554ead198c939cfaa425f7f8e9b1ad2694/pydantic_monty-0.0.17-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a5e9bafd4b5acbc0a8e12ee8403a3ce37281c3b0fa5909d3f412bee76c69003c", size = 7769150, upload-time = "2026-04-22T20:13:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/b6a0bb41f39bac2e11e6a2fd42ca0886893fafa6344fb17c3f0a94e22e83/pydantic_monty-0.0.17-cp313-cp313-win32.whl", hash = "sha256:1c239ae3e610d3f39cd1609285209a4e2d046b465ac1bfed0d4374c615eed0fa", size = 7227705, upload-time = "2026-04-22T20:15:12.262Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e7/d8cd62f537f7ab17714ee19ea221a0e341dab407215376ab1c41d79794c9/pydantic_monty-0.0.17-cp313-cp313-win_amd64.whl", hash = "sha256:1886c3590b02f359ae991f1e76691064f167330eda4fbf22762127ce17d0eb48", size = 8043469, upload-time = "2026-04-22T20:14:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c0/8354baf835e1a04c4b9e11d253f82df7d625a9305e6a23a177fb895b1484/pydantic_monty-0.0.17-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:a166bd04d1996f0d144fbb5e1391cd1c0fbdacd4fa3b689dd48931388679fe98", size = 7341303, upload-time = "2026-04-22T20:14:35.653Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ac/d58221b5e17915421ca00bb08b805ac121b6accb194785d5422da4a2f5fc/pydantic_monty-0.0.17-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d82f319e3fd79707a7b81bbb68596509d14ac73502d2f0daf4ab5d281efdfbdc", size = 7318912, upload-time = "2026-04-22T20:13:59.966Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3f/8eeb8f652f6cd6e06a737aa9f00de2949e37a669b31756bc51b6182457b4/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f38b9875f7ff56fe69538b60b2ecbdcbe2b8b7780407ceb05fe0ee1414bf8d19", size = 7867027, upload-time = "2026-04-22T20:13:51.426Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/ec6620c27c8b4cada6ce53378c52c245e238e50a20b968cafdc1b8573c4e/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74a778bb5a4dcdbc85b3b9002f9a72a43fb6ffd88635bfdd502e8d3053008337", size = 7137542, upload-time = "2026-04-22T20:13:35.939Z" },
+    { url = "https://files.pythonhosted.org/packages/41/78/5419785630511b54b15cfb094871bcb53ec9025ba8d91bd7ab5b22b6c98f/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e2ab074a65738e9c1b4be9a432e7ca1e9987a6706018dc7a5af6d4ce7cecdf3", size = 7450222, upload-time = "2026-04-22T20:13:53.378Z" },
+    { url = "https://files.pythonhosted.org/packages/61/04/cec11fa96a47034da3c21af53e73f43d2270f5ce96cd710809859fe9c0b2/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00fd1cd28b4200c9ccd02629868486b366af1bfe1f0584d4c9e513b7a941a868", size = 7967405, upload-time = "2026-04-22T20:14:03.826Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e3/f2be0fb975100b6936ca36a8410098f10fab3b26729c0b0d1de2fac59ff3/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ea6684555bfd00cbe9d2df3e73caada3d82200c168c63cc475197b55b88401", size = 8199028, upload-time = "2026-04-22T20:13:26.802Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/43/358bdaa9c50d21fe4a25a71d43ce9af2d6796616fa47aca84f807433564e/pydantic_monty-0.0.17-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f804a03a3bbd0cf0ade1d4ce11b50ca6858e9c4440b27c746faf1d3c0a272954", size = 7749903, upload-time = "2026-04-22T20:15:09.626Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/8bcd0a78abf13edceca36aaf5c180fad963e4c2e042fd7247b9e96048306/pydantic_monty-0.0.17-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:b5476e6c08b86b0bea554b97ce9b142aac1177447f2d3c5751864b27991fd1b1", size = 7312704, upload-time = "2026-04-22T20:14:33.668Z" },
+    { url = "https://files.pythonhosted.org/packages/88/49/5de8bb7f8b82c3ebb8f2485e0b7a40055b072193039d95dcb5d35fcba72c/pydantic_monty-0.0.17-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b5fcdcca45439844bee268686f37226dbf5803ec7a5945f5536c41419f151dac", size = 7768902, upload-time = "2026-04-22T20:14:29.389Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7c/500a002f1a52f17c8b8a989875da3e1590c18ce95c89856aa967e2348a36/pydantic_monty-0.0.17-cp314-cp314-win32.whl", hash = "sha256:4dd3e6e80a415e7272f7a7583a4f8e045096653f6074e181117eb61fc8fe3b45", size = 7227049, upload-time = "2026-04-22T20:14:01.871Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/b8f552f2a863778f49ebb708f18aaf0bfb275480a48965786e06efacf1c4/pydantic_monty-0.0.17-cp314-cp314-win_amd64.whl", hash = "sha256:36a8090a628e8cf91df8f66c721a71050ac8f48473d4992b9afbd9585941a647", size = 8062999, upload-time = "2026-04-22T20:14:44.006Z" },
 ]
 
 [[package]]
@@ -1502,15 +1511,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.404"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/6e/026be64c43af681d5632722acd100b06d3d39f383ec382ff50a71a6d5bce/pyright-1.1.404.tar.gz", hash = "sha256:455e881a558ca6be9ecca0b30ce08aa78343ecc031d37a198ffa9a7a1abeb63e", size = 4065679, upload-time = "2025-08-20T18:46:14.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/30/89aa7f7d7a875bbb9a577d4b1dc5a3e404e3d2ae2657354808e905e358e0/pyright-1.1.404-py3-none-any.whl", hash = "sha256:c7b7ff1fdb7219c643079e4c3e7d4125f0dafcc19d253b47e898d130ea426419", size = 5902951, upload-time = "2025-08-20T18:46:12.096Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -1772,9 +1781,13 @@ source = { editable = "." }
 dependencies = [
     { name = "authlib" },
     { name = "brotli" },
+    { name = "click" },
     { name = "cryptography" },
     { name = "fastmcp", extra = ["code-mode"] },
     { name = "httpx" },
+    { name = "idna" },
+    { name = "joserfc" },
+    { name = "mcp" },
     { name = "msgpack" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -1820,10 +1833,14 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.3.1" },
     { name = "brotli", specifier = ">=1.2.0" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "fastmcp", extras = ["code-mode"], specifier = "==3.3.1" },
+    { name = "fastmcp", extras = ["code-mode"], specifier = "==3.4.4" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "joserfc", specifier = ">=1.6.8" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=1.24.0" },
@@ -1845,7 +1862,7 @@ dev = [
     { name = "bandit", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pip-audit", specifier = ">=2.7.0" },
-    { name = "pyright", specifier = ">=1.1.404" },
+    { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

Bumps four transitive dependencies flagged by `pip-audit`, using the repo's existing pattern of direct override constraints in `pyproject.toml` (with `uv.lock` regenerated). Split out from the meeting-recordings PR (#156) since dependency maintenance carries its own risk surface.

| Package | From | To | Advisories |
|---|---|---|---|
| `mcp` | 1.26.0 | **1.28.1** | CVE-2026-52870, CVE-2026-52869, CVE-2026-59950 |
| `joserfc` | 1.6.4 | 1.7.4 | PYSEC-2026-2528, PYSEC-2026-2530 |
| `idna` | 3.10 | 3.18 | PYSEC-2026-215 |
| `click` | 8.1.8 | 8.4.2 | PYSEC-2026-2132 |

## Compatibility

- `mcp` 1.28.1 stays within `fastmcp-slim`'s declared range (`mcp<2.0,>=1.24.0`), so no conflict with the pinned `fastmcp==3.4.4`.
- `uv lock` resolved cleanly (126 packages); no other versions moved.

## Verification

- Full test suite: **535 passed, 13 skipped** (Python 3.12).
- Server imports/instantiates cleanly on `mcp` 1.28.1; `uv build` succeeds.
- `pip-audit` after the bump reports **no remaining project advisories**.

## Note

`pip` itself (26.1.1 → 26.1.2, PYSEC-2026-196) is still flagged by pip-audit, but it's the environment's installer, not a project dependency — it can't be pinned in `[project.dependencies]`, and CI already runs pip-audit as advisory (`continue-on-error`). Out of scope here.