### PR TITLE
Fix: bundle data/swagger.json in the published sdist and wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,15 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Verify sdist and wheel bundle the OpenAPI spec (#153)
+        run: |
+          # uv build produces sdist then wheel-from-sdist (like `python -m build`),
+          # so a sdist that omits the spec fails here rather than at release time.
+          python -m zipfile -l dist/*.whl | grep -q "rootly_mcp_server/data/swagger.json" \
+            || { echo "::error::swagger.json missing from wheel — would litter host CWD (#153)"; exit 1; }
+          tar tzf dist/*.tar.gz | grep -q "data/swagger.json" \
+            || { echo "::error::swagger.json missing from sdist — wheel-from-sdist build would drop it (#153)"; exit 1; }
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           python -m build
 
+      - name: Verify bundled swagger.json shipped in the wheel
+        run: |
+          python -m zipfile -l dist/*.whl | grep -q "rootly_mcp_server/data/swagger.json" \
+            || { echo "::error::swagger.json missing from wheel — the server would fetch it and write swagger.json into the host CWD on every launch (#153)"; exit 1; }
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,16 @@ Issues = "https://github.com/rootlyhq/rootly-mcp-server/issues"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# The bundled OpenAPI spec (data/swagger.json) is git-ignored, so hatchling's
+# default VCS-aware file selection excludes it from BOTH the sdist and the wheel.
+# The previous `[...wheel.include]` mapping didn't ship it, so the server fell
+# back to fetching the spec and writing swagger.json into the host CWD on every
+# launch (#153). `artifacts` force-includes VCS-ignored paths across all build
+# targets — critically the sdist too, since `python -m build` builds the wheel
+# *from* the sdist (a wheel-only force-include fails there with FileNotFound).
+[tool.hatch.build]
+artifacts = ["src/rootly_mcp_server/data/swagger.json"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/rootly_mcp_server"]
 
@@ -73,9 +83,6 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel.sources]
 "src" = ""
-
-[tool.hatch.build.targets.wheel.include]
-"src/rootly_mcp_server/data" = "rootly_mcp_server/data"
 
 [project.scripts]
 rootly-mcp-server = "rootly_mcp_server.__main__:main"


### PR DESCRIPTION
Closes #153.

## In simple terms

The server needs a big spec file (`swagger.json`) to run. That file was supposed to be packaged *inside* the app, but a packaging mistake left it out.

So every time the server started, it downloaded the file and **saved a ~3 MB `swagger.json` into whatever folder you happened to be in** — leaving stray copies all over your project folders.

**This PR fixes the packaging so the file ships inside the app.** No more download, no more stray files.

## Does this change anything for normal users?

Only for the better — the junk files stop. The app just gets a tiny bit bigger (it now includes the spec file, like it always should have).

## Tested

Built the app and confirmed the file is now inside it. Installed it fresh and started it from an empty folder — it worked and left nothing behind. Also added a safety check so this can't silently break again.