### PR TITLE
Improve hosted telemetry configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,15 @@ To restrict either deployment to read-only tools, start the server with `--no-en
 
 For hosted clients that want the smaller remote profile, append `?tool_profile=slim` to the MCP URL or send `X-Rootly-Tool-Profile: slim`.
 
+### AgentCat and Sentry telemetry
+
+Hosted deployments can send MCP telemetry to AgentCat by setting
+`ROOTLY_MCPCAT_PROJECT_ID`. To also export AgentCat events to Sentry, provide
+`SENTRY_DSN` through the deployment's secret store. The optional
+`SENTRY_ENVIRONMENT` and `SENTRY_RELEASE` variables default to `production` and
+the installed Rootly MCP Server version, respectively. Sentry performance
+tracing is enabled when the exporter is configured.
+
 To override the hosted or self-hosted default profile entirely, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names. When that variable is set, it fully replaces the default selection.
 
 To expose only a specific subset of MCP tools on a self-hosted deployment, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names, for example `list_incidents,get_incident,get_server_version`.

--- a/README.md
+++ b/README.md
@@ -376,9 +376,9 @@ For hosted clients that want the smaller remote profile, append `?tool_profile=s
 Hosted deployments can send MCP telemetry to AgentCat by setting
 `ROOTLY_MCPCAT_PROJECT_ID`. To also export AgentCat events to Sentry, provide
 `SENTRY_DSN` through the deployment's secret store. The optional
-`SENTRY_ENVIRONMENT` and `SENTRY_RELEASE` variables default to `production` and
-the installed Rootly MCP Server version, respectively. Sentry performance
-tracing is enabled when the exporter is configured.
+`ENVIRONMENT` defaults to `production`, and `SENTRY_RELEASE` defaults to the
+installed Rootly MCP Server version. Sentry performance tracing is enabled when
+the exporter is configured.
 Free-form event text is redacted and actor names are omitted from Sentry-bound
 telemetry; stable internal actor IDs remain available for correlation.
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ Hosted deployments can send MCP telemetry to AgentCat by setting
 `SENTRY_ENVIRONMENT` and `SENTRY_RELEASE` variables default to `production` and
 the installed Rootly MCP Server version, respectively. Sentry performance
 tracing is enabled when the exporter is configured.
+Free-form event text is redacted and actor names are omitted from Sentry-bound
+telemetry; stable internal actor IDs remain available for correlation.
 
 To override the hosted or self-hosted default profile entirely, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names. When that variable is set, it fully replaces the default selection.
 

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -142,7 +142,7 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
                 "sentry": {
                     "type": "sentry",
                     "dsn": sentry_dsn,
-                    "environment": os.getenv("SENTRY_ENVIRONMENT", "production"),
+                    "environment": os.getenv("ENVIRONMENT", "production"),
                     "release": os.getenv(
                         "SENTRY_RELEASE",
                         f"rootly-mcp-server@{__version__}",

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -116,7 +116,8 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
         agentcat_types = importlib.import_module("agentcat.types")
     except ImportError:
         logger.warning(
-            "ROOTLY_MCPCAT_PROJECT_ID is set but agentcat is not installed; skipping AgentCat tracking"
+            "AgentCat or Sentry telemetry is configured but agentcat is not installed; "
+            "skipping telemetry"
         )
         return
 

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -10,6 +10,7 @@ import asyncio
 import importlib
 import logging
 import os
+import re
 import sys
 from collections.abc import Mapping
 from contextlib import AsyncExitStack, asynccontextmanager
@@ -44,6 +45,8 @@ TRANSPORT_ALIASES: dict[str, TransportName] = {
 }
 HOSTED_TOOL_PROFILE_QUERY_PARAM = "tool_profile"
 HOSTED_TOOL_PROFILE_HEADER = "x-rootly-tool-profile"
+SENTRY_DSN_PATTERN = re.compile(r"^https://[a-f0-9]+@[\w.-]+(?::\d+)?(?:/.*)?/\d+$")
+REDACTED_TELEMETRY_TEXT = "[REDACTED]"
 
 
 def normalize_transport(value: str) -> TransportName:
@@ -110,6 +113,11 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
     sentry_dsn = os.getenv("SENTRY_DSN", "").strip()
     if not project_id and not sentry_dsn:
         return
+    if sentry_dsn and not SENTRY_DSN_PATTERN.fullmatch(sentry_dsn):
+        logger.warning("Sentry telemetry is disabled because SENTRY_DSN is invalid")
+        sentry_dsn = ""
+        if not project_id:
+            return
 
     try:
         agentcat = importlib.import_module("agentcat")
@@ -123,9 +131,13 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
 
     try:
         options_kwargs: dict[str, Any] = {
-            "identify": build_mcpcat_identify_callback(agentcat_types.UserIdentity),
+            "identify": build_mcpcat_identify_callback(
+                agentcat_types.UserIdentity,
+                include_user_name=not bool(sentry_dsn),
+            ),
         }
         if sentry_dsn:
+            options_kwargs["redact_sensitive_information"] = redact_agentcat_telemetry_text
             options_kwargs["exporters"] = {
                 "sentry": {
                     "type": "sentry",
@@ -140,11 +152,23 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
             }
         options = agentcat_types.AgentCatOptions(**options_kwargs)
         agentcat.track(server, project_id, options)
-    except Exception:
-        logger.warning("AgentCat tracking could not be enabled; skipping", exc_info=True)
+    except Exception as error:
+        logger.warning(
+            "AgentCat tracking could not be enabled; skipping (%s)",
+            type(error).__name__,
+        )
 
 
-def build_mcpcat_identify_callback(user_identity_cls: type[Any]):
+def redact_agentcat_telemetry_text(_value: str) -> str:
+    """Remove free-form text before AgentCat sends events to telemetry backends."""
+    return REDACTED_TELEMETRY_TEXT
+
+
+def build_mcpcat_identify_callback(
+    user_identity_cls: type[Any],
+    *,
+    include_user_name: bool = True,
+):
     """Build a lightweight AgentCat identify callback from hosted auth context."""
 
     def identify(_request: dict[str, Any], _context: Any) -> Any:
@@ -154,7 +178,11 @@ def build_mcpcat_identify_callback(user_identity_cls: type[Any]):
 
         return user_identity_cls(
             user_id=user["id"],
-            user_name=(user.get("full_name_with_team") or user.get("name") or user.get("email")),
+            user_name=(
+                user.get("full_name_with_team") or user.get("name") or user.get("email")
+                if include_user_name
+                else None
+            ),
             user_data=None,
         )
 

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -16,7 +16,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from . import server_defaults
+from . import __version__, server_defaults
 from .code_mode import (
     code_mode_enabled_from_env,
     code_mode_path_from_env,
@@ -107,7 +107,8 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
     unchanged for self-hosted users and local development environments that do
     not install AgentCat.
     """
-    if not project_id:
+    sentry_dsn = os.getenv("SENTRY_DSN", "").strip()
+    if not project_id and not sentry_dsn:
         return
 
     try:
@@ -120,9 +121,23 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
         return
 
     try:
-        options = agentcat_types.AgentCatOptions(
-            identify=build_mcpcat_identify_callback(agentcat_types.UserIdentity),
-        )
+        options_kwargs: dict[str, Any] = {
+            "identify": build_mcpcat_identify_callback(agentcat_types.UserIdentity),
+        }
+        if sentry_dsn:
+            options_kwargs["exporters"] = {
+                "sentry": {
+                    "type": "sentry",
+                    "dsn": sentry_dsn,
+                    "environment": os.getenv("SENTRY_ENVIRONMENT", "production"),
+                    "release": os.getenv(
+                        "SENTRY_RELEASE",
+                        f"rootly-mcp-server@{__version__}",
+                    ),
+                    "enable_tracing": True,
+                }
+            }
+        options = agentcat_types.AgentCatOptions(**options_kwargs)
         agentcat.track(server, project_id, options)
     except Exception:
         logger.warning("AgentCat tracking could not be enabled; skipping", exc_info=True)

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -200,6 +200,86 @@ def test_maybe_enable_mcpcat_tracking_tracks_when_available():
     assert callable(call.args[2].identify)
 
 
+def test_maybe_enable_mcpcat_tracking_configures_sentry_exporter():
+    server = object()
+    logger = Mock()
+    agentcat_module = SimpleNamespace(track=Mock())
+    agentcat_types_module = SimpleNamespace(
+        AgentCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+        UserIdentity=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+
+    def import_side_effect(module_name: str):
+        if module_name == "agentcat":
+            return agentcat_module
+        if module_name == "agentcat.types":
+            return agentcat_types_module
+        raise ImportError(module_name)
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "SENTRY_DSN": "https://public@example.ingest.sentry.io/123",
+                "SENTRY_ENVIRONMENT": "staging",
+                "SENTRY_RELEASE": "rootly-mcp-server@test",
+            },
+            clear=True,
+        ),
+        patch(
+            "rootly_mcp_server.__main__.importlib.import_module",
+            side_effect=import_side_effect,
+        ),
+    ):
+        maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
+
+    options = agentcat_module.track.call_args.args[2]
+    assert options.exporters == {
+        "sentry": {
+            "type": "sentry",
+            "dsn": "https://public@example.ingest.sentry.io/123",
+            "environment": "staging",
+            "release": "rootly-mcp-server@test",
+            "enable_tracing": True,
+        }
+    }
+
+
+def test_maybe_enable_mcpcat_tracking_supports_sentry_without_agentcat_project():
+    server = object()
+    logger = Mock()
+    agentcat_module = SimpleNamespace(track=Mock())
+    agentcat_types_module = SimpleNamespace(
+        AgentCatOptions=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+        UserIdentity=Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+
+    def import_side_effect(module_name: str):
+        if module_name == "agentcat":
+            return agentcat_module
+        if module_name == "agentcat.types":
+            return agentcat_types_module
+        raise ImportError(module_name)
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"SENTRY_DSN": "https://public@example.ingest.sentry.io/123"},
+            clear=True,
+        ),
+        patch(
+            "rootly_mcp_server.__main__.importlib.import_module",
+            side_effect=import_side_effect,
+        ),
+    ):
+        maybe_enable_mcpcat_tracking(server, None, logger)
+
+    assert agentcat_module.track.call_args.args[:2] == (server, None)
+    options = agentcat_module.track.call_args.args[2]
+    assert options.exporters["sentry"]["environment"] == "production"
+    assert options.exporters["sentry"]["release"].startswith("rootly-mcp-server@")
+
+
 def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
     server = object()
     logger = Mock()

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -224,7 +224,7 @@ def test_maybe_enable_mcpcat_tracking_configures_sentry_exporter():
             "os.environ",
             {
                 "SENTRY_DSN": "https://abcdef@example.ingest.sentry.io/123",
-                "SENTRY_ENVIRONMENT": "staging",
+                "ENVIRONMENT": "staging",
                 "SENTRY_RELEASE": "rootly-mcp-server@test",
             },
             clear=True,
@@ -270,7 +270,10 @@ def test_maybe_enable_mcpcat_tracking_supports_sentry_without_agentcat_project()
     with (
         patch.dict(
             "os.environ",
-            {"SENTRY_DSN": "https://abcdef@example.ingest.sentry.io/123"},
+            {
+                "SENTRY_DSN": "https://abcdef@example.ingest.sentry.io/123",
+                "ENVIRONMENT": "production-us-east-1",
+            },
             clear=True,
         ),
         patch(
@@ -282,7 +285,7 @@ def test_maybe_enable_mcpcat_tracking_supports_sentry_without_agentcat_project()
 
     assert agentcat_module.track.call_args.args[:2] == (server, None)
     options = agentcat_module.track.call_args.args[2]
-    assert options.exporters["sentry"]["environment"] == "production"
+    assert options.exporters["sentry"]["environment"] == "production-us-east-1"
     assert options.exporters["sentry"]["release"].startswith("rootly-mcp-server@")
 
 

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -170,7 +170,10 @@ def test_maybe_enable_mcpcat_tracking_logs_when_package_missing():
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
     mock_import.assert_called_once_with("agentcat")
-    logger.warning.assert_called_once()
+    logger.warning.assert_called_once_with(
+        "AgentCat or Sentry telemetry is configured but agentcat is not installed; "
+        "skipping telemetry"
+    )
 
 
 def test_maybe_enable_mcpcat_tracking_tracks_when_available():

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -223,7 +223,7 @@ def test_maybe_enable_mcpcat_tracking_configures_sentry_exporter():
         patch.dict(
             "os.environ",
             {
-                "SENTRY_DSN": "https://public@example.ingest.sentry.io/123",
+                "SENTRY_DSN": "https://abcdef@example.ingest.sentry.io/123",
                 "SENTRY_ENVIRONMENT": "staging",
                 "SENTRY_RELEASE": "rootly-mcp-server@test",
             },
@@ -237,10 +237,13 @@ def test_maybe_enable_mcpcat_tracking_configures_sentry_exporter():
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
     options = agentcat_module.track.call_args.args[2]
+    assert options.redact_sensitive_information("Bearer production-secret") == "[REDACTED]"
+    identity = options.identify({}, SimpleNamespace())
+    assert identity is None
     assert options.exporters == {
         "sentry": {
             "type": "sentry",
-            "dsn": "https://public@example.ingest.sentry.io/123",
+            "dsn": "https://abcdef@example.ingest.sentry.io/123",
             "environment": "staging",
             "release": "rootly-mcp-server@test",
             "enable_tracing": True,
@@ -267,7 +270,7 @@ def test_maybe_enable_mcpcat_tracking_supports_sentry_without_agentcat_project()
     with (
         patch.dict(
             "os.environ",
-            {"SENTRY_DSN": "https://public@example.ingest.sentry.io/123"},
+            {"SENTRY_DSN": "https://abcdef@example.ingest.sentry.io/123"},
             clear=True,
         ),
         patch(
@@ -281,6 +284,24 @@ def test_maybe_enable_mcpcat_tracking_supports_sentry_without_agentcat_project()
     options = agentcat_module.track.call_args.args[2]
     assert options.exporters["sentry"]["environment"] == "production"
     assert options.exporters["sentry"]["release"].startswith("rootly-mcp-server@")
+
+
+def test_maybe_enable_mcpcat_tracking_rejects_invalid_sentry_dsn_without_logging_it():
+    server = object()
+    logger = Mock()
+    invalid_dsn = "not-a-valid-dsn-containing-a-secret"
+
+    with (
+        patch.dict("os.environ", {"SENTRY_DSN": invalid_dsn}, clear=True),
+        patch("rootly_mcp_server.__main__.importlib.import_module") as mock_import,
+    ):
+        maybe_enable_mcpcat_tracking(server, None, logger)
+
+    mock_import.assert_not_called()
+    logger.warning.assert_called_once_with(
+        "Sentry telemetry is disabled because SENTRY_DSN is invalid"
+    )
+    assert invalid_dsn not in repr(logger.mock_calls)
 
 
 def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
@@ -306,8 +327,8 @@ def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
 
     assert agentcat_module.track.call_args.args[:2] == (server, "proj_test_123")
     logger.warning.assert_called_once_with(
-        "AgentCat tracking could not be enabled; skipping",
-        exc_info=True,
+        "AgentCat tracking could not be enabled; skipping (%s)",
+        "RuntimeError",
     )
 
 
@@ -328,6 +349,25 @@ def test_build_mcpcat_identify_callback_returns_authenticated_user_identity():
 
     assert identity.user_id == "user_123"
     assert identity.user_name == "[Acme Reliability] Example User"
+
+
+def test_build_mcpcat_identify_callback_omits_user_name_for_sentry():
+    user_identity_cls = Mock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+    callback = build_mcpcat_identify_callback(user_identity_cls, include_user_name=False)
+
+    with patch(
+        "rootly_mcp_server.__main__.get_hosted_authenticated_user",
+        return_value={
+            "id": "user_123",
+            "email": "example.user@example.test",
+            "name": "Example User",
+            "full_name_with_team": "[Acme Reliability] Example User",
+        },
+    ):
+        identity = callback({}, SimpleNamespace())
+
+    assert identity.user_id == "user_123"
+    assert identity.user_name is None
     assert identity.user_data is None
 
 


### PR DESCRIPTION
## Summary

- add optional hosted telemetry export configuration
- support tracing and release metadata
- preserve exporter-only operation
- add focused tests and documentation

## Validation

- Python 3.13 unit tests passed
- Ruff lint and formatting passed
- GitHub security, package, and container checks passed