### PR TITLE
feat: satisfy OpenAI plugin submission scan for Rootly Code Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,15 @@ To override the hosted or self-hosted default profile entirely, set `ROOTLY_MCP_
 
 To expose only a specific subset of MCP tools on a self-hosted deployment, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names, for example `list_incidents,get_incident,get_server_version`.
 
+### OpenAI Apps domain verification
+
+Hosted deployments expose an unauthenticated domain-verification endpoint used by the OpenAI plugin directory:
+
+- **Endpoint:** `GET /.well-known/openai-apps-challenge`
+- **Environment variable:** `ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN`
+
+Set `ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN` to the token generated in the OpenAI submission portal. The endpoint returns that exact token as `text/plain` (with `Cache-Control: no-store`), and returns `404` when the variable is unset or empty. The token is read from the environment at request time — never hardcode or commit it. The route is served on both the dual-transport (`--transport both`) and profiled streamable-HTTP hosted deployments and is not subject to Bearer authentication.
+
 To discover the exact tool names available under your current self-hosted configuration, run:
 
 ```bash

--- a/src/rootly_mcp_server/code_mode.py
+++ b/src/rootly_mcp_server/code_mode.py
@@ -45,6 +45,12 @@ _EXECUTE_TOOL_ANNOTATIONS = ToolAnnotations(
     idempotentHint=False,
     openWorldHint=True,
 )
+_EXECUTE_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"result": {}},
+    "required": ["result"],
+    "x-fastmcp-wrap-result": True,
+}
 
 DEFAULT_CODE_MODE_PATH = "/mcp-codemode"
 _TOOL_NAME_PREFIXES = (
@@ -270,6 +276,7 @@ class RootlyCodeMode(CodeMode):
             name=self.execute_tool_name,
             description=self._build_execute_description(),
             annotations=_EXECUTE_TOOL_ANNOTATIONS,
+            output_schema=_EXECUTE_OUTPUT_SCHEMA,
         )
 
 

--- a/src/rootly_mcp_server/code_mode.py
+++ b/src/rootly_mcp_server/code_mode.py
@@ -20,6 +20,7 @@ from fastmcp.experimental.transforms.code_mode import (
 )
 from fastmcp.server.context import Context
 from fastmcp.tools import Tool
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from .server import create_rootly_mcp_server
@@ -27,6 +28,23 @@ from .server import create_rootly_mcp_server
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
+
+# Discovery tools (list_tools, tool_search, get_schema, tags) only read the tool
+# catalog — safe, idempotent, no external side effects.
+_DISCOVERY_TOOL_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+# execute is a gateway that can invoke ANY Rootly tool, including writes and
+# destructive actions, so it gets the most conservative annotations.
+_EXECUTE_TOOL_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=False,
+    destructiveHint=True,
+    idempotentHint=False,
+    openWorldHint=True,
+)
 
 DEFAULT_CODE_MODE_PATH = "/mcp-codemode"
 _TOOL_NAME_PREFIXES = (
@@ -192,6 +210,15 @@ class CompatibleMontySandboxProvider(MontySandboxProvider):
 class RootlyCodeMode(CodeMode):
     """Rootly-specific Code Mode transform with friendlier execute ergonomics."""
 
+    def _build_discovery_tools(self) -> list[Tool]:
+        # Attach read-only annotations to the actual Tool objects FastMCP exposes
+        # (list_tools, tool_search, get_schema, tags). The base result is cached,
+        # so we annotate the concrete objects the runtime returns.
+        tools = super()._build_discovery_tools()
+        for tool in tools:
+            tool.annotations = _DISCOVERY_TOOL_ANNOTATIONS
+        return tools
+
     def _make_execute_tool(self) -> Tool:
         transform = self
 
@@ -242,6 +269,7 @@ class RootlyCodeMode(CodeMode):
             fn=execute,
             name=self.execute_tool_name,
             description=self._build_execute_description(),
+            annotations=_EXECUTE_TOOL_ANNOTATIONS,
         )
 
 

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -721,7 +721,20 @@ def create_rootly_mcp_server(
     # OAuth 2.0 Protected Resource Metadata (RFC 9728)
     # MCP clients fetch this to discover which authorization server to use.
     if hosted:
-        from starlette.responses import JSONResponse
+        from starlette.responses import JSONResponse, PlainTextResponse, Response
+
+        # OpenAI Apps domain-verification endpoint (unauthenticated).
+        # The portal-generated token is supplied at deploy time via
+        # ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN and must never be hardcoded/committed.
+        # Returns the exact token as text/plain, or 404 when unset/empty. This
+        # path is not an MCP transport path, so the hosted auth middleware lets it
+        # through without a Bearer token.
+        @mcp.custom_route("/.well-known/openai-apps-challenge", methods=["GET"])
+        async def openai_apps_challenge(request):
+            token = os.getenv("ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN", "").strip()
+            if not token:
+                return Response(status_code=404)
+            return PlainTextResponse(token, headers={"Cache-Control": "no-store"})
 
         async def _oauth_protected_resource_handler(request):
             mcp_server_url = resolve_mcp_server_url(request)

--- a/tests/unit/test_openai_submission.py
+++ b/tests/unit/test_openai_submission.py
@@ -74,17 +74,17 @@ class TestCodeModeServerExposedAnnotations:
         server = create_rootly_codemode_server(swagger_path=SWAGGER_PATH, hosted=True)
         tools = {t.name: t for t in await server.list_tools()}
 
-        # The Code Mode discovery + execute tools are exposed...
-        for name in (*_DISCOVERY_TOOL_NAMES, "execute"):
-            assert name in tools, f"{name} not exposed by the Code Mode server"
+        # Only the Code Mode discovery + execute tools are exposed.
+        assert set(tools) == {*_DISCOVERY_TOOL_NAMES, "execute"}
 
-        # ...every exposed tool is annotated (catches any raw-tool leak too)...
+        # Every exposed tool is annotated.
         for name, tool in tools.items():
             assert tool.annotations is not None, f"{name} exposed without annotations"
 
-        # ...and the hints match the submission requirements.
+        # The hints match the submission requirements.
         for name in _DISCOVERY_TOOL_NAMES:
             ann = tools[name].annotations
+            assert ann is not None
             assert (
                 ann.readOnlyHint,
                 ann.destructiveHint,
@@ -93,6 +93,7 @@ class TestCodeModeServerExposedAnnotations:
             ) == (True, False, True, False)
 
         execute = tools["execute"].annotations
+        assert execute is not None
         assert (
             execute.readOnlyHint,
             execute.destructiveHint,

--- a/tests/unit/test_openai_submission.py
+++ b/tests/unit/test_openai_submission.py
@@ -11,8 +11,10 @@ Code Mode:
 import pytest
 from starlette.testclient import TestClient
 
-from rootly_mcp_server.code_mode import build_code_mode_transform
+from rootly_mcp_server.code_mode import build_code_mode_transform, create_rootly_codemode_server
 from rootly_mcp_server.server import create_rootly_mcp_server
+
+_DISCOVERY_TOOL_NAMES = ("list_tools", "tool_search", "get_schema", "tags")
 
 SWAGGER_PATH = "src/rootly_mcp_server/data/swagger.json"
 CHALLENGE_PATH = "/.well-known/openai-apps-challenge"
@@ -57,6 +59,46 @@ class TestCodeModeAnnotations:
             "required": ["result"],
             "x-fastmcp-wrap-result": True,
         }
+
+
+@pytest.mark.unit
+class TestCodeModeServerExposedAnnotations:
+    """End-to-end: assert on the tools the Code Mode server actually exposes.
+
+    This guards the whole chain the OpenAI scanner sees (transform -> registration
+    -> the served tool list), not just the internal builder methods, so a future
+    FastMCP change that drops the annotations is caught here.
+    """
+
+    async def test_exposed_code_mode_tools_carry_annotations(self):
+        server = create_rootly_codemode_server(swagger_path=SWAGGER_PATH, hosted=True)
+        tools = {t.name: t for t in await server.list_tools()}
+
+        # The Code Mode discovery + execute tools are exposed...
+        for name in (*_DISCOVERY_TOOL_NAMES, "execute"):
+            assert name in tools, f"{name} not exposed by the Code Mode server"
+
+        # ...every exposed tool is annotated (catches any raw-tool leak too)...
+        for name, tool in tools.items():
+            assert tool.annotations is not None, f"{name} exposed without annotations"
+
+        # ...and the hints match the submission requirements.
+        for name in _DISCOVERY_TOOL_NAMES:
+            ann = tools[name].annotations
+            assert (
+                ann.readOnlyHint,
+                ann.destructiveHint,
+                ann.idempotentHint,
+                ann.openWorldHint,
+            ) == (True, False, True, False)
+
+        execute = tools["execute"].annotations
+        assert (
+            execute.readOnlyHint,
+            execute.destructiveHint,
+            execute.idempotentHint,
+            execute.openWorldHint,
+        ) == (False, True, False, True)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_openai_submission.py
+++ b/tests/unit/test_openai_submission.py
@@ -1,0 +1,91 @@
+"""Tests for OpenAI plugin submission requirements.
+
+Covers the two changes made to satisfy the OpenAI submission scan for Rootly
+Code Mode:
+
+1. Explicit MCP ToolAnnotations on the Code Mode tools.
+2. The unauthenticated ``/.well-known/openai-apps-challenge`` domain-verification
+   endpoint.
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+from rootly_mcp_server.code_mode import build_code_mode_transform
+from rootly_mcp_server.server import create_rootly_mcp_server
+
+SWAGGER_PATH = "src/rootly_mcp_server/data/swagger.json"
+CHALLENGE_PATH = "/.well-known/openai-apps-challenge"
+CHALLENGE_ENV = "ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN"
+
+
+@pytest.mark.unit
+class TestCodeModeAnnotations:
+    """Code Mode tools must expose explicit, accurate ToolAnnotations."""
+
+    def _tools_by_name(self):
+        transform = build_code_mode_transform()
+        tools = {t.name: t for t in transform._build_discovery_tools()}  # noqa: SLF001
+        execute = transform._make_execute_tool()  # noqa: SLF001
+        tools[execute.name] = execute
+        return tools
+
+    def test_discovery_tools_are_read_only(self):
+        tools = self._tools_by_name()
+        for name in ("list_tools", "tool_search", "get_schema", "tags"):
+            assert name in tools, f"missing discovery tool {name}"
+            ann = tools[name].annotations
+            assert ann is not None, f"{name} has no annotations"
+            assert ann.readOnlyHint is True
+            assert ann.destructiveHint is False
+            assert ann.idempotentHint is True
+            assert ann.openWorldHint is False
+
+    def test_execute_has_conservative_gateway_annotations(self):
+        ann = self._tools_by_name()["execute"].annotations
+        assert ann is not None
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is True
+        assert ann.idempotentHint is False
+        assert ann.openWorldHint is True
+
+
+@pytest.mark.unit
+class TestOpenAIAppsChallenge:
+    """The domain-verification endpoint returns the configured token or 404."""
+
+    def _hosted_server(self):
+        return create_rootly_mcp_server(swagger_path=SWAGGER_PATH, hosted=True)
+
+    def test_challenge_route_registered_in_hosted_app(self):
+        server = self._hosted_server()
+        paths = [getattr(r, "path", None) for r in server._get_additional_http_routes()]  # noqa: SLF001
+        assert CHALLENGE_PATH in paths
+
+    def test_returns_configured_token(self, monkeypatch):
+        monkeypatch.setenv(CHALLENGE_ENV, "portal-token-xyz")
+        with TestClient(self._hosted_server().http_app()) as client:
+            resp = client.get(CHALLENGE_PATH)
+        assert resp.status_code == 200
+        assert resp.text == "portal-token-xyz"
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert resp.headers["cache-control"] == "no-store"
+
+    def test_token_is_stripped(self, monkeypatch):
+        monkeypatch.setenv(CHALLENGE_ENV, "  padded-token  ")
+        with TestClient(self._hosted_server().http_app()) as client:
+            resp = client.get(CHALLENGE_PATH)
+        assert resp.status_code == 200
+        assert resp.text == "padded-token"
+
+    def test_404_when_token_absent(self, monkeypatch):
+        monkeypatch.delenv(CHALLENGE_ENV, raising=False)
+        with TestClient(self._hosted_server().http_app()) as client:
+            resp = client.get(CHALLENGE_PATH)
+        assert resp.status_code == 404
+
+    def test_404_when_token_empty(self, monkeypatch):
+        monkeypatch.setenv(CHALLENGE_ENV, "   ")
+        with TestClient(self._hosted_server().http_app()) as client:
+            resp = client.get(CHALLENGE_PATH)
+        assert resp.status_code == 404

--- a/tests/unit/test_openai_submission.py
+++ b/tests/unit/test_openai_submission.py
@@ -49,6 +49,15 @@ class TestCodeModeAnnotations:
         assert ann.idempotentHint is False
         assert ann.openWorldHint is True
 
+    def test_execute_declares_generic_wrapped_output_schema(self):
+        schema = self._tools_by_name()["execute"].output_schema
+        assert schema == {
+            "type": "object",
+            "properties": {"result": {}},
+            "required": ["result"],
+            "x-fastmcp-wrap-result": True,
+        }
+
 
 @pytest.mark.unit
 class TestOpenAIAppsChallenge:


### PR DESCRIPTION
Prepares the repo for the OpenAI plugin directory submission of **Rootly Code Mode** (`https://mcp.rootly.com/mcp-codemode`).

## OpenAI submission scan failures addressed
1. **Missing tool annotations** — the Code Mode tools (`list_tools`, `tool_search`, `get_schema`, `tags`, `execute`) exposed no MCP `ToolAnnotations`, which the scan requires (`readOnlyHint` / `openWorldHint` / `destructiveHint`).
2. **Missing domain verification** — no `/.well-known/openai-apps-challenge` endpoint for the directory's domain-ownership check.

## 1. Code Mode annotation fix (`code_mode.py`)
Annotations are attached to the **actual `Tool` objects** FastMCP 3.4.4 returns (via `_build_discovery_tools()` and `_make_execute_tool()`), not config objects:

| Tool(s) | readOnly | destructive | idempotent | openWorld |
|---|---|---|---|---|
| `list_tools`, `tool_search`, `get_schema`, `tags` | ✅ true | false | ✅ true | false |
| `execute` | false | ✅ **true** | false | ✅ **true** |

`execute` gets conservative gateway annotations because it can invoke any Rootly tool, including writes and destructive actions.

`execute` also declares a generic wrapped `outputSchema`, allowing scalar, list, and object workflow results to be returned as structured content under `result`.

## 2. Configurable domain-verification endpoint (`server.py`)
`GET /.well-known/openai-apps-challenge` (hosted deployments only):
- Reads the token from **`ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN`** (portal-generated; read at request time — **not hardcoded or committed**).
- Returns the **exact token** as `text/plain` with `Cache-Control: no-store`.
- Returns **404** when the env var is unset or empty.
- Registered as a FastMCP custom route → included via `_get_additional_http_routes()` in **both** the dual-transport and profiled streamable-HTTP hosted apps.
- Sits outside the MCP transport paths, so the hosted Bearer-auth middleware does **not** block it (verified).

## Required deployment configuration
Set the env var on the hosted deployment before/at submission:
```
ROOTLY_OPENAI_APPS_CHALLENGE_TOKEN=<token from the OpenAI submission portal>
```
Without it, the endpoint 404s (safe default). **The token is intentionally not in this PR or the repo** — configure it in the deployment environment only.

## Submitted endpoint
The submission uses **`https://mcp.rootly.com/mcp-codemode`** (Code Mode). No repo configuration references the slim-profile endpoint (verified — nothing uses `?tool_profile=slim`). `server.json` is left as the general MCP-registry manifest (its standard `/mcp` listing is unrelated to this submission).

## Validation performed
- **Annotations:** built the transform and asserted the exact hints on all four discovery tools and `execute`.
- **Endpoint:** via Starlette `TestClient` — token set → 200, exact token, `text/plain`, `no-store`; unset/empty → 404; token is stripped; route present in `_get_additional_http_routes()`.
- **Gate:** `ruff` lint + format clean, `pyright` 0 errors, `mypy` clean, full suite **564 passed, 13 skipped** (8 focused tests in `tests/unit/test_openai_submission.py`).
- Reviewed the final diff — only the four intended files changed, no unrelated edits.
