### PR TITLE
chore: release v2.3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Rootly MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.15] - Unreleased
+## [2.3.16] - Released 2026-07-23
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rootly-mcp-server"
-version = "2.3.15"
+version = "2.3.16"
 description = "Secure Model Context Protocol server for Rootly APIs with AI SRE capabilities, comprehensive error handling, and input validation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1776,7 +1776,7 @@ wheels = [
 
 [[package]]
 name = "rootly-mcp-server"
-version = "2.3.15"
+version = "2.3.16"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Version bump **2.3.15 → 2.3.16** and CHANGELOG finalize.

## What's in 2.3.16
The `[2.3.15] - Unreleased` section is renamed to `[2.3.16] - Released 2026-07-23` (2.3.15 was never tagged or published — PyPI is at 2.3.9 — so this batch becomes 2.3.16). It covers the recently merged work:

- **Added** — Meeting Recordings & Transcripts (`get_meeting_recording`, `list_meeting_recordings`, `list_all_meeting_recordings`; `include=transcript`)
- **Fixed** — Incident tool hardening (error taxonomy, input safety, pagination signals); sequential incident lookups via `filter[sequential_id]`; alert payload on detail lookups
- **Security** — transitive dependency bumps (mcp, joserfc, idna, click, and the earlier dependabot set)

## Changes in this PR
- `pyproject.toml`: `version = "2.3.16"`
- `CHANGELOG.md`: `[2.3.15] - Unreleased` → `[2.3.16] - Released 2026-07-23`
- `uv.lock`: local package version synced to 2.3.16

Follows the repo's `chore: release vX.Y.Z` convention (matches how v2.3.14 was cut). Merging to `main` and tagging `v2.3.16` triggers the PyPI publish workflow.