### PR TITLE
Support Idempotency-Key on create_incident

### DIFF
--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -943,6 +943,18 @@ def register_incident_tools(
                 str | None,
                 Field(description="Comma-separated incident type IDs to attach to the incident."),
             ] = None,
+            idempotency_key: Annotated[
+                str | None,
+                Field(
+                    description=(
+                        "Optional idempotency key forwarded as the Idempotency-Key request "
+                        "header. Repeating a create with the same key returns the original "
+                        "incident instead of creating a duplicate. Use a stable, unique value "
+                        "per logical incident (e.g. the source alert or intake ID) to make "
+                        "unattended declaration safe to retry."
+                    )
+                ),
+            ] = None,
         ) -> JsonDict:
             """Create an incident with a scoped set of fields for agent-driven workflows."""
             normalized_title = _normalize_optional_text(title)
@@ -988,8 +1000,19 @@ def register_incident_tools(
                 }
             }
 
+            # Forward an optional idempotency key as the Idempotency-Key header so
+            # Rootly's replay behavior dedupes retried declarations. Only send the
+            # header when a non-blank key is provided; make_authenticated_request
+            # merges in Authorization on top of whatever headers we pass.
+            request_kwargs: dict[str, Any] = {"json": payload}
+            normalized_idempotency_key = _normalize_optional_text(idempotency_key)
+            if normalized_idempotency_key is not None:
+                request_kwargs["headers"] = {"Idempotency-Key": normalized_idempotency_key}
+
             try:
-                response = await make_authenticated_request("POST", "/v1/incidents", json=payload)
+                response = await make_authenticated_request(
+                    "POST", "/v1/incidents", **request_kwargs
+                )
                 response.raise_for_status()
 
                 response_data = response.json()

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -246,6 +246,45 @@ class TestScopedIncidentUpdateTool:
         assert "Must provide at least one of title or summary" in result["message"]
 
     @pytest.mark.asyncio
+    async def test_create_incident_forwards_idempotency_key_header(self):
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {"id": "inc-9", "type": "incidents", "attributes": {}}
+        }
+        request.return_value = response
+
+        await tools["create_incident"](title="Prod outage", idempotency_key="  intake-42  ")
+
+        # Trimmed key is forwarded as the Idempotency-Key header for replay safety.
+        request.assert_awaited_once_with(
+            "POST",
+            "/v1/incidents",
+            json={"data": {"type": "incidents", "attributes": {"title": "Prod outage"}}},
+            headers={"Idempotency-Key": "intake-42"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_incident_omits_idempotency_header_when_blank(self):
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {"id": "inc-9", "type": "incidents", "attributes": {}}
+        }
+        request.return_value = response
+
+        await tools["create_incident"](title="Prod outage", idempotency_key="   ")
+
+        # A blank key sends no header at all (not an empty one).
+        request.assert_awaited_once_with(
+            "POST",
+            "/v1/incidents",
+            json={"data": {"type": "incidents", "attributes": {"title": "Prod outage"}}},
+        )
+
+    @pytest.mark.asyncio
     async def test_get_incident_fetches_single_incident(self):
         tools, request = self._register_tools()
         response = Mock()


### PR DESCRIPTION
## Summary

Adds an optional `idempotency_key` argument to the curated **`create_incident`** tool and forwards it as the HTTP **`Idempotency-Key`** header on `POST /v1/incidents`, so unattended agents can declare incidents safely with retry/replay protection.

## Why (customer: CertifID, Pylon MCP enablement)

CertifID runs a published ChatGPT Workspace Agent (*FRS Incident Coordinator*) against the hosted endpoint. On 2026-08-05 a qualifying production intake reached the agent, duplicate searches completed, but **declaration was intentionally blocked** because the hosted `create_incident` tool had no argument that could be forwarded as `Idempotency-Key` — so there was no way to make unattended creation safe against duplicates. No incident was created.

[Rootly's docs](https://docs.rootly.com/incidents/creating-incidents/creating-incidents-via-api) recommend sending `Idempotency-Key` with `POST /api/v1/incidents`; the server dedupes retries with the same key. This wires that through the tool.

## Change

- New optional `idempotency_key: str | None` argument on `create_incident`.
- When provided (non-blank, trimmed), forwarded verbatim as the `Idempotency-Key` request header. Rootly's replay behavior then returns the original incident on repeated calls instead of creating a duplicate.
- When absent/blank, **no header is sent** — the request is byte-for-byte identical to today (zero behavior change for existing callers).
- `make_authenticated_request` merges `Authorization` on top of the headers we pass, so the key coexists with auth in both hosted and self-hosted modes.

## Tests

- `test_create_incident_forwards_idempotency_key_header` — key forwarded as the header (and trimmed).
- `test_create_incident_omits_idempotency_header_when_blank` — blank key sends no header.
- Existing `create_incident` tests unchanged and passing (no header when no key).
- Full suite: **571 passed, 13 skipped**; ruff clean.

## Rollout note

This ships in the tool schema automatically; once merged and deployed to `https://mcp.rootly.com/mcp` (server currently reports 2.3.16), CertifID can refresh/republish their Workspace Agent connection to pick up the new `idempotency_key` argument. No client change is required for callers that don't use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)