### PR TITLE
Fix: honor ROOTLY_MCP_ENABLE_WRITE_TOOLS=false on the CLI / python -m path

### DIFF
--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -245,7 +245,11 @@ def parse_args():
         "--no-enable-write-tools",
         dest="enable_write_tools",
         action="store_false",
-        default=True,
+        # Default None (not True) so "flag absent" is distinguishable from
+        # "flag passed -> False". Otherwise `args.enable_write_tools or <env>`
+        # short-circuits to True and ROOTLY_MCP_ENABLE_WRITE_TOOLS=false is
+        # silently ignored on the CLI / `python -m` path.
+        default=None,
         help="Disable write tools to expose read-only operations",
     )
     parser.add_argument(
@@ -712,8 +716,12 @@ def main():
         # argparse already normalizes/validates --transport via type=normalize_transport
         normalized_transport = args.transport
         code_mode_enabled = args.enable_code_mode or code_mode_enabled_from_env(default=True)
-        enable_write_tools = args.enable_write_tools or write_tools_enabled_from_env(
-            default=hosted_mode
+        # Explicit --no-enable-write-tools wins; otherwise fall back to the env
+        # var (default True to preserve full access and match get_server()).
+        enable_write_tools = (
+            args.enable_write_tools
+            if args.enable_write_tools is not None
+            else write_tools_enabled_from_env(default=True)
         )
         code_mode_path = (
             normalize_code_mode_path(args.code_mode_path)

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -58,6 +58,101 @@ def test_get_server_passes_write_tool_env_flag():
     assert mock_create.call_args.kwargs["enable_write_tools"] is True
 
 
+@pytest.mark.parametrize(
+    ("flag", "env", "expected"),
+    [
+        # Regression for #149: env var must take effect when the flag is absent.
+        (None, "false", False),
+        (None, "true", True),
+        (None, None, True),  # nothing set -> full access preserved
+        (False, None, False),  # --no-enable-write-tools honored
+        (False, "true", False),  # explicit flag wins over env
+    ],
+)
+def test_main_write_tools_respects_flag_then_env(flag, env, expected):
+    args = SimpleNamespace(
+        swagger_path=None,
+        log_level="ERROR",
+        name="Rootly",
+        transport="stdio",
+        debug=False,
+        base_url=None,
+        allowed_paths=None,
+        hosted=False,
+        enable_code_mode=False,
+        enable_write_tools=flag,
+        enabled_tools=None,
+        list_tools=False,
+        code_mode_path=None,
+        host=False,
+    )
+    server = SimpleNamespace(run=Mock())
+    environ = {"ROOTLY_API_TOKEN": "x" * 40}  # stdio path requires a valid-length token
+    if env is not None:
+        environ["ROOTLY_MCP_ENABLE_WRITE_TOOLS"] = env
+
+    with patch.dict("os.environ", environ, clear=True):
+        with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
+            with patch("rootly_mcp_server.__main__.setup_logging"):
+                with patch(
+                    "rootly_mcp_server.__main__.create_rootly_mcp_server",
+                    return_value=server,
+                ) as mock_create:
+                    main()
+
+    assert mock_create.call_args.kwargs["enable_write_tools"] is expected
+
+
+@pytest.mark.parametrize(
+    ("flag", "env", "expected"),
+    [
+        (None, "false", False),  # #149 2nd bug: env=false must apply on hosted too
+        (False, None, False),  # #149 2nd bug: --no-enable-write-tools honored on hosted
+        (None, None, True),  # hosted default preserved: full access
+    ],
+)
+def test_main_write_tools_hosted_path_respects_flag_then_env(flag, env, expected):
+    # The resolution is transport-independent; this guards the hosted streamable
+    # path specifically (where --no-enable-write-tools + no env was previously
+    # ignored via `False or write_tools_enabled_from_env(default=hosted_mode)`).
+    args = SimpleNamespace(
+        swagger_path=None,
+        log_level="ERROR",
+        name="Rootly",
+        transport="streamable-http",
+        debug=False,
+        base_url=None,
+        allowed_paths=None,
+        hosted=True,
+        enable_code_mode=False,
+        enable_write_tools=flag,
+        enabled_tools=None,
+        list_tools=False,
+        code_mode_path=None,
+        host=False,
+    )
+    environ = {} if env is None else {"ROOTLY_MCP_ENABLE_WRITE_TOOLS": env}
+
+    with patch.dict("os.environ", environ, clear=True):
+        with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
+            with patch("rootly_mcp_server.__main__.setup_logging"):
+                with patch(
+                    "rootly_mcp_server.__main__.create_rootly_mcp_server",
+                    return_value=SimpleNamespace(),
+                ) as mock_create:
+                    with patch(
+                        "rootly_mcp_server.__main__.get_hosted_auth_middleware",
+                        return_value=[],
+                    ):
+                        with patch(
+                            "rootly_mcp_server.__main__.run_profiled_streamable_http_server"
+                        ):
+                            main()
+
+    # every profile server is built with the resolved value
+    assert mock_create.call_args.kwargs["enable_write_tools"] is expected
+
+
 def test_get_server_passes_enabled_tools_env_flag():
     with patch.dict(
         "os.environ",


### PR DESCRIPTION
Closes #149.

## In simple terms

There are two ways to turn OFF write tools (so the server can only read, not create/update/delete):
1. a command-line flag, or
2. the setting `ROOTLY_MCP_ENABLE_WRITE_TOOLS=false`

The flag worked. The setting **did not** — if you used it, you thought you were read-only, but all the write tools were still turned on. That's a safety problem.

**This PR makes the setting actually work.**

## Does this change anything for normal users?

No. If you don't set anything, write tools stay ON, same as before. The only thing that changes: if you *asked* for read-only (with the setting or the flag), you now actually get read-only.

## Tested

Checked every on/off combination of the flag and the setting. All tests pass.