### PR TITLE
Upgrade AgentCat telemetry SDK to v2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,12 @@ RUN uv pip install --system --no-cache-dir -e .
 
 # Install AgentCat (formerly MCPcat) for hosted telemetry without changing the
 # repo dependency graph. The [community] extra provides FastMCP support, which
-# this server relies on. AgentCat's package metadata pins an older Pydantic
-# range, but the SDK imports successfully with our runtime pin, so we restore
-# the server's pinned version after installation.
-RUN uv pip install --system --no-cache-dir "agentcat[community]==1.0.1" \
+# this server relies on. v2 supports the MCP 2026-07-28 spec and tracks sessions
+# via a session_id in the tool list rather than stateful connections — a better
+# fit for our stateless hosted transport. Our integration code is unchanged.
+# In case AgentCat constrains Pydantic, we restore the server's pinned version
+# after installation.
+RUN uv pip install --system --no-cache-dir "agentcat[community]==2.0.1" \
     && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user

--- a/README.md
+++ b/README.md
@@ -382,6 +382,11 @@ the exporter is configured.
 Free-form event text is redacted and actor names are omitted from Sentry-bound
 telemetry; stable internal actor IDs remain available for correlation.
 
+Telemetry runs on AgentCat v2 (MCP 2026-07-28 spec). Sessions are correlated via
+a session_id carried in the tool list rather than stateful connections, which
+suits our stateless hosted transport; `initialize` and `tools/list` events are no
+longer published by the SDK.
+
 To override the hosted or self-hosted default profile entirely, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names. When that variable is set, it fully replaces the default selection.
 
 To expose only a specific subset of MCP tools on a self-hosted deployment, set `ROOTLY_MCP_ENABLED_TOOLS` (or pass `--enabled-tools`) with a comma-separated allowlist of exact tool names, for example `list_incidents,get_incident,get_server_version`.


### PR DESCRIPTION
## In simple terms

AgentCat is the tool we use to see how our MCP server is being used. We're on version 1; this bumps it to **2.0.1**.

The only change is the version number in the Dockerfile — the code that hooks AgentCat up doesn't change at all.

## Why bother

Version 1 figured out "which tool calls belong to the same session" by relying on a long-lived connection. **We don't use long-lived connections** — our hosted server runs in stateless mode (clients don't reliably close sessions, and keeping them open leaks resources). So v1's session tracking was a poor fit for how we actually run.

Version 2 tracks sessions a different way that works fine without long-lived connections, so our usage data should get more accurate.

Side effect: v2 stops reporting two low-value events (`initialize` and `tools/list`), so those will go quiet in the dashboard.

## Does this break anything?

It shouldn't. We checked that AgentCat 2.0.1 installs cleanly alongside everything else we pin (FastMCP, MCP SDK, pydantic) — it doesn't force any of them to change. The vendor notes you only *need* v2 if you're moving to FastMCP v4 / MCP SDK v2, which we're not; we're upgrading because it fits our setup better.

## Tested

The AgentCat/Sentry tests pass (11) and the full suite passes. **One thing CI needs to confirm:** the Docker image actually building and the server starting with telemetry on — that couldn't be verified locally.